### PR TITLE
Validate properties in CRD

### DIFF
--- a/manifests/00-crd-operator-config.yaml
+++ b/manifests/00-crd-operator-config.yaml
@@ -24,21 +24,15 @@ spec:
             managementState:
               pattern: ^(Managed|Unmanaged|Removed|Forced)$
               type: string
-              description: managementState indicates whether and how the operator
+              description: ManagementState indicates whether and how the operator
                 should manage the component
-            authentication:
-              properties:
-                logoutRedirect:
-                  pattern: ^((https):\/\/?)[^\s()<>]+(?:\([\w\d]+\)|([^[:punct:]\s]|\/?))$
-                  type: string
-                  description: Logout Redirect must be a valid URL
             customization:
               properties:
                 documentationBaseURL:
-                  pattern: ^((https):\/\/?)[^\s()<>]+(?:\([\w\d]+\)|([^[:punct:]\s]|\/?))\/$
+                  pattern: ^$|^((https):\/\/?)[^\s()<>]+(?:\([\w\d]+\)|([^[:punct:]\s]|\/?))\/$
                   type: string
-                  description: Document base URL must be a valid URL that ends in a trailing slash
+                  description: Documentation base url can optionally be set but must end in a trailing slash
                 brand:
-                  pattern: ^(ocp|origin|okd|dedicated|online|azure)$
+                  pattern: ^$|^(ocp|origin|okd|dedicated|online|azure)$
                   type: string
-                  description: Brand must be be one of six values - azure|dedicated|ocp|okd|online|origin
+                  description: Brand may be optionally set to one of six values - azure|dedicated|ocp|okd|online|origin


### PR DESCRIPTION
This will need to be rebased when PR164 goes through.
This PR adds:

    1. Validation in the CRD to test that well formed URLs are supplied for DOC link
       a) https://www.redhat.com:8080/ is valid
       b) http://www.redhat.com  is invalid (no http)

    2. The validation also checks for trailing slash on the DOC link
       a) https://doc.com/     is vaild
       b) https://doc.com/doc    is invalid

    3. Validate that the brand is null or one of the 6 acceptable values: ocp|origin|okd|dedicated|online|azure

    4. Validate that managedState is one of the 4 possible values: Managed|Unmanaged|Removed|Forced