### PR TITLE
Add e2e test for console operator Unmanaged and Removed states

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -13,8 +13,12 @@ const (
 const (
 	OpenShiftConsoleName              = "openshift-console"
 	OpenShiftConsoleShortName         = "console"
-	OpenShiftConsoleNamespace         = "openshift-console"
-	OpenShiftConsoleOperatorNamespace = "openshift-console"
+	OpenShiftConsoleNamespace         = OpenShiftConsoleName
+	OpenShiftConsoleOperatorNamespace = OpenShiftConsoleName
 	OpenShiftConsoleOperator          = "console-operator"
+	OpenShiftConsoleConfigMapName     = "console-config"
+	OpenShiftConsoleDeploymentName    = OpenShiftConsoleName
+	OpenShiftConsoleServiceName       = OpenShiftConsoleShortName
+	OpenShiftConsoleRouteName         = OpenShiftConsoleShortName
 	OAuthClientName                   = OpenShiftConsoleName
 )

--- a/pkg/testframework/clientset.go
+++ b/pkg/testframework/clientset.go
@@ -8,7 +8,7 @@ import (
 	clientcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	restclient "k8s.io/client-go/rest"
 
-	clientconfigv1 "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
+	clientroutev1 "github.com/openshift/client-go/route/clientset/versioned/typed/route/v1"
 	clientconsolev1alpha1 "github.com/openshift/console-operator/pkg/generated/clientset/versioned/typed/console/v1alpha1"
 )
 
@@ -16,7 +16,7 @@ import (
 type Clientset struct {
 	clientcorev1.CoreV1Interface
 	clientappsv1.AppsV1Interface
-	clientconfigv1.ConfigV1Interface
+	clientroutev1.RouteV1Interface
 	clientconsolev1alpha1.ConsoleV1alpha1Interface
 }
 
@@ -40,7 +40,7 @@ func NewClientset(kubeconfig *restclient.Config) (*Clientset, error) {
 	if err != nil {
 		return nil, err
 	}
-	clientset.ConfigV1Interface, err = clientconfigv1.NewForConfig(kubeconfig)
+	clientset.RouteV1Interface, err = clientroutev1.NewForConfig(kubeconfig)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/testframework/console.go
+++ b/pkg/testframework/console.go
@@ -1,0 +1,152 @@
+package testframework
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	// operatorapi "github.com/openshift/api/operator/v1"
+	operatorsv1alpha1 "github.com/openshift/api/operator/v1alpha1"
+
+	consoleapi "github.com/openshift/console-operator/pkg/api"
+	v1alpha1 "github.com/openshift/console-operator/pkg/apis/console/v1alpha1"
+)
+
+func isOperatorManaged(cr *v1alpha1.Console) bool {
+	return cr.Spec.ManagementState == operatorsv1alpha1.Managed
+}
+
+func isOperatorUnmanaged(cr *v1alpha1.Console) bool {
+	return cr.Spec.ManagementState == operatorsv1alpha1.Unmanaged
+}
+
+func isOperatorRemoved(cr *v1alpha1.Console) bool {
+	return cr.Spec.ManagementState == operatorsv1alpha1.Removed
+}
+
+type operatorStateReactionFn func(cr *v1alpha1.Console) bool
+
+func ensureConsoleIsInDesiredState(t *testing.T, client *Clientset, state operatorsv1alpha1.ManagementState) error {
+	var cr *v1alpha1.Console
+	// var checkFunc func()
+	var checkFunc operatorStateReactionFn
+
+	switch state {
+	case operatorsv1alpha1.Managed:
+		checkFunc = isOperatorManaged
+	case operatorsv1alpha1.Unmanaged:
+		checkFunc = isOperatorUnmanaged
+	case operatorsv1alpha1.Removed:
+		checkFunc = isOperatorRemoved
+	}
+
+	err := wait.Poll(1*time.Second, AsyncOperationTimeout, func() (stop bool, err error) {
+		cr, err = client.ConsoleV1alpha1Interface.Consoles(consoleapi.OpenShiftConsoleOperatorNamespace).Get(consoleapi.ResourceName, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		return checkFunc(cr), nil
+	})
+	if err != nil {
+		DumpObject(t, "the latest observed state of the console resource", cr)
+		DumpOperatorLogs(t, client)
+		return fmt.Errorf("failed to wait to change console operator state to 'Removed': %s", err)
+	}
+	return nil
+}
+
+func ManageConsole(t *testing.T, client *Clientset) error {
+	cr, err := client.ConsoleV1alpha1Interface.Consoles(consoleapi.OpenShiftConsoleOperatorNamespace).Get(consoleapi.ResourceName, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	if isOperatorManaged(cr) {
+		t.Logf("console operator already in 'Managed' state")
+		return nil
+	}
+
+	t.Logf("changing console operator state to 'Managed'...")
+
+	_, err = client.ConsoleV1alpha1Interface.Consoles(consoleapi.OpenShiftConsoleOperatorNamespace).Patch(consoleapi.ResourceName, types.MergePatchType, []byte(`{"spec": {"managementState": "Managed"}}`))
+	if err != nil {
+		return err
+	}
+	if err := ensureConsoleIsInDesiredState(t, client, operatorsv1alpha1.Managed); err != nil {
+		return fmt.Errorf("unable to change console operator state to 'Managed': %s", err)
+	}
+
+	return nil
+}
+
+func UnmanageConsole(t *testing.T, client *Clientset) error {
+	cr, err := client.ConsoleV1alpha1Interface.Consoles(consoleapi.OpenShiftConsoleOperatorNamespace).Get(consoleapi.ResourceName, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	if isOperatorUnmanaged(cr) {
+		t.Logf("console operator already in 'Unmanaged' state")
+		return nil
+	}
+
+	t.Logf("changing console operator state to 'Unmanaged'...")
+
+	_, err = client.ConsoleV1alpha1Interface.Consoles(consoleapi.OpenShiftConsoleOperatorNamespace).Patch(consoleapi.ResourceName, types.MergePatchType, []byte(`{"spec": {"managementState": "Unmanaged"}}`))
+	if err != nil {
+		return err
+	}
+	if err := ensureConsoleIsInDesiredState(t, client, operatorsv1alpha1.Unmanaged); err != nil {
+		return fmt.Errorf("unable to change console operator state to 'Unmanaged': %s", err)
+	}
+
+	return nil
+}
+
+func RemoveConsole(t *testing.T, client *Clientset) error {
+	cr, err := client.ConsoleV1alpha1Interface.Consoles(consoleapi.OpenShiftConsoleOperatorNamespace).Get(consoleapi.ResourceName, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	if isOperatorRemoved(cr) {
+		t.Logf("console operator already in 'Removed' state")
+		return nil
+	}
+
+	t.Logf("changing console operator state to 'Removed'...")
+
+	_, err = client.ConsoleV1alpha1Interface.Consoles(consoleapi.OpenShiftConsoleOperatorNamespace).Patch(consoleapi.ResourceName, types.MergePatchType, []byte(`{"spec": {"managementState": "Removed"}}`))
+	if err != nil {
+		return err
+	}
+	if err := ensureConsoleIsInDesiredState(t, client, operatorsv1alpha1.Removed); err != nil {
+		return fmt.Errorf("unable to change console operator state to 'Removed': %s", err)
+	}
+
+	return nil
+}
+func MustManageConsole(t *testing.T, client *Clientset) error {
+	if err := ManageConsole(t, client); err != nil {
+		t.Fatal(err)
+	}
+	return nil
+}
+
+func MustUnmanageConsole(t *testing.T, client *Clientset) error {
+	if err := UnmanageConsole(t, client); err != nil {
+		t.Fatal(err)
+	}
+	return nil
+}
+
+func MustRemoveConsole(t *testing.T, client *Clientset) error {
+	if err := RemoveConsole(t, client); err != nil {
+		t.Fatal(err)
+	}
+	return nil
+}

--- a/pkg/testframework/framework.go
+++ b/pkg/testframework/framework.go
@@ -1,13 +1,15 @@
 package testframework
 
 import (
+	"fmt"
+	"testing"
 	"time"
-
-	// "github.com/davecgh/go-spew/spew"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
+
+	consoleapi "github.com/openshift/console-operator/pkg/api"
 )
 
 var (
@@ -18,6 +20,59 @@ var (
 
 	AsyncOperationTimeout = 5 * time.Minute
 )
+
+func DeleteAll(t *testing.T, client *Clientset) {
+	resources := []string{"Deployment", "Service", "Route", "ConfigMap"}
+
+	for _, resource := range resources {
+		t.Logf("deleting console %s...", resource)
+		if err := DeleteCompletely(
+			func() (metav1.Object, error) {
+				return getResource(client, resource)
+			},
+			func(*metav1.DeleteOptions) error {
+				return deleteResource(client, resource)
+			},
+		); err != nil {
+			t.Fatalf("unable to delete console %s: %s", resource, err)
+		}
+	}
+}
+
+func getResource(client *Clientset, resource string) (metav1.Object, error) {
+	var res metav1.Object
+	var err error
+	switch resource {
+	case "ConfigMap":
+		res, err = client.ConfigMaps(consoleapi.OpenShiftConsoleOperatorNamespace).Get(consoleapi.OpenShiftConsoleConfigMapName, metav1.GetOptions{})
+	case "Service":
+		res, err = client.Services(consoleapi.OpenShiftConsoleOperatorNamespace).Get(consoleapi.OpenShiftConsoleServiceName, metav1.GetOptions{})
+	case "Route":
+		res, err = client.Routes(consoleapi.OpenShiftConsoleOperatorNamespace).Get(consoleapi.OpenShiftConsoleRouteName, metav1.GetOptions{})
+	case "Deployment":
+		fallthrough
+	default:
+		res, err = client.Deployments(consoleapi.OpenShiftConsoleOperatorNamespace).Get(consoleapi.OpenShiftConsoleDeploymentName, metav1.GetOptions{})
+	}
+	return res, err
+}
+
+func deleteResource(client *Clientset, resource string) error {
+	var err error
+	switch resource {
+	case "ConfigMap":
+		err = client.ConfigMaps(consoleapi.OpenShiftConsoleOperatorNamespace).Delete(consoleapi.OpenShiftConsoleConfigMapName, &metav1.DeleteOptions{})
+	case "Service":
+		err = client.Services(consoleapi.OpenShiftConsoleOperatorNamespace).Delete(consoleapi.OpenShiftConsoleServiceName, &metav1.DeleteOptions{})
+	case "Route":
+		err = client.Routes(consoleapi.OpenShiftConsoleOperatorNamespace).Delete(consoleapi.OpenShiftConsoleRouteName, &metav1.DeleteOptions{})
+	case "Deployment":
+		fallthrough
+	default:
+		err = client.Deployments(consoleapi.OpenShiftConsoleOperatorNamespace).Delete(consoleapi.OpenShiftConsoleDeploymentName, &metav1.DeleteOptions{})
+	}
+	return err
+}
 
 // DeleteCompletely sends a delete request and waits until the resource and
 // its dependents are deleted.
@@ -56,4 +111,46 @@ func DeleteCompletely(getObject func() (metav1.Object, error), deleteObject func
 
 		return obj.GetUID() != uid, nil
 	})
+}
+
+// IsResourceAvailable checks if tested resource is available(recreated by console-operator),
+// during 10 second period. If not error will be returned.
+func IsResourceAvailable(errChan chan error, client *Clientset, resource string) {
+	counter := 0
+	err := wait.Poll(1*time.Second, AsyncOperationTimeout, func() (stop bool, err error) {
+		_, err = getResource(client, resource)
+		if err == nil {
+			return true, nil
+		}
+		if counter == 10 {
+			if err != nil {
+				return true, fmt.Errorf("deleted console %s was not recreated", resource)
+			}
+			return true, nil
+		}
+		counter++
+		return false, nil
+	})
+	errChan <- err
+}
+
+// IsResourceUnavailable checks if tested resource is unavailable(not recreated by console-operator),
+// during 10 second period. If not error will be returned.
+func IsResourceUnavailable(errChan chan error, client *Clientset, resource string) {
+	counter := 0
+	err := wait.Poll(1*time.Second, AsyncOperationTimeout, func() (stop bool, err error) {
+		_, err = getResource(client, resource)
+		if err == nil {
+			return true, fmt.Errorf("deleted console %s was recreated", resource)
+		}
+		if !errors.IsNotFound(err) {
+			return true, err
+		}
+		counter++
+		if counter == 10 {
+			return true, nil
+		}
+		return false, nil
+	})
+	errChan <- err
 }

--- a/pkg/testframework/logs.go
+++ b/pkg/testframework/logs.go
@@ -1,0 +1,107 @@
+package testframework
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"regexp"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+
+	consoleapi "github.com/openshift/console-operator/pkg/api"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type PodLog []string
+
+func (log PodLog) Contains(re *regexp.Regexp) bool {
+	for _, line := range log {
+		if re.MatchString(line) {
+			return true
+		}
+	}
+	return false
+}
+
+type PodSetLogs map[string]PodLog
+
+func (psl PodSetLogs) Contains(re *regexp.Regexp) bool {
+	for _, podlog := range psl {
+		if podlog.Contains(re) {
+			return true
+		}
+	}
+	return false
+}
+
+func GetLogsByLabelSelector(client *Clientset, namespace string, labelSelector *metav1.LabelSelector) (PodSetLogs, error) {
+	selector, err := metav1.LabelSelectorAsSelector(labelSelector)
+	if err != nil {
+		return nil, err
+	}
+
+	podList, err := client.Pods(namespace).List(metav1.ListOptions{
+		LabelSelector: selector.String(),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	podLogs := make(PodSetLogs)
+	for _, pod := range podList.Items {
+		var podLog PodLog
+		log, err := client.Pods(pod.Namespace).GetLogs(pod.Name, &corev1.PodLogOptions{}).Stream()
+		if err != nil {
+			return nil, fmt.Errorf("failed to get logs for pod %s: %s", pod.Name, err)
+		}
+		r := bufio.NewReader(log)
+		for {
+			line, readErr := r.ReadSlice('\n')
+			if len(line) > 0 || readErr == nil {
+				podLog = append(podLog, string(line))
+			}
+			if readErr == io.EOF {
+				break
+			} else if readErr != nil {
+				return nil, fmt.Errorf("failed to read log for pod %s: %s", pod.Name, readErr)
+			}
+		}
+		podLogs[pod.Name] = podLog
+	}
+	return podLogs, nil
+}
+
+// DumpObject prints the object to the test log.
+func DumpObject(t *testing.T, prefix string, obj interface{}) {
+	t.Logf("%s:\n%s", prefix, spew.Sdump(obj))
+}
+
+func DumpPodLogs(t *testing.T, podLogs PodSetLogs) {
+	if len(podLogs) > 0 {
+		for pod, logs := range podLogs {
+			t.Logf("=== logs for pod/%s", pod)
+			for _, line := range logs {
+				t.Logf("%s", line)
+			}
+		}
+		t.Logf("=== end of logs")
+	}
+}
+
+func GetOperatorLogs(client *Clientset) (PodSetLogs, error) {
+	return GetLogsByLabelSelector(client, consoleapi.OpenShiftConsoleNamespace, &metav1.LabelSelector{
+		MatchLabels: map[string]string{
+			"name": "console-operator",
+		},
+	})
+}
+
+func DumpOperatorLogs(t *testing.T, client *Clientset) {
+	podLogs, err := GetOperatorLogs(client)
+	if err != nil {
+		t.Logf("failed to get the operator logs: %s", err)
+	}
+	DumpPodLogs(t, podLogs)
+}

--- a/test/e2e/managed_test.go
+++ b/test/e2e/managed_test.go
@@ -2,44 +2,29 @@ package e2e_test
 
 import (
 	"testing"
-	"time"
 
-	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/wait"
-
-	consoleapi "github.com/openshift/console-operator/pkg/api"
 	"github.com/openshift/console-operator/pkg/testframework"
 )
 
+// TestManaged sets console-operator to Managed state. After that "openshift-console
+// deployment is deleted after which the deployment is tested for availability, together
+// with other resources from the 'openshift-console' namespace - ConfigMap, Router, Service
 func TestManaged(t *testing.T) {
 	client := testframework.MustNewClientset(t, nil)
-
-	t.Logf("deleting console deployment...")
-	if err := testframework.DeleteCompletely(
-		func() (metav1.Object, error) {
-			return client.Deployments(consoleapi.OpenShiftConsoleOperatorNamespace).Get(consoleapi.OpenShiftConsoleName, metav1.GetOptions{})
-		},
-		func(deleteOptions *metav1.DeleteOptions) error {
-			return client.Deployments(consoleapi.OpenShiftConsoleOperatorNamespace).Delete(consoleapi.OpenShiftConsoleName, deleteOptions)
-		},
-	); err != nil {
-		t.Fatalf("unable to delete console deployment: %s", err)
-	}
+	defer testframework.MustManageConsole(t, client)
+	testframework.MustManageConsole(t, client)
+	testframework.DeleteAll(t, client)
 
 	t.Logf("waiting the operator to recreate console deployment...")
-	err := wait.Poll(1*time.Second, testframework.AsyncOperationTimeout, func() (stop bool, err error) {
-		_, err = client.Deployments(consoleapi.OpenShiftConsoleOperatorNamespace).Get(consoleapi.OpenShiftConsoleName, metav1.GetOptions{})
-		if err == nil {
-			return true, nil
-		}
-		t.Logf("get deployment: %s", err)
-		if errors.IsNotFound(err) {
-			return false, nil
-		}
-		return false, err
-	})
-	if err != nil {
-		t.Fatal(err)
+
+	errChan := make(chan error)
+	go testframework.IsResourceAvailable(errChan, client, "ConfigMap")
+	go testframework.IsResourceAvailable(errChan, client, "Route")
+	go testframework.IsResourceAvailable(errChan, client, "Service")
+	go testframework.IsResourceAvailable(errChan, client, "Deployment")
+	checkErr := <-errChan
+
+	if checkErr != nil {
+		t.Fatal(checkErr)
 	}
 }

--- a/test/e2e/removed_test.go
+++ b/test/e2e/removed_test.go
@@ -1,0 +1,29 @@
+package e2e_test
+
+import (
+	"testing"
+
+	"github.com/openshift/console-operator/pkg/testframework"
+)
+
+// TestRemoved sets console-operator to Removed state. After that all the resources
+// from the 'openshift-console' namespace (Deployment, ConfigMap, Router, Service),
+// are tested for unavailability since the operator should delete them.
+func TestRemoved(t *testing.T) {
+	client := testframework.MustNewClientset(t, nil)
+	defer testframework.MustManageConsole(t, client)
+	testframework.MustRemoveConsole(t, client)
+
+	t.Logf("waiting to check if the operator has not recreate removed console resources...")
+
+	errChan := make(chan error)
+	go testframework.IsResourceUnavailable(errChan, client, "ConfigMap")
+	go testframework.IsResourceUnavailable(errChan, client, "Route")
+	go testframework.IsResourceUnavailable(errChan, client, "Service")
+	go testframework.IsResourceUnavailable(errChan, client, "Deployment")
+	checkErr := <-errChan
+
+	if checkErr != nil {
+		t.Fatal(checkErr)
+	}
+}

--- a/test/e2e/unmanaged_test.go
+++ b/test/e2e/unmanaged_test.go
@@ -1,0 +1,31 @@
+package e2e_test
+
+import (
+	"testing"
+
+	"github.com/openshift/console-operator/pkg/testframework"
+)
+
+// TestUnmanaged sets console-operator to Unmanaged state. After that "openshift-console
+// deployment is deleted after which the deploymnet is tested for unavailability, to
+// check that it wasn't recreated byt the console operator. Other resources from the
+// 'openshift-console' namespace (ConfigMap, Router, Service) are tested for availability
+// since they have not been deleted.
+func TestUnmanaged(t *testing.T) {
+	client := testframework.MustNewClientset(t, nil)
+	defer testframework.MustManageConsole(t, client)
+	testframework.MustUnmanageConsole(t, client)
+	testframework.DeleteAll(t, client)
+
+	t.Logf("waiting to check if the operator has not recreate deleted resources...")
+	errChan := make(chan error)
+	go testframework.IsResourceUnavailable(errChan, client, "ConfigMap")
+	go testframework.IsResourceUnavailable(errChan, client, "Route")
+	go testframework.IsResourceUnavailable(errChan, client, "Service")
+	go testframework.IsResourceUnavailable(errChan, client, "Deployment")
+	checkErr := <-errChan
+
+	if checkErr != nil {
+		t.Fatal(checkErr)
+	}
+}


### PR DESCRIPTION
/assign @benjaminapetersen 

Adding Unmanaged and Removed test cases.
Each tests is testing several resources from the "openshift-console" namespace - Deployment/ConfigMap/Service/Route and their availability/unavailability for each operator state.
 
Also added `logs.go` that I've get [from](https://github.com/openshift/cluster-image-registry-operator/blob/master/pkg/testframework/logs.go) to get better logs.