### PR TITLE
Add manifests/image-references file

### DIFF
--- a/manifests/image-references
+++ b/manifests/image-references
@@ -1,0 +1,8 @@
+kind: ImageStream
+apiVersion: image.openshift.io/v1
+spec:
+  tags:
+  - name: console-operator
+    from:
+      kind: DockerImage
+      name: docker.io/openshift/origin-console-operator:latest


### PR DESCRIPTION
I'm seeing this file crop up in the `/manifests` dir, so creating it, but need to verify its purpose before removing WIP.

An example:
- https://github.com/openshift/cluster-image-registry-operator/blob/master/deploy/image-references

