### PR TITLE
Correct image references for origin-console

### DIFF
--- a/examples/cr.yaml
+++ b/examples/cr.yaml
@@ -16,8 +16,5 @@ spec:
   managementState: Managed
   # there should be only one console at this time
   count: 1
-  # this is the console image
-  baseImage: docker.io/openshift/origin-console
-  version: latest
   logging:
     level: 0

--- a/manifests/05-operator.yaml
+++ b/manifests/05-operator.yaml
@@ -30,5 +30,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: IMAGE
+          value: docker.io/openshift/origin-console:latest
         - name: OPERATOR_NAME
           value: "console-operator"

--- a/manifests/image-references
+++ b/manifests/image-references
@@ -6,3 +6,8 @@ spec:
     from:
       kind: DockerImage
       name: docker.io/openshift/origin-console-operator:latest
+  - name: console
+    from:
+      kind: DockerImage
+      name: docker.io/openshift/origin-console:latest
+

--- a/pkg/apis/console/v1alpha1/types.go
+++ b/pkg/apis/console/v1alpha1/types.go
@@ -36,9 +36,7 @@ type Console struct {
 type ConsoleSpec struct {
 	operatorv1alpha1.OperatorSpec
 	// Count is the number of Console replicas
-	Count     int32  `json:"count,omitempty"`
-	BaseImage string `json:"baseImage"`
-	Version   string `json:"version"`
+	Count int32 `json:"count,omitempty"`
 	// 0 error, 1 warn 2 info? default debug
 	// aiming at consistency with this for now:
 	// https://github.com/openshift/cluster-image-registry-operator/blob/master/pkg/generate/podtemplatespec.go#L21
@@ -63,16 +61,8 @@ type LoggingConfig struct {
 // SetDefaults ensures that the necessary default values are present on the Console Spec
 func (c *Console) SetDefaults() bool {
 	changed := false
-	if len(c.Spec.BaseImage) == 0 {
-		c.Spec.BaseImage = "docker.io/openshift/origin-console"
-		changed = true
-	}
 	if c.Spec.Count == 0 {
 		c.Spec.Count = 1
-		changed = true
-	}
-	if len(c.Spec.BaseImage) == 0 {
-		c.Spec.BaseImage = defaultBaseImage
 		changed = true
 	}
 	if len(c.Spec.Version) == 0 {

--- a/pkg/operator/deployment.go
+++ b/pkg/operator/deployment.go
@@ -137,7 +137,7 @@ func consoleContainer(cr *v1alpha1.Console) corev1.Container {
 	volumeMounts := consoleVolumeMounts(volumeConfigList)
 
 	return corev1.Container{
-		Image:           image(cr.Spec.BaseImage, cr.Spec.Version),
+		Image:           GetImageEnv(),
 		ImagePullPolicy: corev1.PullPolicy("IfNotPresent"),
 		Name:            OpenShiftConsoleShortName,
 		Command: []string{

--- a/pkg/operator/util.go
+++ b/pkg/operator/util.go
@@ -6,6 +6,7 @@ import (
 	"gopkg.in/yaml.v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"os"
 )
 
 const (
@@ -91,4 +92,10 @@ func ownerRefFrom(cr *v1alpha1.Console) *metav1.OwnerReference {
 		}
 	}
 	return nil
+}
+
+// borrowed from library-go
+// https://github.com/openshift/library-go/blob/master/pkg/operator/v1alpha1helpers/helpers.go
+func GetImageEnv() string {
+	return os.Getenv("IMAGE")
 }


### PR DESCRIPTION
The operator itself is fine, but the image for the console was not correctly referenced in `/manifests/image-references`. 

- The IMAGE env var is now passed in `/manifests/05-operator.yaml`
- The operator does not handle `image:version` on the deployment, CVO handles versioning
