### PR TITLE
ConfigMap/validation

### DIFF
--- a/pkg/console/operator/sync_v400.go
+++ b/pkg/console/operator/sync_v400.go
@@ -192,7 +192,20 @@ func SyncConfigMap(co *ConsoleOperator, consoleConfig *v1alpha1.Console, rt *rou
 		logrus.Errorf("%q: %v \n", "configmap", cmErr)
 		return nil, false, cmErr
 	}
+
+	if validatedConfig, changed := configmapsub.Validate(cm); changed {
+		_, _, cmErr := resourceapply.ApplyConfigMap(co.configMapClient, validatedConfig)
+		if cmErr != nil {
+			logrus.Errorf("%q: %v \n", "service", cmErr)
+			return nil, false, cmErr
+		}
+		errMsg := fmt.Errorf("configmap is invalid, correcting configmap state")
+		logrus.Error(errMsg)
+		return nil, true, errMsg
+	}
+
 	logrus.Println("configmap exists and is in the correct state")
+	logrus.Printf("existing config:\n%v", configmapsub.GetConsoleConfig(cm))
 	return cm, cmChanged, cmErr
 }
 

--- a/pkg/console/subresource/configmap/configmap.go
+++ b/pkg/console/subresource/configmap/configmap.go
@@ -45,6 +45,12 @@ func Stub() *corev1.ConfigMap {
 	return configMap
 }
 
+func Validate(cm *corev1.ConfigMap) (*corev1.ConfigMap, bool) {
+	// noop, there is no validation needed for the configmap.
+	// the sync loop naturally ensures the configmap is in the correct state.
+	return cm, false
+}
+
 func NewYamlConfigString(host string) string {
 	return string(NewYamlConfig(host))
 }
@@ -124,4 +130,8 @@ func authServerYaml() yaml.MapSlice {
 
 func consoleBaseAddr(host string) string {
 	return util.HTTPS(host)
+}
+
+func GetConsoleConfig(cm *corev1.ConfigMap) string {
+	return cm.Data[consoleConfigYamlFile]
 }


### PR DESCRIPTION
Looking at dropping the config string into the logging output:

<img width="838" alt="screen shot 2018-12-14 at 1 27 38 pm" src="https://user-images.githubusercontent.com/280512/50020550-4ad51c80-ffa4-11e8-8178-f1fd809ce83d.png">

this is as currently as `yaml`, rather than `json`.