### PR TITLE
Update CRD for operator.openshift.io Console (Operator Config)

### DIFF
--- a/manifests/00-crd-operator-config.yaml
+++ b/manifests/00-crd-operator-config.yaml
@@ -1,13 +1,18 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: consoles.console.openshift.io
+  name: consoles.operator.openshift.io
 spec:
-  group: console.openshift.io
+  scope: Cluster
+  group: operator.openshift.io
   names:
     kind: Console
     listKind: ConsoleList
     plural: consoles
     singular: console
-  scope: Namespaced
-  version: v1alpha1
+  subresources:
+    status: {}
+  versions:
+  - name: v1
+    served: true
+    storage: true


### PR DESCRIPTION
- Partial from #127, breaking this up again into units.
- Related to [cluster-config-operator PR 11](https://github.com/openshift/cluster-config-operator/pull/11).
- CRD for operator config stays here, top level console config goes to cluster-config-operator
   - We don't own this config.  Its top level, so multiple operators may need to consume it.
   - We do still own our operator config.


