### PR TITLE
Rename Deployment openshift-console to console

### DIFF
--- a/manifests/00-oauth.yaml
+++ b/manifests/00-oauth.yaml
@@ -1,6 +1,6 @@
 apiVersion: oauth.openshift.io/v1
 kind: OAuthClient
 metadata:
-  name: openshift-console
+  name: console
 grantMethod: auto
 respondWithChallenges: false

--- a/manifests/02-rbac-role.yaml
+++ b/manifests/02-rbac-role.yaml
@@ -121,7 +121,7 @@ rules:
   - update
   - watch
   resourceNames:
-  - openshift-console
+  - console
 - apiGroups:
   - config.openshift.io
   resources:

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -11,14 +11,13 @@ const (
 
 // consts to maintain existing names of various sub-resources
 const (
-	OpenShiftConsoleName              = "openshift-console"
-	OpenShiftConsoleShortName         = "console"
+	OpenShiftConsoleName              = "console"
 	OpenShiftConsoleNamespace         = TargetNamespace
 	OpenShiftConsoleOperatorNamespace = "openshift-console-operator"
 	OpenShiftConsoleOperator          = "console-operator"
 	OpenShiftConsoleConfigMapName     = "console-config"
 	OpenShiftConsoleDeploymentName    = OpenShiftConsoleName
-	OpenShiftConsoleServiceName       = OpenShiftConsoleShortName
-	OpenShiftConsoleRouteName         = OpenShiftConsoleShortName
+	OpenShiftConsoleServiceName       = OpenShiftConsoleName
+	OpenShiftConsoleRouteName         = OpenShiftConsoleName
 	OAuthClientName                   = OpenShiftConsoleName
 )

--- a/pkg/console/operator/operator.go
+++ b/pkg/console/operator/operator.go
@@ -113,8 +113,8 @@ func NewConsoleOperator(
 		operator.WithInformer(deployments, operator.FilterByNames(api.OpenShiftConsoleName)),
 		operator.WithInformer(configMapInformer, operator.FilterByNames(configmap.ConsoleConfigMapName, configmap.ServiceCAConfigMapName)),
 		operator.WithInformer(secretsInformer, operator.FilterByNames(deployment.ConsoleOauthConfigName)),
-		operator.WithInformer(routes, operator.FilterByNames(api.OpenShiftConsoleShortName)),
-		operator.WithInformer(serviceInformer, operator.FilterByNames(api.OpenShiftConsoleShortName)),
+		operator.WithInformer(routes, operator.FilterByNames(api.OpenShiftConsoleName)),
+		operator.WithInformer(serviceInformer, operator.FilterByNames(api.OpenShiftConsoleName)),
 		operator.WithInformer(oauthClients, operator.FilterByNames(api.OAuthClientName)),
 	)
 }

