### PR TITLE
Inject service-ca.crt into the console pod from a config map

### DIFF
--- a/pkg/console/operator/operator.go
+++ b/pkg/console/operator/operator.go
@@ -110,7 +110,7 @@ func NewConsoleOperator(
 	return operator.New(controllerName, c,
 		operator.WithInformer(consoles, operator.FilterByNames(api.ResourceName)),
 		operator.WithInformer(deployments, operator.FilterByNames(api.OpenShiftConsoleName)),
-		operator.WithInformer(configMapInformer, operator.FilterByNames(configmap.ConsoleConfigMapName)),
+		operator.WithInformer(configMapInformer, operator.FilterByNames(configmap.ConsoleConfigMapName, configmap.ServiceCAConfigMapName)),
 		operator.WithInformer(secretsInformer, operator.FilterByNames(deployment.ConsoleOauthConfigName)),
 		operator.WithInformer(routes, operator.FilterByNames(api.OpenShiftConsoleShortName)),
 		operator.WithInformer(serviceInformer, operator.FilterByNames(api.OpenShiftConsoleShortName)),

--- a/pkg/console/subresource/configmap/service_ca.go
+++ b/pkg/console/subresource/configmap/service_ca.go
@@ -1,0 +1,36 @@
+package configmap
+
+import (
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/openshift/console-operator/pkg/apis/console/v1alpha1"
+	"github.com/openshift/console-operator/pkg/console/subresource/util"
+)
+
+const (
+	// ServiceCAConfigMapName is the name of the config map that contains the service CA bundle.
+	ServiceCAConfigMapName = "service-ca"
+	// See https://github.com/openshift/service-serving-cert-signer
+	injectCABundleAnnotation = "service.alpha.openshift.io/inject-cabundle"
+)
+
+// DefaultServiceCAConfigMap creates a config map that holds the service CA bundle.
+// Console uses this bundle to proxy to Prometheus. The value is injected into
+// key "service-ca.crt" by the service serving cert operator.
+func DefaultServiceCAConfigMap(cr *v1alpha1.Console) *corev1.ConfigMap {
+	configMap := ServiceCAStub()
+	util.AddOwnerRef(configMap, util.OwnerRefFrom(cr))
+	return configMap
+}
+
+func ServiceCAStub() *corev1.ConfigMap {
+	meta := util.SharedMeta()
+	meta.Name = ServiceCAConfigMapName
+	meta.Annotations = map[string]string{
+		injectCABundleAnnotation: "true",
+	}
+	configMap := &corev1.ConfigMap{
+		ObjectMeta: meta,
+	}
+	return configMap
+}


### PR DESCRIPTION
Annotate a config map to hold the service-ca.crt for the Prometheus proxy.

Requires https://github.com/openshift/console/pull/960

See https://github.com/openshift/service-serving-cert-signer#openshift-service-serving-cert-signer-operator

/cc @benjaminapetersen @enj 