### PR TITLE
[WIP] Manifests/env/pod name and operator image

### DIFF
--- a/manifests/05-operator.yaml
+++ b/manifests/05-operator.yaml
@@ -41,6 +41,10 @@ spec:
           value: docker.io/openshift/origin-console:latest
         - name: OPERATOR_NAME
           value: "console-operator"
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
       volumes:
       - name: config
         configMap:

--- a/manifests/05-operator.yaml
+++ b/manifests/05-operator.yaml
@@ -16,7 +16,7 @@ spec:
       serviceAccountName: console-operator
       containers:
       - name: console-operator
-        image: docker.io/openshift/origin-console-operator:latest
+        image: docker.io/openshift/origin-console-operator:v4.0
         ports:
         - containerPort: 60000
           name: metrics
@@ -41,6 +41,8 @@ spec:
           value: docker.io/openshift/origin-console:latest
         - name: OPERATOR_NAME
           value: "console-operator"
+        - name: OPERATOR_IMAGE
+          value: docker.io/openshift/origin-console-operator:v4.0
         - name: POD_NAME
           valueFrom:
             fieldRef:

--- a/manifests/image-references
+++ b/manifests/image-references
@@ -5,9 +5,9 @@ spec:
   - name: console-operator
     from:
       kind: DockerImage
-      name: docker.io/openshift/origin-console-operator:latest
+      name: docker.io/openshift/origin-console-operator:v4.0
   - name: console
     from:
       kind: DockerImage
-      name: docker.io/openshift/origin-console:latest
+      name: docker.io/openshift/origin-console:v4.0
 


### PR DESCRIPTION
@jhadvig fyi 

- Add POD_NAME and OPERATOR_IMAGE env vars, 
- update image-references to :v4.0 instead of :latest

WIP on this until we are certain about the correct tag to use.