### PR TITLE
diff.ObjectGoPrintDiff() in Unit Tests

### DIFF
--- a/pkg/console/subresource/configmap/configmap_test.go
+++ b/pkg/console/subresource/configmap/configmap_test.go
@@ -5,6 +5,8 @@ import (
 	"reflect"
 	"testing"
 
+	"k8s.io/apimachinery/pkg/util/diff"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -89,12 +91,12 @@ func TestDefaultConfigMap(t *testing.T) {
 					CreationTimestamp:          metav1.Time{},
 					DeletionTimestamp:          nil,
 					DeletionGracePeriodSeconds: nil,
-					Labels:          map[string]string{"app": api.OpenShiftConsoleName},
-					Annotations:     map[string]string{},
-					OwnerReferences: nil,
-					Initializers:    nil,
-					Finalizers:      nil,
-					ClusterName:     "",
+					Labels:                     map[string]string{"app": api.OpenShiftConsoleName},
+					Annotations:                map[string]string{},
+					OwnerReferences:            nil,
+					Initializers:               nil,
+					Finalizers:                 nil,
+					ClusterName:                "",
 				},
 				Data:       map[string]string{"console-config.yaml": exampleYaml},
 				BinaryData: nil,
@@ -130,12 +132,12 @@ func TestStub(t *testing.T) {
 					CreationTimestamp:          metav1.Time{},
 					DeletionTimestamp:          nil,
 					DeletionGracePeriodSeconds: nil,
-					Labels:          map[string]string{"app": api.OpenShiftConsoleName},
-					Annotations:     map[string]string{},
-					OwnerReferences: nil,
-					Initializers:    nil,
-					Finalizers:      nil,
-					ClusterName:     "",
+					Labels:                     map[string]string{"app": api.OpenShiftConsoleName},
+					Annotations:                map[string]string{},
+					OwnerReferences:            nil,
+					Initializers:               nil,
+					Finalizers:                 nil,
+					ClusterName:                "",
 				},
 				BinaryData: nil,
 				Data:       nil,
@@ -145,7 +147,7 @@ func TestStub(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := Stub(); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("\nStub() = %v\n -------- want %v", got, tt.want)
+				t.Errorf("diff %v", diff.ObjectGoPrintDiff(tt.want, got))
 			}
 		})
 	}


### PR DESCRIPTION
Example of output, `A` & `B` with the specific diff `BROKEN THING`:

<img width="373" alt="screen shot 2019-02-25 at 11 50 21 am" src="https://user-images.githubusercontent.com/280512/53353902-b700c480-38f3-11e9-9462-ab36d0d34898.png">

previously:

<img width="283" alt="screen shot 2019-02-25 at 11 55 24 am" src="https://user-images.githubusercontent.com/280512/53354190-47d7a000-38f4-11e9-9a2e-e43d98ba6755.png">


I'd probably prefer even more clarity, such as coloring the error `A: BROKEN THING`, but perhaps its a step in the right direction.

@zherman0 / @jhadvig thoughts?