### PR TITLE
[WIP] Add flag to handle brand

### DIFF
--- a/pkg/apis/console/v1alpha1/types.go
+++ b/pkg/apis/console/v1alpha1/types.go
@@ -43,3 +43,8 @@ type ConsoleList struct {
 
 	Items []Console `json:"items"`
 }
+
+type FlagOptions struct {
+	Brand string `json:"brand"`
+	SetDefault bool `json:"setDefault"`
+}

--- a/pkg/apis/console/v1alpha1/types.go
+++ b/pkg/apis/console/v1alpha1/types.go
@@ -45,6 +45,6 @@ type ConsoleList struct {
 }
 
 type FlagOptions struct {
-	Brand string `json:"brand"`
-	SetDefault bool `json:"setDefault"`
+	Brand      string `json:"brand"`
+	SetDefault bool   `json:"setDefault"`
 }

--- a/pkg/cmd/operator/cmd.go
+++ b/pkg/cmd/operator/cmd.go
@@ -36,5 +36,13 @@ func NewOperator() *cobra.Command {
         `,
 	)
 
+	cmd.Flags().StringVarP(
+		&operator.Brand,
+		"brand",
+		"b",
+		"okd",
+		"Defines what branding the console will show. Defaults to OKD.",
+	)
+
 	return cmd
 }

--- a/pkg/console/operator/operator.go
+++ b/pkg/console/operator/operator.go
@@ -58,6 +58,7 @@ const (
 )
 
 var CreateDefaultConsoleFlag bool
+var Brand string
 
 type consoleOperator struct {
 	// for a performance sensitive operator, it would make sense to use informers
@@ -183,13 +184,14 @@ func (c *consoleOperator) Sync(obj metav1.Object) error {
 	v311_to_401 := versioning.NewRangeOrDie("3.11.0", "4.0.1")
 
 	outConfig := operatorConfig.DeepCopy()
+
 	var errs []error
 
 	configChanged := false
 	switch {
 	// v4.0.0 or nil
 	case v311_to_401.BetweenOrEmpty(currentActualVersion):
-		outConfig, configChanged, err = sync_v400(c, outConfig)
+		outConfig, configChanged, err = sync_v400(c, outConfig, consolev1alpha1.FlagOptions{Brand, CreateDefaultConsoleFlag})
 		errs = append(errs, err)
 		if err == nil {
 			outConfig.Status.TaskSummary = "sync-4.0.0"

--- a/pkg/console/operator/sync_v400.go
+++ b/pkg/console/operator/sync_v400.go
@@ -39,7 +39,7 @@ import (
 // The next loop will pick up where they previous left off and move the process forward one step.
 // This ensures the logic is simpler as we do not have to handle coordination between objects within
 // the loop.
-func sync_v400(co *consoleOperator, consoleConfig *v1alpha1.Console) (*v1alpha1.Console, bool, error) {
+func sync_v400(co *consoleOperator, consoleConfig *v1alpha1.Console, options v1alpha1.FlagOptions) (*v1alpha1.Console, bool, error) {
 	logrus.Println("running sync loop 4.0.0")
 	recorder := co.recorder
 
@@ -58,7 +58,7 @@ func sync_v400(co *consoleOperator, consoleConfig *v1alpha1.Console) (*v1alpha1.
 	}
 	toUpdate = toUpdate || svcChanged
 
-	cm, cmChanged, cmErr := SyncConfigMap(co, recorder, consoleConfig, rt)
+	cm, cmChanged, cmErr := SyncConfigMap(co, recorder, consoleConfig, rt, options)
 	if cmErr != nil {
 		return consoleConfig, toUpdate, cmErr
 	}
@@ -199,9 +199,9 @@ func SyncSecret(co *consoleOperator, recorder events.Recorder, consoleConfig *v1
 // apply configmap (needs route)
 // by the time we get to the configmap, we can assume the route exits & is configured properly
 // therefore no additional error handling is needed here.
-func SyncConfigMap(co *consoleOperator, recorder events.Recorder, consoleConfig *v1alpha1.Console, rt *routev1.Route) (*corev1.ConfigMap, bool, error) {
+func SyncConfigMap(co *consoleOperator, recorder events.Recorder, consoleConfig *v1alpha1.Console, rt *routev1.Route, options v1alpha1.FlagOptions) (*corev1.ConfigMap, bool, error) {
 	logrus.Printf("validating console configmap...")
-	cm, cmChanged, cmErr := resourceapply.ApplyConfigMap(co.configMapClient, recorder, configmapsub.DefaultConfigMap(consoleConfig, rt))
+	cm, cmChanged, cmErr := resourceapply.ApplyConfigMap(co.configMapClient, recorder, configmapsub.DefaultConfigMap(consoleConfig, rt, options))
 	if cmErr != nil {
 		logrus.Errorf("%q: %v \n", "configmap", cmErr)
 		return nil, false, cmErr

--- a/pkg/console/subresource/configmap/configmap.go
+++ b/pkg/console/subresource/configmap/configmap.go
@@ -26,9 +26,9 @@ const (
 	keyFilePath  = "/var/serving-cert/tls.key"
 )
 
-func DefaultConfigMap(cr *v1alpha1.Console, rt *routev1.Route) *corev1.ConfigMap {
+func DefaultConfigMap(cr *v1alpha1.Console, rt *routev1.Route, options v1alpha1.FlagOptions) *corev1.ConfigMap {
 	host := rt.Spec.Host
-	config := NewYamlConfigString(host)
+	config := NewYamlConfigString(host, options)
 	configMap := Stub()
 	configMap.Data = map[string]string{
 		consoleConfigYamlFile: config,
@@ -47,11 +47,11 @@ func Stub() *corev1.ConfigMap {
 	return configMap
 }
 
-func NewYamlConfigString(host string) string {
-	return string(NewYamlConfig(host))
+func NewYamlConfigString(host string, options v1alpha1.FlagOptions) string {
+	return string(NewYamlConfig(host, options))
 }
 
-func NewYamlConfig(host string) []byte {
+func NewYamlConfig(host string, options v1alpha1.FlagOptions) []byte {
 	conf := yaml.MapSlice{
 		{
 			Key: "kind", Value: "ConsoleConfig",
@@ -62,7 +62,7 @@ func NewYamlConfig(host string) []byte {
 		}, {
 			Key: "clusterInfo", Value: clusterInfo(host),
 		}, {
-			Key: "customization", Value: customization(),
+			Key: "customization", Value: customization(options),
 		}, {
 			Key: "servingInfo", Value: servingInfo(),
 		},
@@ -87,12 +87,12 @@ func servingInfo() yaml.MapSlice {
 	}
 }
 
-func customization() yaml.MapSlice {
+func customization(options v1alpha1.FlagOptions) yaml.MapSlice {
 	return yaml.MapSlice{
 		{
 			// TODO: branding will need to be provided by higher level config.
 			// it should not be configurable in the CR, but needs to be configured somewhere.
-			Key: "branding", Value: brandingDefault,
+			Key: "branding", Value: options.Brand,
 		}, {
 			Key: "documentationBaseURL", Value: documentationBaseURL,
 		},

--- a/pkg/console/subresource/configmap/configmap_test.go
+++ b/pkg/console/subresource/configmap/configmap_test.go
@@ -39,6 +39,7 @@ func TestDefaultConfigMap(t *testing.T) {
 	type args struct {
 		cr *v1alpha1.Console
 		rt *v1.Route
+		opt v1alpha1.FlagOptions
 	}
 	tests := []struct {
 		name string
@@ -68,6 +69,9 @@ func TestDefaultConfigMap(t *testing.T) {
 					},
 					Status: v1.RouteStatus{},
 				},
+				opt: v1alpha1.FlagOptions{
+					Brand: brandingDefault,
+				},
 			},
 			want: &corev1.ConfigMap{
 				TypeMeta: metav1.TypeMeta{},
@@ -96,7 +100,7 @@ func TestDefaultConfigMap(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := DefaultConfigMap(tt.args.cr, tt.args.rt); !reflect.DeepEqual(got, tt.want) {
+			if got := DefaultConfigMap(tt.args.cr, tt.args.rt, tt.args.opt); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("DefaultConfigMap() = %v\n ----------- want %v", got, tt.want)
 			}
 		})
@@ -150,6 +154,7 @@ func TestStub(t *testing.T) {
 func TestNewYamlConfig(t *testing.T) {
 	type args struct {
 		host string
+		options v1alpha1.FlagOptions
 	}
 	tests := []struct {
 		name string
@@ -160,13 +165,14 @@ func TestNewYamlConfig(t *testing.T) {
 			name: "TestNewYamlConfig",
 			args: args{
 				host: host,
+				options: v1alpha1.FlagOptions{Brand:brandingDefault},
 			},
 			want: exampleYaml,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := NewYamlConfigString(tt.args.host); !reflect.DeepEqual(got, tt.want) {
+			if got := NewYamlConfigString(tt.args.host, tt.args.options); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("NewYamlConfig() = \n%v\n ----> want\n%v", got, tt.want)
 			}
 		})

--- a/pkg/console/subresource/configmap/configmap_test.go
+++ b/pkg/console/subresource/configmap/configmap_test.go
@@ -37,8 +37,8 @@ servingInfo:
 // To manually run these tests: go test -v ./pkg/console/subresource/configmap/...
 func TestDefaultConfigMap(t *testing.T) {
 	type args struct {
-		cr *v1alpha1.Console
-		rt *v1.Route
+		cr  *v1alpha1.Console
+		rt  *v1.Route
 		opt v1alpha1.FlagOptions
 	}
 	tests := []struct {
@@ -153,7 +153,7 @@ func TestStub(t *testing.T) {
 // TODO: remove - This unit test is probably not useful since it is just testing yaml methods slice and marshal with no logic
 func TestNewYamlConfig(t *testing.T) {
 	type args struct {
-		host string
+		host    string
 		options v1alpha1.FlagOptions
 	}
 	tests := []struct {
@@ -164,8 +164,8 @@ func TestNewYamlConfig(t *testing.T) {
 		{
 			name: "TestNewYamlConfig",
 			args: args{
-				host: host,
-				options: v1alpha1.FlagOptions{Brand:brandingDefault},
+				host:    host,
+				options: v1alpha1.FlagOptions{Brand: brandingDefault},
 			},
 			want: exampleYaml,
 		},


### PR DESCRIPTION
[WIP] This PR adds a runtime flag option to the operator that allows the user to set the brand value.  The command would look like:
`IMAGE=docker.io/openshift/origin-console:latest  console operator  --brand ocp`
