### PR TITLE
Add console ClusterOperator manifest

### DIFF
--- a/manifests/05-clusteroperator.yaml
+++ b/manifests/05-clusteroperator.yaml
@@ -1,0 +1,5 @@
+apiVersion: config.openshift.io/v1
+kind: ClusterOperator
+metadata:
+  name: console
+spec: {}

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -22,3 +22,14 @@ const (
 	OpenShiftConsoleRouteName         = OpenShiftConsoleShortName
 	OAuthClientName                   = OpenShiftConsoleName
 )
+
+// configs always have the name "cluster"
+const (
+	ConsoleConfigName         = "cluster"
+	ConsoleOperatorConfigName = ConsoleConfigName
+)
+
+// however, the ClusterOperator resource is named "console"
+const (
+	ClusterOperatorName = "console"
+)

--- a/pkg/console/operator/operator.go
+++ b/pkg/console/operator/operator.go
@@ -216,7 +216,7 @@ func (c *consoleOperator) deleteAllResources(cr *operatorsv1.Console) error {
 func (c *consoleOperator) defaultConsoleConfig() *configv1.Console {
 	return &configv1.Console{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: api.ResourceName,
+			Name: api.ConsoleConfigName,
 		},
 	}
 }
@@ -225,7 +225,7 @@ func (c *consoleOperator) defaultConsoleConfig() *configv1.Console {
 func (c *consoleOperator) defaultConsoleOperatorConfig() *operatorsv1.Console {
 	return &operatorsv1.Console{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: api.ResourceName,
+			Name: api.ConsoleOperatorConfigName,
 		},
 		Spec: operatorsv1.ConsoleSpec{
 			OperatorSpec: operatorsv1.OperatorSpec{


### PR DESCRIPTION
In order for CVO to be aware of the `console` `ClusterOperator`, we need to have a manifest.

Uncertain about name `console` vs `openshift-console` atm.  Will find out.

@jhadvig @zherman0 