### PR TITLE
Improve log message for resource version annotation comparison

### DIFF
--- a/pkg/console/subresource/deployment/deployment.go
+++ b/pkg/console/subresource/deployment/deployment.go
@@ -237,13 +237,13 @@ func livenessProbe() *corev1.Probe {
 
 func ConfigMapResourceVersionChanged(dep *appsv1.Deployment, cm *corev1.ConfigMap) bool {
 	currentVersion := dep.Spec.Template.Annotations[configMapResourceVersionAnnotation]
-	logrus.Infof("%v changed? %v (%v vs %v)", configMapResourceVersionAnnotation, cm.GetResourceVersion() != currentVersion, cm.GetResourceVersion(), currentVersion)
+	logrus.Infof("pod template annotation [%v] changed? %v (%v vs %v)", configMapResourceVersionAnnotation, cm.GetResourceVersion() != currentVersion, cm.GetResourceVersion(), currentVersion)
 	return cm.GetResourceVersion() != currentVersion
 }
 
 func SecretResourceVersionChanged(dep *appsv1.Deployment, sec *corev1.Secret) bool {
 	currentVersion := dep.Spec.Template.Annotations[secretResourceVersionAnnotation]
-	logrus.Infof("%v changed? %v (%v vs %v)", secretResourceVersionAnnotation, sec.GetResourceVersion() != currentVersion, sec.GetResourceVersion(), currentVersion)
+	logrus.Infof("pod template annotation [%v] changed? %v (%v vs %v)", secretResourceVersionAnnotation, sec.GetResourceVersion() != currentVersion, sec.GetResourceVersion(), currentVersion)
 	return sec.GetResourceVersion() != currentVersion
 }
 


### PR DESCRIPTION
Attempting to make the logging of the resource version comparison clear to someone who is not intimately familiar with the inner workings of the operator:

<img width="840" alt="screen shot 2018-12-14 at 1 35 54 pm" src="https://user-images.githubusercontent.com/280512/50020855-4fe69b80-ffa5-11e8-9ccf-b79ed32ce973.png">

Knowing that these annotations are for the `spec.template.metadata.annotations`, for the `pod`, is helpful in the log output, should the information be needed to diagnost problems.

