### PR TITLE
Test editing resources in Managed and Unmanaged console-operator state

### DIFF
--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -1,4 +1,4 @@
-package e2e_test
+package e2e
 
 import (
 	"fmt"

--- a/test/e2e/managed_test.go
+++ b/test/e2e/managed_test.go
@@ -1,4 +1,4 @@
-package e2e_test
+package e2e
 
 import (
 	"testing"
@@ -26,5 +26,35 @@ func TestManaged(t *testing.T) {
 
 	if checkErr != nil {
 		t.Fatal(checkErr)
+	}
+}
+
+func TestEditManagedConfigMap(t *testing.T) {
+	client := testframework.MustNewClientset(t, nil)
+	defer testframework.MustManageConsole(t, client)
+	testframework.MustManageConsole(t, client)
+
+	if !patchAndCheckConfigMap(t, client) {
+		t.Fatalf("console ConfigMap data are not set to default value")
+	}
+}
+
+func TestEditManagedService(t *testing.T) {
+	client := testframework.MustNewClientset(t, nil)
+	defer testframework.MustManageConsole(t, client)
+	testframework.MustManageConsole(t, client)
+
+	if !patchAndCheckService(t, client) {
+		t.Fatalf("console Service data are not set to default value")
+	}
+}
+
+func TestEditManagedRoute(t *testing.T) {
+	client := testframework.MustNewClientset(t, nil)
+	defer testframework.MustManageConsole(t, client)
+	testframework.MustManageConsole(t, client)
+
+	if !patchAndCheckRoute(t, client) {
+		t.Fatalf("console Route data are not set to default value")
 	}
 }

--- a/test/e2e/managed_test.go
+++ b/test/e2e/managed_test.go
@@ -34,8 +34,9 @@ func TestEditManagedConfigMap(t *testing.T) {
 	defer testframework.MustManageConsole(t, client)
 	testframework.MustManageConsole(t, client)
 
-	if !patchAndCheckConfigMap(t, client) {
-		t.Fatalf("console ConfigMap data are not set to default value")
+	err := patchAndCheckConfigMap(t, client, true)
+	if err != nil {
+		t.Fatalf("error: %s", err)
 	}
 }
 
@@ -44,8 +45,9 @@ func TestEditManagedService(t *testing.T) {
 	defer testframework.MustManageConsole(t, client)
 	testframework.MustManageConsole(t, client)
 
-	if !patchAndCheckService(t, client) {
-		t.Fatalf("console Service data are not set to default value")
+	err := patchAndCheckService(t, client, true)
+	if err != nil {
+		t.Fatalf("error: %s", err)
 	}
 }
 
@@ -54,7 +56,8 @@ func TestEditManagedRoute(t *testing.T) {
 	defer testframework.MustManageConsole(t, client)
 	testframework.MustManageConsole(t, client)
 
-	if !patchAndCheckRoute(t, client) {
-		t.Fatalf("console Route data are not set to default value")
+	err := patchAndCheckRoute(t, client, true)
+	if err != nil {
+		t.Fatalf("error: %s", err)
 	}
 }

--- a/test/e2e/removed_test.go
+++ b/test/e2e/removed_test.go
@@ -1,4 +1,4 @@
-package e2e_test
+package e2e
 
 import (
 	"testing"

--- a/test/e2e/unmanaged_test.go
+++ b/test/e2e/unmanaged_test.go
@@ -1,4 +1,4 @@
-package e2e_test
+package e2e
 
 import (
 	"testing"
@@ -27,5 +27,35 @@ func TestUnmanaged(t *testing.T) {
 
 	if checkErr != nil {
 		t.Fatal(checkErr)
+	}
+}
+
+func TestEditUnmanagedConfigMap(t *testing.T) {
+	client := testframework.MustNewClientset(t, nil)
+	defer testframework.MustManageConsole(t, client)
+	testframework.MustUnmanageConsole(t, client)
+
+	if patchAndCheckConfigMap(t, client) {
+		t.Fatalf("console ConfigMap data are set to default value")
+	}
+}
+
+func TestEditUnmanagedService(t *testing.T) {
+	client := testframework.MustNewClientset(t, nil)
+	defer testframework.MustManageConsole(t, client)
+	testframework.MustUnmanageConsole(t, client)
+
+	if patchAndCheckService(t, client) {
+		t.Fatalf("console Service status are set to default value")
+	}
+}
+
+func TestEditUnmanagedRoute(t *testing.T) {
+	client := testframework.MustNewClientset(t, nil)
+	defer testframework.MustManageConsole(t, client)
+	testframework.MustUnmanageConsole(t, client)
+
+	if patchAndCheckRoute(t, client) {
+		t.Fatalf("console Route status are set to default value")
 	}
 }

--- a/test/e2e/unmanaged_test.go
+++ b/test/e2e/unmanaged_test.go
@@ -35,8 +35,9 @@ func TestEditUnmanagedConfigMap(t *testing.T) {
 	defer testframework.MustManageConsole(t, client)
 	testframework.MustUnmanageConsole(t, client)
 
-	if patchAndCheckConfigMap(t, client) {
-		t.Fatalf("console ConfigMap data are set to default value")
+	err := patchAndCheckConfigMap(t, client, false)
+	if err != nil {
+		t.Fatalf("error: %s", err)
 	}
 }
 
@@ -45,8 +46,9 @@ func TestEditUnmanagedService(t *testing.T) {
 	defer testframework.MustManageConsole(t, client)
 	testframework.MustUnmanageConsole(t, client)
 
-	if patchAndCheckService(t, client) {
-		t.Fatalf("console Service status are set to default value")
+	err := patchAndCheckService(t, client, false)
+	if err != nil {
+		t.Fatalf("error: %s", err)
 	}
 }
 
@@ -55,7 +57,8 @@ func TestEditUnmanagedRoute(t *testing.T) {
 	defer testframework.MustManageConsole(t, client)
 	testframework.MustUnmanageConsole(t, client)
 
-	if patchAndCheckRoute(t, client) {
-		t.Fatalf("console Route status are set to default value")
+	err := patchAndCheckRoute(t, client, false)
+	if err != nil {
+		t.Fatalf("error: %s", err)
 	}
 }

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -5,99 +5,88 @@ import (
 	"testing"
 	"time"
 
-	routev1 "github.com/openshift/api/route/v1"
 	"github.com/openshift/console-operator/pkg/testframework"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
 
 	consoleapi "github.com/openshift/console-operator/pkg/api"
 )
 
-// Basically each of these tests helpers are similar, they only vary in the
-// resource they are GETting, PATCHing and patch itself.
-// Since after the patch is done, the test needs to wait, till it can GET
-// patched object(or not, if the operator status is set to Managed).
+// Each of these tests helpers are similar, they only vary in the
+// resource they are GETting and PATCHing.
+// After the patch is done the test will poll the given resource.
+// In case the console-operator is Managed state the patched data should
+// not be equal to the one obtained after patch is applied.
+// In case the console-operator is Unmanaged state the patched data should
+// be equal to the one obtained after patch is applied.
 
-func patchAndCheckConfigMap(t *testing.T, client *testframework.Clientset) bool {
-	res, err := testframework.GetResource(client, "ConfigMap")
-	errorCheck(t, err)
-	configMap, ok := res.(*corev1.ConfigMap)
-	if !ok {
-		t.Fatalf("unable to type received object as ConfigMap")
-	}
-	originalData := configMap.Data
+var pollTimeout = 10 * time.Second
 
+func patchAndCheckConfigMap(t *testing.T, client *testframework.Clientset, isOperatorManaged bool) error {
 	t.Logf("patching Data on the console ConfigMap")
-	_, err = client.ConfigMaps(consoleapi.OpenShiftConsoleOperatorNamespace).Patch(consoleapi.OpenShiftConsoleConfigMapName, types.MergePatchType, []byte(`{"data": {"console-config.yaml": "test"}}`))
-	errorCheck(t, err)
-
-	time.Sleep(5 * time.Second)
-
-	res, err = testframework.GetResource(client, "ConfigMap")
-	errorCheck(t, err)
-	configMap, ok = res.(*corev1.ConfigMap)
-	if !ok {
-		t.Fatalf("unable to type received object as ConfigMap")
-	}
-	newData := configMap.Data
-
-	return reflect.DeepEqual(originalData, newData)
-}
-
-func patchAndCheckService(t *testing.T, client *testframework.Clientset) bool {
-	res, err := testframework.GetResource(client, "Service")
-	errorCheck(t, err)
-	service, ok := res.(*corev1.Service)
-	if !ok {
-		t.Fatalf("unable to type received object as Service")
-	}
-	originalData := service.GetAnnotations()
-
-	t.Logf("patching Annotations on the console Service")
-	_, err = client.Services(consoleapi.OpenShiftConsoleOperatorNamespace).Patch(consoleapi.OpenShiftConsoleServiceName, types.MergePatchType, []byte(`{"metadata": {"annotations": {"service.alpha.openshift.io/serving-cert-secret-name": "test"}}}`))
-	errorCheck(t, err)
-
-	time.Sleep(5 * time.Second)
-
-	res, err = testframework.GetResource(client, "Service")
-	errorCheck(t, err)
-	service, ok = res.(*corev1.Service)
-	if !ok {
-		t.Fatalf("unable to type received object as Service")
-	}
-	newData := service.GetAnnotations()
-
-	return reflect.DeepEqual(originalData, newData)
-}
-
-func patchAndCheckRoute(t *testing.T, client *testframework.Clientset) bool {
-	res, err := testframework.GetResource(client, "Route")
-	errorCheck(t, err)
-	route, ok := res.(*routev1.Route)
-	if !ok {
-		t.Fatalf("unable to type received object as Route")
-	}
-	originalData := route.Spec.Port.TargetPort
-
-	t.Logf("patching TargetPort on the console Route")
-	_, err = client.Routes(consoleapi.OpenShiftConsoleOperatorNamespace).Patch(consoleapi.OpenShiftConsoleRouteName, types.MergePatchType, []byte(`{"spec": {"port": {"targetPort": "http"}}}`))
-	errorCheck(t, err)
-
-	time.Sleep(5 * time.Second)
-
-	res, err = testframework.GetResource(client, "Route")
-	errorCheck(t, err)
-	route, ok = res.(*routev1.Route)
-	if !ok {
-		t.Fatalf("unable to type received object as Route")
-	}
-	newData := route.Spec.Port.TargetPort
-
-	return reflect.DeepEqual(originalData, newData)
-}
-
-func errorCheck(t *testing.T, err error) {
+	configMap, err := client.ConfigMaps(consoleapi.OpenShiftConsoleNamespace).Patch(consoleapi.OpenShiftConsoleConfigMapName, types.MergePatchType, []byte(`{"data": {"console-config.yaml": "test"}}`))
 	if err != nil {
-		t.Fatalf("Fatal error: %s", err)
+		return err
 	}
+	patchedData := configMap.Data
+
+	t.Logf("polling for patched Data on the console ConfigMap")
+	err = wait.Poll(1*time.Second, pollTimeout, func() (stop bool, err error) {
+		configMap, err = testframework.GetConsoleConfigMap(client)
+		if err != nil {
+			return true, err
+		}
+		newData := configMap.Data
+		if isOperatorManaged {
+			return !reflect.DeepEqual(patchedData, newData), nil
+		}
+		return reflect.DeepEqual(patchedData, newData), nil
+	})
+	return err
+}
+
+func patchAndCheckService(t *testing.T, client *testframework.Clientset, isOperatorManaged bool) error {
+	t.Logf("patching Annotation on the console Service")
+	service, err := client.Services(consoleapi.OpenShiftConsoleNamespace).Patch(consoleapi.OpenShiftConsoleServiceName, types.MergePatchType, []byte(`{"metadata": {"annotations": {"service.alpha.openshift.io/serving-cert-secret-name": "test"}}}`))
+	if err != nil {
+		return err
+	}
+	patchedData := service.GetAnnotations()
+
+	t.Logf("polling for patched Annotation on the console Service")
+	err = wait.Poll(1*time.Second, pollTimeout, func() (stop bool, err error) {
+		service, err = testframework.GetConsoleService(client)
+		if err != nil {
+			return true, err
+		}
+		newData := service.GetAnnotations()
+		if isOperatorManaged {
+			return !reflect.DeepEqual(patchedData, newData), nil
+		}
+		return reflect.DeepEqual(patchedData, newData), nil
+	})
+	return err
+}
+
+func patchAndCheckRoute(t *testing.T, client *testframework.Clientset, isOperatorManaged bool) error {
+	t.Logf("patching TargetPort on the console Route")
+	route, err := client.Routes(consoleapi.OpenShiftConsoleNamespace).Patch(consoleapi.OpenShiftConsoleRouteName, types.MergePatchType, []byte(`{"spec": {"port": {"targetPort": "http"}}}`))
+	if err != nil {
+		return err
+	}
+	patchedData := route.Spec.Port.TargetPort
+
+	t.Logf("polling for patched TargetPort on the console Route")
+	err = wait.Poll(1*time.Second, pollTimeout, func() (stop bool, err error) {
+		route, err = testframework.GetConsoleRoute(client)
+		if err != nil {
+			return true, err
+		}
+		newData := route.Spec.Port.TargetPort
+		if isOperatorManaged {
+			return !reflect.DeepEqual(patchedData, newData), nil
+		}
+		return reflect.DeepEqual(patchedData, newData), nil
+	})
+	return err
 }

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -1,0 +1,103 @@
+package e2e
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	routev1 "github.com/openshift/api/route/v1"
+	"github.com/openshift/console-operator/pkg/testframework"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	consoleapi "github.com/openshift/console-operator/pkg/api"
+)
+
+// Basically each of these tests helpers are similar, they only vary in the
+// resource they are GETting, PATCHing and patch itself.
+// Since after the patch is done, the test needs to wait, till it can GET
+// patched object(or not, if the operator status is set to Managed).
+
+func patchAndCheckConfigMap(t *testing.T, client *testframework.Clientset) bool {
+	res, err := testframework.GetResource(client, "ConfigMap")
+	errorCheck(t, err)
+	configMap, ok := res.(*corev1.ConfigMap)
+	if !ok {
+		t.Fatalf("unable to type received object as ConfigMap")
+	}
+	originalData := configMap.Data
+
+	t.Logf("patching Data on the console ConfigMap")
+	_, err = client.ConfigMaps(consoleapi.OpenShiftConsoleOperatorNamespace).Patch(consoleapi.OpenShiftConsoleConfigMapName, types.MergePatchType, []byte(`{"data": {"console-config.yaml": "test"}}`))
+	errorCheck(t, err)
+
+	time.Sleep(5 * time.Second)
+
+	res, err = testframework.GetResource(client, "ConfigMap")
+	errorCheck(t, err)
+	configMap, ok = res.(*corev1.ConfigMap)
+	if !ok {
+		t.Fatalf("unable to type received object as ConfigMap")
+	}
+	newData := configMap.Data
+
+	return reflect.DeepEqual(originalData, newData)
+}
+
+func patchAndCheckService(t *testing.T, client *testframework.Clientset) bool {
+	res, err := testframework.GetResource(client, "Service")
+	errorCheck(t, err)
+	service, ok := res.(*corev1.Service)
+	if !ok {
+		t.Fatalf("unable to type received object as Service")
+	}
+	originalData := service.GetAnnotations()
+
+	t.Logf("patching Annotations on the console Service")
+	_, err = client.Services(consoleapi.OpenShiftConsoleOperatorNamespace).Patch(consoleapi.OpenShiftConsoleServiceName, types.MergePatchType, []byte(`{"metadata": {"annotations": {"service.alpha.openshift.io/serving-cert-secret-name": "test"}}}`))
+	errorCheck(t, err)
+
+	time.Sleep(5 * time.Second)
+
+	res, err = testframework.GetResource(client, "Service")
+	errorCheck(t, err)
+	service, ok = res.(*corev1.Service)
+	if !ok {
+		t.Fatalf("unable to type received object as Service")
+	}
+	newData := service.GetAnnotations()
+
+	return reflect.DeepEqual(originalData, newData)
+}
+
+func patchAndCheckRoute(t *testing.T, client *testframework.Clientset) bool {
+	res, err := testframework.GetResource(client, "Route")
+	errorCheck(t, err)
+	route, ok := res.(*routev1.Route)
+	if !ok {
+		t.Fatalf("unable to type received object as Route")
+	}
+	originalData := route.Spec.Port.TargetPort
+
+	t.Logf("patching TargetPort on the console Route")
+	_, err = client.Routes(consoleapi.OpenShiftConsoleOperatorNamespace).Patch(consoleapi.OpenShiftConsoleRouteName, types.MergePatchType, []byte(`{"spec": {"port": {"targetPort": "http"}}}`))
+	errorCheck(t, err)
+
+	time.Sleep(5 * time.Second)
+
+	res, err = testframework.GetResource(client, "Route")
+	errorCheck(t, err)
+	route, ok = res.(*routev1.Route)
+	if !ok {
+		t.Fatalf("unable to type received object as Route")
+	}
+	newData := route.Spec.Port.TargetPort
+
+	return reflect.DeepEqual(originalData, newData)
+}
+
+func errorCheck(t *testing.T, err error) {
+	if err != nil {
+		t.Fatalf("Fatal error: %s", err)
+	}
+}


### PR DESCRIPTION
@benjaminapetersen adding promised tests.
Per our discussion, the tests are editing the resources separately, not bulk, since they have different semantics for the test.
The tests are testing ConfigMap, Service and Route. I've skipped the Deployment since the console operator is not managing changes user makes to it(which is kinda weird?).
 
Also made the `getResource()` public -> `GetResource()`, so it can be used on different places + now it's returning runtime.Object so different fields object field can be accessed.

PTAL