### PR TITLE
Redact shared secret string in logging

### DIFF
--- a/pkg/operator/oauth.go
+++ b/pkg/operator/oauth.go
@@ -96,14 +96,14 @@ func CreateOAuthClient(cr *v1alpha1.Console, rt *routev1.Route) (*oauthv1.OAuthC
 		logrus.Errorf("failed to create console oauth client : %v", err)
 		return nil, nil, err
 	} else {
-		logrus.Info("created console oauth client with secret ", randomBits)
+		logrus.Info("created console oauth client with secret")
 	}
 
 	if err := sdk.Create(authSecret); err != nil && !errors.IsAlreadyExists(err) {
 		logrus.Errorf("failed to create console oauth client secret : %v", err)
 		return nil, nil, err
 	} else {
-		logrus.Info("created console oauth secret ", randomBits)
+		logrus.Info("created console oauth secret")
 	}
 	return authClient, authSecret, nil
 }


### PR DESCRIPTION
A random secret string is generated & shared between the oauth client & a Secret.  This redacts most of the logging of the random bytes, but leaves a few characters for debugging purposes. 

<img width="714" alt="screen shot 2018-10-02 at 11 16 36 pm" src="https://user-images.githubusercontent.com/280512/46388367-91032b00-c699-11e8-9ec3-662952066e3b.png">
