### PR TITLE
Change unit test to use cleaner error output

### DIFF
--- a/pkg/console/subresource/configmap/configmap_test.go
+++ b/pkg/console/subresource/configmap/configmap_test.go
@@ -2,7 +2,7 @@ package configmap
 
 import (
 	"fmt"
-	"reflect"
+	"github.com/go-test/deep"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -103,8 +103,8 @@ func TestDefaultConfigMap(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := DefaultConfigMap(tt.args.operatorConfig, tt.args.consoleConfig, tt.args.rt); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("DefaultConfigMap() = %v\n ----------- want %v", got, tt.want)
+			if diff := deep.Equal(DefaultConfigMap(tt.args.operatorConfig, tt.args.consoleConfig, tt.args.rt), tt.want); diff != nil {
+				t.Error(diff)
 			}
 		})
 	}
@@ -144,8 +144,8 @@ func TestStub(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := Stub(); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("\nStub() = %v\n -------- want %v", got, tt.want)
+			if diff := deep.Equal(Stub(), tt.want); diff != nil {
+				t.Error(diff)
 			}
 		})
 	}
@@ -153,7 +153,6 @@ func TestStub(t *testing.T) {
 
 // This unit test relies on both NewYamlConfig and NewYamlConfigString
 // to ensure the serialized data is created from host name
-// TODO: remove - This unit test is probably not useful since it is just testing yaml methods slice and marshal with no logic
 func TestNewYamlConfig(t *testing.T) {
 	type args struct {
 		host           string
@@ -179,8 +178,8 @@ func TestNewYamlConfig(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := string(NewYamlConfig(tt.args.host, tt.args.logoutRedirect, tt.args.brand, tt.args.docURL)); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("NewYamlConfig() = \n%v\n ----> want\n%v", got, tt.want)
+			if diff := deep.Equal(string(NewYamlConfig(tt.args.host, tt.args.logoutRedirect, tt.args.brand, tt.args.docURL)), tt.want); diff != nil {
+				t.Error(diff)
 			}
 		})
 	}
@@ -205,8 +204,8 @@ func Test_consoleBaseAddr(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := consoleBaseAddr(tt.args.host); got != tt.want {
-				t.Errorf("consoleBaseAddr() = %v, want %v", got, tt.want)
+			if diff := deep.Equal(consoleBaseAddr(tt.args.host), tt.want); diff != nil {
+				t.Error(diff)
 			}
 		})
 	}

--- a/pkg/console/subresource/configmap/service_ca_test.go
+++ b/pkg/console/subresource/configmap/service_ca_test.go
@@ -1,7 +1,7 @@
 package configmap
 
 import (
-	"reflect"
+	"github.com/go-test/deep"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -49,8 +49,8 @@ func TestDefaultServiceCAConfigMap(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := DefaultServiceCAConfigMap(tt.args.cr); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("DefaultServiceCAConfigMap() = %v, want %v", got, tt.want)
+			if diff := deep.Equal(DefaultServiceCAConfigMap(tt.args.cr), tt.want); diff != nil {
+				t.Error(diff)
 			}
 		})
 	}
@@ -85,8 +85,8 @@ func TestServiceCAStub(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := ServiceCAStub(); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("ServiceCAStub() = %v, want %v", got, tt.want)
+			if diff := deep.Equal(ServiceCAStub(), tt.want); diff != nil {
+				t.Error(diff)
 			}
 		})
 	}

--- a/pkg/console/subresource/deployment/deployment_test.go
+++ b/pkg/console/subresource/deployment/deployment_test.go
@@ -1,7 +1,7 @@
 package deployment
 
 import (
-	"reflect"
+	"github.com/go-test/deep"
 	"testing"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -164,8 +164,8 @@ func TestDefaultDeployment(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := DefaultDeployment(tt.args.cr, tt.args.cm, tt.args.cm, tt.args.sec); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("\nDefaultDeployment() = %v\n, want %v", got, tt.want)
+			if diff := deep.Equal(DefaultDeployment(tt.args.cr, tt.args.cm, tt.args.cm, tt.args.sec), tt.want); diff != nil {
+				t.Error(diff)
 			}
 		})
 	}
@@ -210,8 +210,8 @@ func TestStub(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := Stub(); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("Stub() = %v, want %v", got, tt.want)
+			if diff := deep.Equal(Stub(), tt.want); diff != nil {
+				t.Error(diff)
 			}
 		})
 	}
