### PR TITLE
Validate URLs from the CR file and additional unit tests for ocp tag

### DIFF
--- a/examples/cr-console.operator.config.yaml
+++ b/examples/cr-console.operator.config.yaml
@@ -1,0 +1,16 @@
+apiVersion: operator.openshift.io/v1
+kind: Console
+metadata:
+  name: cluster
+spec:
+  managementState: Managed
+  authentication:
+    # the logout redirect must be a valid URI that starts with http(s)
+    # valid examples: http://localhost:8080/logout.html, https://www.redhat.com/log/out/
+    logoutRedirect: "https://www.redhat.com/i/should/logout"
+  customization:
+    brand: okd
+    # the documentation base must be a valid URI that starts with http(s) AND it must have a trailing slash
+    # the trailing slash is required because additional values will be appended
+    # valid examples: https://localhost:9999/docs/, http://192.168.1.5:3000/doc/location/
+    documentationBaseURL: "https://www.redhat.com/someplace/for/docs/"

--- a/hack/test-unit.sh
+++ b/hack/test-unit.sh
@@ -26,3 +26,20 @@ do
     os::log::info "Testing ${PACKAGE}"
     go test $PACKAGE
 done
+
+OCP_PACKAGES_TO_TEST=(
+    "github.com/openshift/console-operator/pkg/console/subresource/configmap"
+    "github.com/openshift/console-operator/pkg/console/subresource/deployment"
+    "github.com/openshift/console-operator/pkg/console/subresource/oauthclient"
+    "github.com/openshift/console-operator/pkg/console/subresource/route"
+    "github.com/openshift/console-operator/pkg/console/subresource/secret"
+    "github.com/openshift/console-operator/pkg/console/subresource/service"
+    "github.com/openshift/console-operator/pkg/console/subresource/util"
+    "github.com/openshift/console-operator/pkg/console/version"
+)
+
+for PACKAGE in "${OCP_PACKAGES_TO_TEST[@]}"
+do
+    os::log::info "Testing with tag ocp ${PACKAGE}"
+    go test -tags "ocp" $PACKAGE
+done

--- a/manifests/00-crd-operator-config.yaml
+++ b/manifests/00-crd-operator-config.yaml
@@ -13,6 +13,32 @@ spec:
   subresources:
     status: {}
   versions:
-  - name: v1
-    served: true
-    storage: true
+    - name: v1
+      served: true
+      storage: true
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          properties:
+            managementState:
+              pattern: ^(Managed|Unmanaged|Removed|Forced)$
+              type: string
+              description: managementState indicates whether and how the operator
+                should manage the component
+            authentication:
+              properties:
+                logoutRedirect:
+                  pattern: ^((https):\/\/?)[^\s()<>]+(?:\([\w\d]+\)|([^[:punct:]\s]|\/?))$
+                  type: string
+                  description: Logout Redirect must be a valid URL
+            customization:
+              properties:
+                documentationBaseURL:
+                  pattern: ^((https):\/\/?)[^\s()<>]+(?:\([\w\d]+\)|([^[:punct:]\s]|\/?))\/$
+                  type: string
+                  description: Document base URL must be a valid URL that ends in a trailing slash
+                brand:
+                  pattern: ^(ocp|origin|okd|dedicated|online|azure)$
+                  type: string
+                  description: Brand must be be one of six values - azure|dedicated|ocp|okd|online|origin

--- a/pkg/console/subresource/configmap/configmap_test.go
+++ b/pkg/console/subresource/configmap/configmap_test.go
@@ -27,8 +27,8 @@ clusterInfo:
   consoleBaseAddress: https://` + host + `
   consoleBasePath: ""
 customization:
-  branding: okd
-  documentationBaseURL: https://docs.okd.io/4.0/
+  branding: ` + DEFAULT_BRAND + `
+  documentationBaseURL: ` + DEFAULT_DOC_URL + `
 servingInfo:
   bindAddress: https://0.0.0.0:8443
   certFile: /var/serving-cert/tls.crt
@@ -171,8 +171,8 @@ func TestNewYamlConfig(t *testing.T) {
 			args: args{
 				host:           host,
 				logoutRedirect: "",
-				brand:          "okd",
-				docURL:         "https://docs.okd.io/4.0/",
+				brand:          DEFAULT_BRAND,
+				docURL:         DEFAULT_DOC_URL,
 			},
 			want: exampleYaml,
 		},


### PR DESCRIPTION
This PR adds: 
1) Validation in the CRD to test that well formed URLs are supplied
   a) https://www.redhat.com:8080/logout.html is valid
   b) www.redhat.com (no http) is invalid
2) The validation also checks for trailing slash on the DOC link
   a) https://doc.com/     is vaild
   b) https://doc.com/doc    is invalid
3) Validate that the brand is one of the 5 acceptable values: ocp|origin|okd|dedicated|online
4) Validate that managedState is one of the 4 possible values: Managed|Unmanaged|Removed|Forced
5) Unit test for builds with the "ocp" tag set
6) There is no E2E test for URL at the moment because I have not figured out how to load/test values that are being detected at the oc api level
7) I had code in the config map to test URLs but have removed it since it duplicated the validation being done at the oc api level.