### PR TITLE
Bug 1685233: Switch to `imagePullPolicy: IfNotPresent`

### DIFF
--- a/manifests/07-operator.yaml
+++ b/manifests/07-operator.yaml
@@ -35,7 +35,7 @@ spec:
         - "--create-default-console=true"
         # 04-config.yaml provides this config for the operator
         - "--config=/var/run/configmaps/config/controller-config.yaml"
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         volumeMounts:
         - mountPath: /var/run/configmaps/config
           name: config


### PR DESCRIPTION
All operator created pods should be using digest based UIDs, so `imagePullPolicy: Always` is not appropriate.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1685233

/assign @jhadvig 