--- a/pkg/console/subresource/configmap/configmap_test.go
+++ b/pkg/console/subresource/configmap/configmap_test.go
@@ -18,7 +18,7 @@ const (
 	exampleYaml = `kind: ConsoleConfig
 apiVersion: console.openshift.io/v1beta1
 auth:
-  clientID: openshift-console
+  clientID: console
   clientSecretFile: /var/oauth-config/clientSecret
   logoutRedirect: ""
   oauthEndpointCAFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt

--- a/pkg/console/subresource/deployment/deployment.go
+++ b/pkg/console/subresource/deployment/deployment.go
@@ -88,7 +88,7 @@ func DefaultDeployment(operatorConfig *operatorv1.Console, cm *corev1.ConfigMap,
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:   api.OpenShiftConsoleShortName,
+					Name:   api.OpenShiftConsoleName,
 					Labels: labels,
 					Annotations: map[string]string{
 						configMapResourceVersionAnnotation:          cm.GetResourceVersion(),
@@ -197,7 +197,7 @@ func consoleContainer(cr *operatorv1.Console) corev1.Container {
 	return corev1.Container{
 		Image:           util.GetImageEnv(),
 		ImagePullPolicy: corev1.PullPolicy("IfNotPresent"),
-		Name:            api.OpenShiftConsoleShortName,
+		Name:            api.OpenShiftConsoleName,
 		Command: []string{
 			"/opt/bridge/bin/bridge",
 			"--public-dir=/opt/bridge/static",

--- a/pkg/console/subresource/deployment/deployment_test.go
+++ b/pkg/console/subresource/deployment/deployment_test.go
@@ -105,7 +105,7 @@ func TestDefaultDeployment(t *testing.T) {
 						MatchLabels: labels,
 					},
 					Template: corev1.PodTemplateSpec{ObjectMeta: metav1.ObjectMeta{
-						Name:   api.OpenShiftConsoleShortName,
+						Name:   api.OpenShiftConsoleName,
 						Labels: labels,
 						Annotations: map[string]string{
 							configMapResourceVersionAnnotation:          "",

--- a/pkg/console/subresource/route/route.go
+++ b/pkg/console/subresource/route/route.go
@@ -11,7 +11,6 @@ import (
 	operatorv1 "github.com/openshift/api/operator/v1"
 	routev1 "github.com/openshift/api/route/v1"
 	routeclient "github.com/openshift/client-go/route/clientset/versioned/typed/route/v1"
-	"github.com/openshift/console-operator/pkg/api"
 	"github.com/openshift/library-go/pkg/operator/resource/resourcemerge"
 
 	// operator
@@ -94,7 +93,6 @@ func DefaultRoute(cr *operatorv1.Console) *routev1.Route {
 
 func Stub() *routev1.Route {
 	meta := util.SharedMeta()
-	meta.Name = api.OpenShiftConsoleShortName
 	return &routev1.Route{
 		ObjectMeta: meta,
 	}
@@ -133,7 +131,6 @@ func Validate(route *routev1.Route) (*routev1.Route, bool) {
 
 func routeMeta() metav1.ObjectMeta {
 	meta := util.SharedMeta()
-	meta.Name = api.OpenShiftConsoleShortName
 	return meta
 }
 

--- a/pkg/console/subresource/route/route_test.go
+++ b/pkg/console/subresource/route/route_test.go
@@ -37,7 +37,7 @@ func TestDefaultRoute(t *testing.T) {
 			want: &routev1.Route{
 				TypeMeta: metav1.TypeMeta{},
 				ObjectMeta: metav1.ObjectMeta{
-					Name:        api.OpenShiftConsoleShortName,
+					Name:        api.OpenShiftConsoleName,
 					Namespace:   api.OpenShiftConsoleNamespace,
 					Labels:      map[string]string{"app": api.OpenShiftConsoleName},
 					Annotations: map[string]string{},
@@ -45,7 +45,7 @@ func TestDefaultRoute(t *testing.T) {
 				Spec: routev1.RouteSpec{
 					To: routev1.RouteTargetReference{
 						Kind:   "Service",
-						Name:   api.OpenShiftConsoleShortName,
+						Name:   api.OpenShiftConsoleName,
 						Weight: &weight,
 					},
 					Port: &routev1.RoutePort{
@@ -80,7 +80,7 @@ func TestStub(t *testing.T) {
 			want: &routev1.Route{
 				TypeMeta: metav1.TypeMeta{},
 				ObjectMeta: metav1.ObjectMeta{
-					Name:                       api.OpenShiftConsoleShortName,
+					Name:                       api.OpenShiftConsoleName,
 					GenerateName:               "",
 					Namespace:                  api.OpenShiftConsoleNamespace,
 					SelfLink:                   "",

--- a/pkg/console/subresource/service/service.go
+++ b/pkg/console/subresource/service/service.go
@@ -5,7 +5,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
-	"github.com/openshift/console-operator/pkg/api"
 	"github.com/openshift/console-operator/pkg/console/subresource/util"
 )
 
@@ -24,7 +23,6 @@ const (
 func DefaultService(cr *operatorv1.Console) *corev1.Service {
 	labels := util.LabelsForConsole()
 	meta := util.SharedMeta()
-	meta.Name = api.OpenShiftConsoleShortName
 	meta.Annotations = map[string]string{
 		ServingCertSecretAnnotation: ConsoleServingCertName,
 	}
@@ -49,7 +47,6 @@ func DefaultService(cr *operatorv1.Console) *corev1.Service {
 
 func Stub() *corev1.Service {
 	meta := util.SharedMeta()
-	meta.Name = api.OpenShiftConsoleShortName
 	meta.Annotations = map[string]string{
 		ServingCertSecretAnnotation: ConsoleServingCertName,
 	}

--- a/pkg/console/subresource/service/service_test.go
+++ b/pkg/console/subresource/service/service_test.go
@@ -29,7 +29,7 @@ func TestDefaultService(t *testing.T) {
 			want: &corev1.Service{
 				TypeMeta: v12.TypeMeta{},
 				ObjectMeta: v12.ObjectMeta{
-					Name:      api.OpenShiftConsoleShortName,
+					Name:      api.OpenShiftConsoleName,
 					Namespace: api.OpenShiftConsoleNamespace,
 					Labels:    map[string]string{"app": api.OpenShiftConsoleName},
 					Annotations: map[string]string{
@@ -71,7 +71,7 @@ func TestStub(t *testing.T) {
 			want: &corev1.Service{
 				TypeMeta: v12.TypeMeta{},
 				ObjectMeta: v12.ObjectMeta{
-					Name:      api.OpenShiftConsoleShortName,
+					Name:      api.OpenShiftConsoleName,
 					Namespace: api.OpenShiftConsoleNamespace,
 					Labels:    map[string]string{"app": api.OpenShiftConsoleName},
 					Annotations: map[string]string{


### PR DESCRIPTION
Per an email conversation w/@spadgett.

Changing the `Deployment` name to `console` is consistent with the other resources & eliminates the extra `ConsoleShortName` variable.

