### PR TITLE
Service/validation

### DIFF
--- a/pkg/console/subresource/service/service.go
+++ b/pkg/console/subresource/service/service.go
@@ -4,7 +4,9 @@ import (
 	"github.com/openshift/console-operator/pkg/apis/console/v1alpha1"
 	"github.com/openshift/console-operator/pkg/console/subresource/util"
 	"github.com/openshift/console-operator/pkg/controller"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
@@ -18,28 +20,18 @@ const (
 	consolePortName        = "https"
 	consolePort            = 443
 	consoleTargetPort      = 8443
+	sessionAffinity        = "None"
+	serviceType            = "ClusterIP"
 )
 
 func DefaultService(cr *v1alpha1.Console) *v1.Service {
 	labels := util.LabelsForConsole()
-	meta := util.SharedMeta()
-	meta.Name = controller.OpenShiftConsoleShortName
-	meta.Annotations = map[string]string{
-		ServingCertSecretAnnotation: ConsoleServingCertName,
-	}
 	service := Stub()
 	service.Spec = v1.ServiceSpec{
-		Ports: []v1.ServicePort{
-			{
-				Name:       consolePortName,
-				Protocol:   v1.ProtocolTCP,
-				Port:       consolePort,
-				TargetPort: intstr.FromInt(consoleTargetPort),
-			},
-		},
+		Ports:           ports(),
 		Selector:        labels,
-		Type:            "ClusterIP",
-		SessionAffinity: "None",
+		Type:            serviceType,
+		SessionAffinity: sessionAffinity,
 	}
 
 	util.AddOwnerRef(service, util.OwnerRefFrom(cr))
@@ -47,13 +39,59 @@ func DefaultService(cr *v1alpha1.Console) *v1.Service {
 }
 
 func Stub() *v1.Service {
+	service := &v1.Service{
+		ObjectMeta: meta(),
+	}
+	return service
+}
+
+func Validate(svc *v1.Service) (*v1.Service, bool) {
+	changed := false
+
+	if svc.ObjectMeta.Annotations[ServingCertSecretAnnotation] != ConsoleServingCertName {
+		changed = true
+		svc.ObjectMeta.Annotations[ServingCertSecretAnnotation] = ConsoleServingCertName
+	}
+
+	if !equality.Semantic.DeepEqual(svc.Spec.Selector, util.LabelsForConsole()) {
+		changed = true
+		svc.Spec.Selector = util.LabelsForConsole()
+	}
+
+	if !equality.Semantic.DeepEqual(svc.Spec.Ports, ports()) {
+		changed = true
+		svc.Spec.Ports = ports()
+	}
+
+	if svc.Spec.SessionAffinity != sessionAffinity {
+		changed = true
+		svc.Spec.SessionAffinity = sessionAffinity
+	}
+
+	if svc.Spec.Type != serviceType {
+		changed = true
+		svc.Spec.Type = serviceType
+	}
+
+	return svc, changed
+}
+
+func meta() metav1.ObjectMeta {
 	meta := util.SharedMeta()
 	meta.Name = controller.OpenShiftConsoleShortName
 	meta.Annotations = map[string]string{
 		ServingCertSecretAnnotation: ConsoleServingCertName,
 	}
-	service := &v1.Service{
-		ObjectMeta: meta,
+	return meta
+}
+
+func ports() []v1.ServicePort {
+	return []v1.ServicePort{
+		{
+			Name:       consolePortName,
+			Protocol:   v1.ProtocolTCP,
+			Port:       consolePort,
+			TargetPort: intstr.FromInt(consoleTargetPort),
+		},
 	}
-	return service
 }


### PR DESCRIPTION
Continuing with the existing pattern, an invalid state on the `service` will trigger an `update` and throw an error, killing the sync loop:

<img width="757" alt="screen shot 2018-12-14 at 10 29 00 am" src="https://user-images.githubusercontent.com/280512/50011926-4ea87500-ff8b-11e8-80d0-2eef6ce165d6.png">

This change to the service will trigger a new sync loop which will start at the top and work its way through the resources (one thing at a time, if the sync loop reaches the end, this indicates that everything is in the correct state).  
