### PR TITLE
Update namespace to openshift-console

### DIFF
--- a/pkg/operator/util.go
+++ b/pkg/operator/util.go
@@ -1,8 +1,6 @@
 package operator
 
 import (
-	"fmt"
-
 	"github.com/openshift/console-operator/pkg/apis/console/v1alpha1"
 	"github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v2"
@@ -13,14 +11,8 @@ import (
 const (
 	OpenShiftConsoleName      = "openshift-console"
 	OpenShiftConsoleShortName = "console"
+	OpenshiftConsoleNamespace = "openshift-console"
 )
-
-// This should return the public url provided for us by the ROUTE or Ingress...
-func consoleURL() string {
-	// This will need to do some work to generate the real path
-	logrus.Warn("Console container BRIDGE_DEVELOPER_CONSOLE_URL is HARD-CODED value for now")
-	return fmt.Sprintf("https://%s/console/", "api.ui-preserve.origin-gce.dev.openshift.com")
-}
 
 func sharedLabels() map[string]string {
 	return map[string]string{
@@ -50,14 +42,9 @@ func sharedMeta() metav1.ObjectMeta {
 	return metav1.ObjectMeta{
 		// TODO: will we always have one console?
 		// if not, then shouldn't our name be more specific?
-		Name: OpenShiftConsoleName, // ATM no configuration, stable name
-		// NOTE:
-		// namepsace shouldn't be here. it should
-		// create with whatever namespace is set via
-		// the --namespace flag
-		Namespace: "openshift-console-operator-test", // ATM no configuration, "openshift-"
-		// these can be overridden/mutated
-		Labels: sharedLabels(),
+		Name:      OpenShiftConsoleName,
+		Namespace: OpenshiftConsoleNamespace,
+		Labels:    sharedLabels(),
 	}
 }
 


### PR DESCRIPTION
Updated the manifests from `openshift-console-operator-test` namespace to `openshift-console`.  I was previously running side-by-side to the existing console, but we can now use the correct namespace.

@spadgett @jwforres 
