### PR TITLE
Console operator e2e test - Managed state

### DIFF
--- a/hack/test-e2e.sh
+++ b/hack/test-e2e.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 
-os::log::info "Running e2e tests (noop)"
+os::log::info "Running e2e tests"
+KUBERNETES_CONFIG=${KUBECONFIG} GOCACHE=off go test -timeout 30m -v ./test/e2e/

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -11,8 +11,10 @@ const (
 
 // consts to maintain existing names of various sub-resources
 const (
-	OpenShiftConsoleName      = "openshift-console"
-	OpenShiftConsoleShortName = "console"
-	OpenShiftConsoleNamespace = "openshift-console"
-	OAuthClientName           = OpenShiftConsoleName
+	OpenShiftConsoleName              = "openshift-console"
+	OpenShiftConsoleShortName         = "console"
+	OpenShiftConsoleNamespace         = "openshift-console"
+	OpenShiftConsoleOperatorNamespace = "openshift-console"
+	OpenShiftConsoleOperator          = "console-operator"
+	OAuthClientName                   = OpenShiftConsoleName
 )

--- a/pkg/testframework/clientset.go
+++ b/pkg/testframework/clientset.go
@@ -1,0 +1,62 @@
+package testframework
+
+import (
+	"fmt"
+	"testing"
+
+	clientappsv1 "k8s.io/client-go/kubernetes/typed/apps/v1"
+	clientcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	restclient "k8s.io/client-go/rest"
+
+	clientconfigv1 "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
+	clientconsolev1alpha1 "github.com/openshift/console-operator/pkg/generated/clientset/versioned/typed/console/v1alpha1"
+)
+
+// Clientset is a set of Kubernetes clients.
+type Clientset struct {
+	clientcorev1.CoreV1Interface
+	clientappsv1.AppsV1Interface
+	clientconfigv1.ConfigV1Interface
+	clientconsolev1alpha1.ConsoleV1alpha1Interface
+}
+
+// NewClientset creates a set of Kubernetes clients. The default kubeconfig is
+// used if not provided.
+func NewClientset(kubeconfig *restclient.Config) (*Clientset, error) {
+	var err error
+	if kubeconfig == nil {
+		kubeconfig, err = GetConfig()
+		if err != nil {
+			return nil, fmt.Errorf("unable to get kubeconfig: %s", err)
+		}
+	}
+
+	clientset := &Clientset{}
+	clientset.CoreV1Interface, err = clientcorev1.NewForConfig(kubeconfig)
+	if err != nil {
+		return nil, err
+	}
+	clientset.AppsV1Interface, err = clientappsv1.NewForConfig(kubeconfig)
+	if err != nil {
+		return nil, err
+	}
+	clientset.ConfigV1Interface, err = clientconfigv1.NewForConfig(kubeconfig)
+	if err != nil {
+		return nil, err
+	}
+	clientset.ConsoleV1alpha1Interface, err = clientconsolev1alpha1.NewForConfig(kubeconfig)
+	if err != nil {
+		return nil, err
+	}
+	return clientset, nil
+}
+
+// MustNewClientset is like NewClienset but aborts the test if clienset cannot
+// be constructed.
+func MustNewClientset(t *testing.T, kubeconfig *restclient.Config) *Clientset {
+	clientset, err := NewClientset(kubeconfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return clientset
+}

--- a/pkg/testframework/config.go
+++ b/pkg/testframework/config.go
@@ -1,0 +1,41 @@
+package testframework
+
+import (
+	"fmt"
+	"os"
+	"os/user"
+	"path/filepath"
+
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// GetConfig creates a *rest.Config for talking to a Kubernetes apiserver.
+// Otherwise will assume running in cluster and use the cluster provided kubeconfig.
+//
+// Config precedence
+//
+// * KUBECONFIG environment variable pointing at a file
+//
+// * In-cluster config if running in cluster
+//
+// * $HOME/.kube/config if exists
+func GetConfig() (*rest.Config, error) {
+	// If an env variable is specified with the config location, use that
+	if len(os.Getenv("KUBECONFIG")) > 0 {
+		return clientcmd.BuildConfigFromFlags("", os.Getenv("KUBECONFIG"))
+	}
+	// If no explicit location, try the in-cluster config
+	if c, err := rest.InClusterConfig(); err == nil {
+		return c, nil
+	}
+	// If no in-cluster config, try the default location in the user's home directory
+	if usr, err := user.Current(); err == nil {
+		if c, err := clientcmd.BuildConfigFromFlags(
+			"", filepath.Join(usr.HomeDir, ".kube", "config")); err == nil {
+			return c, nil
+		}
+	}
+
+	return nil, fmt.Errorf("could not locate a kubeconfig")
+}

--- a/pkg/testframework/framework.go
+++ b/pkg/testframework/framework.go
@@ -1,0 +1,59 @@
+package testframework
+
+import (
+	"time"
+
+	// "github.com/davecgh/go-spew/spew"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+var (
+	// AsyncOperationTimeout is how long we want to wait for asynchronous
+	// operations to complete. ForeverTestTimeout is not long enough to create
+	// several replicas and get them available on a slow machine.
+	// Setting this to 5 minutes:w
+
+	AsyncOperationTimeout = 5 * time.Minute
+)
+
+// DeleteCompletely sends a delete request and waits until the resource and
+// its dependents are deleted.
+func DeleteCompletely(getObject func() (metav1.Object, error), deleteObject func(*metav1.DeleteOptions) error) error {
+	obj, err := getObject()
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+
+	uid := obj.GetUID()
+
+	policy := metav1.DeletePropagationForeground
+	if err := deleteObject(&metav1.DeleteOptions{
+		Preconditions: &metav1.Preconditions{
+			UID: &uid,
+		},
+		PropagationPolicy: &policy,
+	}); err != nil {
+		if errors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+
+	return wait.Poll(1*time.Second, AsyncOperationTimeout, func() (stop bool, err error) {
+		obj, err = getObject()
+		if err != nil {
+			if errors.IsNotFound(err) {
+				return true, nil
+			}
+			return false, err
+		}
+
+		return obj.GetUID() != uid, nil
+	})
+}

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -1,0 +1,59 @@
+package e2e_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	kubeset "k8s.io/client-go/kubernetes"
+
+	consoleapi "github.com/openshift/console-operator/pkg/api"
+	"github.com/openshift/console-operator/pkg/testframework"
+)
+
+var (
+	kubeClient *kubeset.Clientset
+)
+
+func TestMain(m *testing.M) {
+
+	kubeconfig, err := testframework.GetConfig()
+	if err != nil {
+		fmt.Printf("unable to get kubeconfig: %s", err)
+		os.Exit(1)
+	}
+
+	kubeClient, err = kubeset.NewForConfig(kubeconfig)
+	if err != nil {
+		fmt.Printf("%#v", err)
+		os.Exit(1)
+	}
+
+	// e2e test job does not guarantee our operator is up before
+	// launching the test, so we need to do so.
+	fmt.Println("checking for console-operator availability")
+	err = waitForOperator()
+	if err != nil {
+		fmt.Println("failed waiting for operator to start")
+		os.Exit(1)
+	}
+
+	os.Exit(m.Run())
+}
+
+func waitForOperator() error {
+	depClient := kubeClient.AppsV1().Deployments(consoleapi.OpenShiftConsoleOperatorNamespace)
+	err := wait.PollImmediate(1*time.Second, 10*time.Minute, func() (bool, error) {
+		_, err := depClient.Get(consoleapi.OpenShiftConsoleOperator, metav1.GetOptions{})
+		if err != nil {
+			fmt.Printf("error waiting for operator deployment to exist: %v\n", err)
+			return false, nil
+		}
+		fmt.Println("found operator deployment")
+		return true, nil
+	})
+	return err
+}

--- a/test/e2e/managed_test.go
+++ b/test/e2e/managed_test.go
@@ -1,0 +1,45 @@
+package e2e_test
+
+import (
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	consoleapi "github.com/openshift/console-operator/pkg/api"
+	"github.com/openshift/console-operator/pkg/testframework"
+)
+
+func TestManaged(t *testing.T) {
+	client := testframework.MustNewClientset(t, nil)
+
+	t.Logf("deleting console deployment...")
+	if err := testframework.DeleteCompletely(
+		func() (metav1.Object, error) {
+			return client.Deployments(consoleapi.OpenShiftConsoleOperatorNamespace).Get(consoleapi.OpenShiftConsoleName, metav1.GetOptions{})
+		},
+		func(deleteOptions *metav1.DeleteOptions) error {
+			return client.Deployments(consoleapi.OpenShiftConsoleOperatorNamespace).Delete(consoleapi.OpenShiftConsoleName, deleteOptions)
+		},
+	); err != nil {
+		t.Fatalf("unable to delete console deployment: %s", err)
+	}
+
+	t.Logf("waiting the operator to recreate console deployment...")
+	err := wait.Poll(1*time.Second, testframework.AsyncOperationTimeout, func() (stop bool, err error) {
+		_, err = client.Deployments(consoleapi.OpenShiftConsoleOperatorNamespace).Get(consoleapi.OpenShiftConsoleName, metav1.GetOptions{})
+		if err == nil {
+			return true, nil
+		}
+		t.Logf("get deployment: %s", err)
+		if errors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
Adding e2e tests for console-operator *Managed* state.

Added the suggested check if the console-operator is up. Then The test will remove the console-operator deployment and will check if the deployment is recreated.

to launch the tests, call `make test-e2e`, whre the **KUBECONFIG** envar has to be set

@benjaminapetersen PTAL