### PR TITLE
Update ocp DEFAULT_DOC_URL

### DIFF
--- a/pkg/console/subresource/configmap/brand_ocp.go
+++ b/pkg/console/subresource/configmap/brand_ocp.go
@@ -4,5 +4,5 @@ package configmap
 
 const (
 	DEFAULT_BRAND   = "ocp"
-	DEFAULT_DOC_URL = "https://docs.openshift.com/container-platform/4.0/welcome/index.html"
+	DEFAULT_DOC_URL = "https://docs.openshift.com/container-platform/4.0/"
 )


### PR DESCRIPTION
Update ocp DEFAULT_DOC_URL to https://docs.openshift.com/container-platform/4.0/ 
Only affects the ocp container build.

The console container has a small bit of validation on the doc url that simply requires a trailling `/`. The full doc link we have for ocp is `https://docs.openshift.com/container-platform/4.0/welcome/index.htm`.  Adding a trailling `/` will 404, but cutting the `welcome/index.htm` will automatically trigger a redirect to the correct location.

@zherman0 