### PR TITLE
Improve sync loop logging feedback

### DIFF
--- a/pkg/console/subresource/util/util.go
+++ b/pkg/console/subresource/util/util.go
@@ -2,14 +2,15 @@ package util
 
 import (
 	"fmt"
+	"os"
+	"strings"
+
 	"github.com/openshift/console-operator/pkg/apis/console/v1alpha1"
 	"github.com/openshift/console-operator/pkg/controller"
 	"github.com/sirupsen/logrus"
-	"gopkg.in/yaml.v2"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	yaml "gopkg.in/yaml.v2"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"os"
-	"strings"
 )
 
 func SharedLabels() map[string]string {
@@ -99,6 +100,5 @@ func HTTPS(host string) string {
 		return host
 	}
 	secured := fmt.Sprintf("%s%s", protocol, host)
-	logrus.Infof("util.HTTPS(): from %s to %s", host, secured)
 	return secured
 }


### PR DESCRIPTION
A block from the sync loop will now look like this:

<img width="905" alt="screen shot 2018-12-12 at 10 35 58 am" src="https://user-images.githubusercontent.com/280512/49880345-f4c47580-fdf9-11e8-9526-0156007be878.png">

This PR only adds a few log statements & cleans up formatting (`\n`, consistent lower case, verbiage, etc).

