### PR TITLE
Add Validate() fn to route

### DIFF
--- a/pkg/console/subresource/route/route.go
+++ b/pkg/console/subresource/route/route.go
@@ -1,15 +1,18 @@
 package route
 
 import (
+
 	// kube
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+
 	// openshift
 	routev1 "github.com/openshift/api/route/v1"
 	routeclient "github.com/openshift/client-go/route/clientset/versioned/typed/route/v1"
 	"github.com/openshift/library-go/pkg/operator/resource/resourcemerge"
+
 	// operator
 	"github.com/openshift/console-operator/pkg/apis/console/v1alpha1"
 	"github.com/openshift/console-operator/pkg/console/subresource/util"
@@ -79,24 +82,12 @@ func ApplyRoute(client routeclient.RoutesGetter, required *routev1.Route) (*rout
 }
 
 func DefaultRoute(cr *v1alpha1.Console) *routev1.Route {
-	meta := util.SharedMeta()
-	meta.Name = controller.OpenShiftConsoleShortName
-	weight := int32(100)
 	route := Stub()
 	route.Spec = routev1.RouteSpec{
-		To: routev1.RouteTargetReference{
-			Kind:   "Service",
-			Name:   meta.Name,
-			Weight: &weight,
-		},
-		Port: &routev1.RoutePort{
-			TargetPort: intstr.FromString("https"),
-		},
-		TLS: &routev1.TLSConfig{
-			Termination:                   routev1.TLSTerminationReencrypt,
-			InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyRedirect,
-		},
-		WildcardPolicy: routev1.WildcardPolicyNone,
+		To:             toService(),
+		Port:           port(),
+		TLS:            tls(),
+		WildcardPolicy: wildcard(),
 	}
 	util.AddOwnerRef(route, util.OwnerRefFrom(cr))
 	return route
@@ -108,4 +99,67 @@ func Stub() *routev1.Route {
 	return &routev1.Route{
 		ObjectMeta: meta,
 	}
+}
+
+// we can't just blindly apply the route, we need the route.Spec.Host
+// and we don't want to trigger a sync loop.
+// TODO: evaluate metadata.annotations to see what will affect our route in
+// an undesirable way:
+// - https://docs.openshift.com/container-platform/3.9/architecture/networking/routes.html#alternateBackends
+func Validate(route *routev1.Route) (*routev1.Route, bool) {
+	changed := false
+
+	if toServiceSame := equality.Semantic.DeepEqual(route.Spec.To, toService()); !toServiceSame {
+		changed = true
+		route.Spec.To = toService()
+	}
+
+	if portSame := equality.Semantic.DeepEqual(route.Spec.Port, port()); !portSame {
+		changed = true
+		route.Spec.Port = port()
+	}
+
+	if tlsSame := equality.Semantic.DeepEqual(route.Spec.TLS, tls()); !tlsSame {
+		changed = true
+		route.Spec.TLS = tls()
+	}
+
+	if wildcardSame := equality.Semantic.DeepEqual(route.Spec.WildcardPolicy, wildcard()); !wildcardSame {
+		changed = true
+		route.Spec.WildcardPolicy = wildcard()
+	}
+
+	return route, changed
+}
+
+func routeMeta() metav1.ObjectMeta {
+	meta := util.SharedMeta()
+	meta.Name = controller.OpenShiftConsoleShortName
+	return meta
+}
+
+func toService() routev1.RouteTargetReference {
+	weight := int32(100)
+	return routev1.RouteTargetReference{
+		Kind:   "Service",
+		Name:   routeMeta().Name,
+		Weight: &weight,
+	}
+}
+
+func port() *routev1.RoutePort {
+	return &routev1.RoutePort{
+		TargetPort: intstr.FromString("https"),
+	}
+}
+
+func tls() *routev1.TLSConfig {
+	return &routev1.TLSConfig{
+		Termination:                   routev1.TLSTerminationReencrypt,
+		InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyRedirect,
+	}
+}
+
+func wildcard() routev1.WildcardPolicyType {
+	return routev1.WildcardPolicyNone
 }


### PR DESCRIPTION
The sync loop should also ensure the correctness of each resource, at least in all of the fields that matter for a running console. This adds a `validate()` fn to the route `sync`, which will only trigger an `update` if `changed` is `true`.

