### PR TITLE
Fix config singleton names

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -2,7 +2,7 @@ package api
 
 const (
 	TargetNamespace    = "openshift-console"
-	ConfigResourceName = "console"
+	ConfigResourceName = "cluster"
 )
 
 // consts to maintain existing names of various sub-resources


### PR DESCRIPTION
Global config & operator config should be named `cluster`, not `console`.  

console.config.openshift.io - cluster
console.operator.openshift.io - cluster

(Note ClusterOperator is still named `console`).