@@ -285,8 +285,8 @@ func Test_consoleVolumes(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := consoleVolumes(tt.args.vc); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("\nconsoleVolumes() = %v, \nwant %v", got, tt.want)
+			if diff := deep.Equal(consoleVolumes(tt.args.vc), tt.want); diff != nil {
+				t.Error(diff)
 			}
 		})
 	}
@@ -331,8 +331,8 @@ func Test_consoleVolumeMounts(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := consoleVolumeMounts(tt.args.vc); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("consoleVolumeMounts() = %v, \nwant %v", got, tt.want)
+			if diff := deep.Equal(consoleVolumeMounts(tt.args.vc), tt.want); diff != nil {
+				t.Error(diff)
 			}
 		})
 	}

--- a/pkg/console/subresource/oauthclient/oauthclient_test.go
+++ b/pkg/console/subresource/oauthclient/oauthclient_test.go
@@ -1,9 +1,9 @@
 package oauthclient
 
 import (
+	"github.com/go-test/deep"
 	"github.com/openshift/console-operator/pkg/api"
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
-	"reflect"
 	"testing"
 
 	oauthv1 "github.com/openshift/api/oauth/v1"
@@ -52,8 +52,9 @@ func TestDeRegisterConsoleFromOAuthClient(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := DeRegisterConsoleFromOAuthClient(tt.args.client); got.Secret == tt.want.Secret || !reflect.DeepEqual(got.RedirectURIs, tt.want.RedirectURIs) {
-				t.Errorf("DeRegisterConsoleFromOAuthClient() = %v, want %v", got, tt.want)
+			got := DeRegisterConsoleFromOAuthClient(tt.args.client)
+			if diff := deep.Equal(got.RedirectURIs, tt.want.RedirectURIs); got.Secret == tt.want.Secret || diff != nil {
+				t.Error(diff)
 			}
 		})
 	}
@@ -76,8 +77,8 @@ func TestStub(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := Stub(); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("Stub() = %v, want %v", got, tt.want)
+			if diff := deep.Equal(Stub(), tt.want); diff != nil {
+				t.Error(diff)
 			}
 		})
 	}
@@ -133,8 +134,8 @@ func TestSetRedirectURI(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := SetRedirectURI(tt.args.client, tt.args.route); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("SetRedirectURI() = %v, want %v", got, tt.want)
+			if diff := deep.Equal(SetRedirectURI(tt.args.client, tt.args.route), tt.want); diff != nil {
+				t.Error(diff)
 			}
 		})
 	}

--- a/pkg/console/subresource/route/route_test.go
+++ b/pkg/console/subresource/route/route_test.go
@@ -1,7 +1,7 @@
 package route
 
 import (
-	"reflect"
+	"github.com/go-test/deep"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -63,8 +63,8 @@ func TestDefaultRoute(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := DefaultRoute(tt.args.cr); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("DefaultRoute() = \n%v\n want \n%v", got, tt.want)
+			if diff := deep.Equal(DefaultRoute(tt.args.cr), tt.want); diff != nil {
+				t.Error(diff)
 			}
 		})
 	}
@@ -104,8 +104,8 @@ func TestStub(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := Stub(); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("Stub() = %v, want %v", got, tt.want)
+			if diff := deep.Equal(Stub(), tt.want); diff != nil {
+				t.Error(diff)
 			}
 		})
 	}

--- a/pkg/console/subresource/secret/secret_test.go
+++ b/pkg/console/subresource/secret/secret_test.go
@@ -1,7 +1,7 @@
 package secret
 
 import (
-	"reflect"
+	"github.com/go-test/deep"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -49,8 +49,8 @@ func TestDefaultSecret(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := DefaultSecret(tt.args.cr, tt.args.randomBits); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("DefaultSecret() = %v, want %v", got, tt.want)
+			if diff := deep.Equal(DefaultSecret(tt.args.cr, tt.args.randomBits), tt.want); diff != nil {
+				t.Error(diff)
 			}
 		})
 	}
@@ -79,8 +79,8 @@ func TestStub(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := Stub(); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("Stub() = %v, want %v", got, tt.want)
+			if diff := deep.Equal(Stub(), tt.want); diff != nil {
+				t.Error(diff)
 			}
 		})
 	}
