### PR TITLE
Fix CMD in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,4 +38,4 @@ RUN useradd console-operator
 USER console-operator
 
 ENTRYPOINT []
-CMD ["/usr/bin/cluster-samples-operator"]
+CMD ["/usr/bin/console-operator"]


### PR DESCRIPTION
Updating the root Dockerfile to use the correct CMD.  This file looks similar to the `tmp/output/build` `Dockerfile`, but has some additional requirements. 