### PR TITLE
Set console-operator replicas to 1

### DIFF
--- a/manifests/07-operator.yaml
+++ b/manifests/07-operator.yaml
@@ -4,7 +4,7 @@ metadata:
   name: console-operator
   namespace: openshift-console-operator
 spec:
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
       name: console-operator


### PR DESCRIPTION
The director for # of replicas for an operator seems to be:

- Other operators depend on you: `replicas: 2`
- Other operators do not depend on you: `replicas: 1`

If the operator goes down & does not block another operator from recovering, a higher number of replicas is not needed 

- `thing you block, if len() > 0 { replicas = 2 } else { replicas = 1 }`. 
- Also `if have web facing traffic replicas >= 2 else replicas 1`.

I almost updated leader election to:

```
apiVersion: operator.openshift.io/v1alpha1
kind: GenericOperatorConfig
leaderElection:
  namespace: openshift-console
  disabled: true
authentication:
  disabled: true
authorization:
  disabled: true
```
but there may be cases where 2 operators could still be deployed.  Perhaps during an upgrade? In this case, it seems safer to leave leader election enabled to avoid the posibility of ever getting into a state where multiple operators fight over the console operand.