@@ -107,8 +107,8 @@ func TestGetSecretString(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := GetSecretString(tt.args.secret); got != tt.want {
-				t.Errorf("GetSecretString() = %v, want %v", got, tt.want)
+			if diff := deep.Equal(GetSecretString(tt.args.secret), tt.want); diff != nil {
+				t.Error(diff)
 			}
 		})
 	}
@@ -137,8 +137,8 @@ func TestSetSecretString(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := SetSecretString(tt.args.secret, tt.args.randomBits); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("SetSecretString() = %v, want %v", got, tt.want)
+			if diff := deep.Equal(SetSecretString(tt.args.secret, tt.args.randomBits), tt.want); diff != nil {
+				t.Error(diff)
 			}
 		})
 	}

--- a/pkg/console/subresource/service/service_test.go
+++ b/pkg/console/subresource/service/service_test.go
@@ -1,7 +1,7 @@
 package service
 
 import (
-	"reflect"
+	"github.com/go-test/deep"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -54,8 +54,8 @@ func TestDefaultService(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := DefaultService(tt.args.cr); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("DefaultService() = %v, want %v", got, tt.want)
+			if diff := deep.Equal(DefaultService(tt.args.cr), tt.want); diff != nil {
+				t.Error(diff)
 			}
 		})
 	}
@@ -84,8 +84,8 @@ func TestStub(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := Stub(); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("Stub() = %v, want %v", got, tt.want)
+			if diff := deep.Equal(Stub(), tt.want); diff != nil {
+				t.Error(diff)
 			}
 		})
 	}

--- a/pkg/console/subresource/util/util_test.go
+++ b/pkg/console/subresource/util/util_test.go
@@ -1,7 +1,7 @@
 package util
 
 import (
-	"reflect"
+	"github.com/go-test/deep"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -24,8 +24,8 @@ func TestSharedLabels(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := SharedLabels(); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("SharedLabels() = %v, want %v", got, tt.want)
+			if diff := deep.Equal(SharedLabels(), tt.want); diff != nil {
+				t.Error(diff)
 			}
 		})
 	}
@@ -43,8 +43,8 @@ func TestLabelsForConsole(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := LabelsForConsole(); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("LabelsForConsole() = %v, want %v", got, tt.want)
+			if diff := deep.Equal(LabelsForConsole(), tt.want); diff != nil {
+				t.Error(diff)
 			}
 		})
 	}
@@ -67,32 +67,12 @@ func TestSharedMeta(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := SharedMeta(); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("SharedMeta() = %v, want %v", got, tt.want)
+			if diff := deep.Equal(SharedMeta(), tt.want); diff != nil {
+				t.Error(diff)
 			}
 		})
 	}
 }
-
-/*
-func TestAddOwnerRef(t *testing.T) {
-	type args struct {
-		obj      metav1Object
-		ownerRef *metav1OwnerReference
-	}
-	tests := []struct {
-		name string
-		args args
-	}{
-		{},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			AddOwnerRef(tt.args.obj, tt.args.ownerRef)
-		})
-	}
-}
-*/
 
 func TestOwnerRefFrom(t *testing.T) {
 	var truthy = true
@@ -135,8 +115,8 @@ func TestOwnerRefFrom(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := OwnerRefFrom(tt.args.cr); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("OwnerRefFrom() = %v, want %v", got, tt.want)
+			if diff := deep.Equal(OwnerRefFrom(tt.args.cr), tt.want); diff != nil {
+				t.Error(diff)
 			}
 		})
 	}
@@ -175,8 +155,8 @@ func TestHTTPS(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := HTTPS(tt.args.host); got != tt.want {
-				t.Errorf("HTTPS() = %v, want %v", got, tt.want)
+			if diff := deep.Equal(HTTPS(tt.args.host), tt.want); diff != nil {
+				t.Error(diff)
 			}
 		})
 	}


### PR DESCRIPTION
Change unit test to use cleaner error output.  Currently any error from unit test failing shows a large blob of data that one must scour through to see what has failed.  This update uses the go-test/deep pkg to only show what has failed in a clean, simple output.
Before:
![unit-befoe](https://user-images.githubusercontent.com/18728857/53522002-be140800-3a96-11e9-898c-165667326d4b.png)
After:
![unit-after](https://user-images.githubusercontent.com/18728857/53522016-c5d3ac80-3a96-11e9-811d-3223b0a936be.png)

