### PR TITLE
Update rbac for oauth and route creation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,10 @@ COPY --from=builder /go/src/github.com/openshift/console-operator/tmp/_output/bi
 # these manifests are necessary for the installer
 COPY deploy/00-crd.yaml \
     deploy/01-namespace.yaml \
-    deploy/02-rbac.yaml \
-    deploy/03-operator.yaml \
+    deploy/02-sa.yaml \
+    deploy/03-rbac-role.yaml \
+    deploy/04-rbac-rolebinding.yaml \
+    deploy/05-operator.yaml \
     /manifests/
 
 LABEL io.k8s.display-name="OpenShift console-operator" \

--- a/deploy/02-sa.yaml
+++ b/deploy/02-sa.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: console-operator
+  namespace: openshift-console

--- a/deploy/03-rbac-role.yaml
+++ b/deploy/03-rbac-role.yaml
@@ -15,8 +15,6 @@ rules:
   resources:
   - pods
   - services
-  - endpoints
-  - persistentvolumeclaims
   - events
   - configmaps
   - secrets
@@ -26,23 +24,23 @@ rules:
   - apps
   resources:
   - deployments
-  - daemonsets
-  - replicasets
-  - statefulsets
   verbs:
   - "*"
-
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes
+  verbs:
+  - "*"
 ---
-
-kind: RoleBinding
+kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: default-account-console-operator
-  namespace: openshift-console
-subjects:
-- kind: ServiceAccount
-  name: default
-roleRef:
-  kind: Role
   name: console-operator
-  apiGroup: rbac.authorization.k8s.io
+rules:
+- apiGroups:
+  - oauth.openshift.io
+  resources:
+  - oauthclients
+  verbs:
+  - "*"

--- a/deploy/04-rbac-rolebinding.yaml
+++ b/deploy/04-rbac-rolebinding.yaml
@@ -1,0 +1,25 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: default-account-console-operator
+  namespace: openshift-console
+subjects:
+- kind: ServiceAccount
+  name: console-operator
+roleRef:
+  kind: Role
+  name: console-operator
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: console-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: console-operator
+subjects:
+- kind: ServiceAccount
+  name: console-operator
+  namespace: openshift-console

--- a/deploy/05-operator.yaml
+++ b/deploy/05-operator.yaml
@@ -13,6 +13,7 @@ spec:
       labels:
         name: console-operator
     spec:
+      serviceAccountName: console-operator
       containers:
       - name: console-operator
         image: openshift/origin-console-operator:latest


### PR DESCRIPTION
Adjusting `rbac.yaml` for deploying the operator.  `operator-sdk up local` permissions were a little more relaxed, deploying the operator via `oc create -f deploy/*` requires these changes for the oauth client & route to be created.

