### PR TITLE
Add env vars to operator deployment manifest

### DIFF
--- a/manifests/05-operator.yaml
+++ b/manifests/05-operator.yaml
@@ -41,6 +41,12 @@ spec:
           value: docker.io/openshift/origin-console:latest
         - name: OPERATOR_NAME
           value: "console-operator"
+        - name: OPERATOR_IMAGE
+          value: docker.io/openshift/origin-console-operator:latest
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
       volumes:
       - name: config
         configMap:


### PR DESCRIPTION
Both of these additional `env` vars seem to be standard across many operators. They do not seem to be used within the operators elsewhere but may be important for other infrastructure reasons.