### PR TITLE
Support Spec.UnsupportedConfigOverrides

### DIFF
--- a/pkg/console/operator/status.go
+++ b/pkg/console/operator/status.go
@@ -55,6 +55,7 @@ const (
 	reasonSyncLoopProgressing = "SyncLoopProgressing"
 	reasonNoPodsAvailable     = "NoPodsAvailable"
 	reasonSyncError           = "SyncError"
+	reasonAsExpected          = "AsExpected"
 )
 
 // Lets transition to using this, and get the repetition out of all of the above.
@@ -183,14 +184,14 @@ func (c *consoleOperator) ConditionResourceSyncFailure(operatorConfig *operators
 	v1helpers.SetOperatorCondition(&operatorConfig.Status.Conditions, operatorsv1.OperatorCondition{
 		Type:               operatorsv1.OperatorStatusTypeAvailable,
 		Status:             operatorsv1.ConditionUnknown,
-		Reason:             reasonUnmanaged,
+		Reason:             reasonSyncError,
 		Message:            message,
 		LastTransitionTime: metav1.Now(),
 	})
 	v1helpers.SetOperatorCondition(&operatorConfig.Status.Conditions, operatorsv1.OperatorCondition{
 		Type:               operatorsv1.OperatorStatusTypeProgressing,
 		Status:             operatorsv1.ConditionTrue,
-		Reason:             reasonUnmanaged,
+		Reason:             reasonSyncError,
 		Message:            message,
 		LastTransitionTime: metav1.Now(),
 	})

--- a/pkg/console/operator/sync_v400.go
+++ b/pkg/console/operator/sync_v400.go
@@ -235,11 +235,18 @@ func SyncSecret(co *consoleOperator, recorder events.Recorder, operatorConfig *o
 // therefore no additional error handling is needed here.
 func SyncConfigMap(co *consoleOperator, recorder events.Recorder, operatorConfig *operatorv1.Console, consoleConfig *configv1.Console, infrastructureConfig *configv1.Infrastructure, rt *routev1.Route) (*corev1.ConfigMap, bool, error) {
 	logrus.Printf("validating console configmap...")
-	cm, cmChanged, cmErr := resourceapply.ApplyConfigMap(co.configMapClient, recorder, configmapsub.DefaultConfigMap(operatorConfig, consoleConfig, infrastructureConfig, rt))
+
+	defaultConfigmap, _, err := configmapsub.DefaultConfigMap(operatorConfig, consoleConfig, infrastructureConfig, rt)
+	if err != nil {
+		return nil, false, err
+	}
+
+	cm, cmChanged, cmErr := resourceapply.ApplyConfigMap(co.configMapClient, recorder, defaultConfigmap)
 	if cmErr != nil {
 		logrus.Errorf("%q: %v \n", "configmap", cmErr)
 		return nil, false, cmErr
 	}
+
 	logrus.Println("configmap exists and is in the correct state")
 	return cm, cmChanged, cmErr
 }

--- a/pkg/console/starter/starter.go
+++ b/pkg/console/starter/starter.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"time"
 
+	"github.com/openshift/library-go/pkg/operator/unsupportedconfigoverridescontroller"
+
 	// kube
 
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -175,6 +177,8 @@ func RunOperator(ctx *controllercmd.ControllerContext) error {
 		ctx.EventRecorder,
 	)
 
+	configUpgradeableController := unsupportedconfigoverridescontroller.NewUnsupportedConfigOverridesController(operatorClient, ctx.EventRecorder)
+
 	kubeInformersNamespaced.Start(ctx.Done())
 	operatorConfigInformers.Start(ctx.Done())
 	configInformers.Start(ctx.Done())
@@ -183,7 +187,8 @@ func RunOperator(ctx *controllercmd.ControllerContext) error {
 
 	go consoleOperator.Run(ctx.Done())
 	go clusterOperatorStatus.Run(1, ctx.Done())
-	<-ctx.Done()
+	go configUpgradeableController.Run(1, ctx.Done())
 
+	<-ctx.Done()
 	return fmt.Errorf("stopped")
 }


### PR DESCRIPTION
`Spec.UnsupportedConfigOverrides` essentially should allow a user to replace our configmap.  This should only be needed as an escape hatch if something terrible has gone wrong.

When used, the `ClusterOperator` for `Console` will record the config overrides under `Status.Conditions.Upgradable`.  This is consistent with what is done by [kube-apiserver-operator](https://github.com/openshift/cluster-kube-apiserver-operator).

ClusterOperator:
`oc get clusteroperator/console -w -o yaml`

<img width="341" alt="screen shot 2019-03-01 at 3 19 18 pm" src="https://user-images.githubusercontent.com/280512/53664490-9cea1d80-3c36-11e9-87b9-d06c3cfb61f1.png">

