### PR TITLE
Add Goflag option to define branding at build time

### DIFF
--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -1,7 +1,7 @@
 FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.10 AS builder
 WORKDIR /go/src/github.com/openshift/console-operator
 COPY . .
-RUN make build
+RUN ADDITIONAL_GOTAGS="ocp" make build WHAT="cmd/console"
 
 FROM registry.svc.ci.openshift.org/ocp/4.0:base
 RUN useradd console-operator

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ OUT_DIR = _output
 OS_OUTPUT_GOPATH ?= 1
 
 export GOFLAGS
+export ADDITIONAL_GOTAGS
 export TESTFLAGS
 # If set to 1, create an isolated GOPATH inside _output using symlinks to avoid
 # other packages being accidentally included. Defaults to on.

--- a/hack/lib/build/binaries.sh
+++ b/hack/lib/build/binaries.sh
@@ -241,7 +241,7 @@ os::build::internal::build_binaries() {
       if [[ ${#nonstatics[@]} -gt 0 ]]; then
         GOOS=${platform%/*} GOARCH=${platform##*/} go install \
           -pkgdir "${pkgdir}/${platform}" \
-          -tags "${OS_GOFLAGS_TAGS-} ${!platform_gotags_envvar:-}" \
+          -tags "${OS_GOFLAGS_TAGS-} ${!platform_gotags_envvar:-} ${ADDITIONAL_GOTAGS-}" \
           -ldflags="${local_ldflags}" \
           "${goflags[@]:+${goflags[@]}}" \
           "${nonstatics[@]}"

--- a/hack/lib/constants.sh
+++ b/hack/lib/constants.sh
@@ -54,11 +54,11 @@ function os::build::ldflags() {
 
   declare -a ldflags=()
 
-  ldflags+=($(os::build::ldflag "${OS_GO_PACKAGE}/pkg/version.majorFromGit" "${OS_GIT_MAJOR}"))
-  ldflags+=($(os::build::ldflag "${OS_GO_PACKAGE}/pkg/version.minorFromGit" "${OS_GIT_MINOR}"))
-  ldflags+=($(os::build::ldflag "${OS_GO_PACKAGE}/pkg/version.versionFromGit" "${OS_GIT_VERSION}"))
-  ldflags+=($(os::build::ldflag "${OS_GO_PACKAGE}/pkg/version.commitFromGit" "${OS_GIT_COMMIT}"))
-  ldflags+=($(os::build::ldflag "${OS_GO_PACKAGE}/pkg/version.buildDate" "${buildDate}"))
+  ldflags+=($(os::build::ldflag "${OS_GO_PACKAGE}/pkg/console/version.majorFromGit" "${OS_GIT_MAJOR}"))
+  ldflags+=($(os::build::ldflag "${OS_GO_PACKAGE}/pkg/console/version.minorFromGit" "${OS_GIT_MINOR}"))
+  ldflags+=($(os::build::ldflag "${OS_GO_PACKAGE}/pkg/console/version.versionFromGit" "${OS_GIT_VERSION}"))
+  ldflags+=($(os::build::ldflag "${OS_GO_PACKAGE}/pkg/console/version.commitFromGit" "${OS_GIT_COMMIT}"))
+  ldflags+=($(os::build::ldflag "${OS_GO_PACKAGE}/pkg/console/version.buildDate" "${buildDate}"))
 
   # The -ldflags parameter takes a single string, so join the output.
   echo "${ldflags[*]-}"

--- a/pkg/cmd/version/cmd.go
+++ b/pkg/cmd/version/cmd.go
@@ -3,14 +3,21 @@ package version
 import (
 	"fmt"
 	"github.com/blang/semver"
+	"github.com/openshift/console-operator/pkg/console/version"
 	"github.com/spf13/cobra"
 	"strings"
+
+	cm "github.com/openshift/console-operator/pkg/console/subresource/configmap"
 )
 
 var (
-	Raw     = "v0.0.1"
-	Version = semver.MustParse(strings.TrimLeft(Raw, "v"))
-	String  = fmt.Sprintf("ConsoleOperator %s", Raw)
+	Raw        = "v0.0.1"
+	VerInfo    = version.Get()
+	GitCommit  = VerInfo.GitCommit
+	BuildDate  = VerInfo.BuildDate
+	Version    = semver.MustParse(strings.TrimLeft(Raw, "v"))
+	BrandValue = cm.DEFAULT_BRAND
+	String     = fmt.Sprintf("ConsoleOperator %s\nGit Commit: %s\nBuild Date: %s\nCurrent Brand Setting: %s", Raw, GitCommit, BuildDate, BrandValue)
 )
 
 func NewVersion() *cobra.Command {

--- a/pkg/console/subresource/configmap/brand_ocp.go
+++ b/pkg/console/subresource/configmap/brand_ocp.go
@@ -1,0 +1,8 @@
+// +build ocp
+
+package configmap
+
+const (
+	DEFAULT_BRAND   = "ocp"
+	DEFAULT_DOC_URL = "https://docs.openshift.com/container-platform/4.0/welcome/index.html"
+)

--- a/pkg/console/subresource/configmap/brand_okd.go
+++ b/pkg/console/subresource/configmap/brand_okd.go
@@ -1,0 +1,8 @@
+// +build !ocp
+
+package configmap
+
+const (
+	DEFAULT_BRAND   = "okd"
+	DEFAULT_DOC_URL = "https://docs.okd.io/4.0/"
+)

--- a/pkg/console/subresource/configmap/configmap.go
+++ b/pkg/console/subresource/configmap/configmap.go
@@ -29,12 +29,6 @@ const (
 	defaultLogoutURL = ""
 )
 
-// overridden by operator config
-const (
-	defaultDocumentationBaseURL = "https://docs.okd.io/4.0/"
-	defaultBranding             = "okd"
-)
-
 func getLogoutRedirect(consoleConfig *configv1.Console) string {
 	if len(consoleConfig.Spec.Authentication.LogoutRedirect) > 0 {
 		return consoleConfig.Spec.Authentication.LogoutRedirect
@@ -46,14 +40,14 @@ func getBrand(operatorConfig *operatorv1.Console) operatorv1.Brand {
 	if len(operatorConfig.Spec.Customization.Brand) > 0 {
 		return operatorConfig.Spec.Customization.Brand
 	}
-	return defaultBranding
+	return DEFAULT_BRAND
 }
 
 func getDocURL(operatorConfig *operatorv1.Console) string {
 	if len(operatorConfig.Spec.Customization.DocumentationBaseURL) > 0 {
 		return operatorConfig.Spec.Customization.DocumentationBaseURL
 	}
-	return defaultDocumentationBaseURL
+	return DEFAULT_DOC_URL
 }
 
 func DefaultConfigMap(operatorConfig *operatorv1.Console, consoleConfig *configv1.Console, rt *routev1.Route) *corev1.ConfigMap {


### PR DESCRIPTION
Add Goflag option to define branding at build time.  Docker rhel file has been updated to provide ocp branding.
Usage: ADDITIONAL_GOTAGS="ocp" make WHAT="cmd/console" 
$ console version
ConsoleOperator v0.0.1
Git Commit: 6cf43775
Build Date: 2019-02-05T20:08:03Z
Current Brand Setting: ocp
Tag option: ocp
This solution uses tags in the build process.

Additionally, updated the console version helper tool to show current Git Commit value, build date, and the brand setting.
