### PR TITLE
Bug 1686133: Fix operator availability to include route availability check

### DIFF
--- a/pkg/console/operator/sync_v400.go
+++ b/pkg/console/operator/sync_v400.go
@@ -114,7 +114,7 @@ func sync_v400(co *consoleOperator, originalOperatorConfig *operatorv1.Console, 
 	}
 	// the operand is available if all resources are present & if we have all the replicas
 	// available is currently defined as "met the users intent"
-	if actualDeployment.Status.ReadyReplicas == deploymentsub.ConsoleReplicas {
+	if deploymentsub.IsReady(actualDeployment) && routesub.IsAdmitted(rt) {
 		co.ConditionDeploymentAvailable(operatorConfig)
 	} else {
 		co.ConditionDeploymentNotAvailable(operatorConfig)

--- a/pkg/console/subresource/deployment/deployment.go
+++ b/pkg/console/subresource/deployment/deployment.go
@@ -1,6 +1,7 @@
 package deployment
 
 import (
+	"github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -250,4 +251,11 @@ func livenessProbe() *corev1.Probe {
 	probe := defaultProbe()
 	probe.InitialDelaySeconds = 150
 	return probe
+}
+
+// for the purpose of availability, ready is when we have at least
+// one ready replica
+func IsReady(deployment *appsv1.Deployment) bool {
+	logrus.Printf("Deployment is avalable: %v \n", deployment.Status.ReadyReplicas >= 1)
+	return deployment.Status.ReadyReplicas >= 1
 }


### PR DESCRIPTION
Bug 1686133

The console should be available when one pod is available and the route has been accepted. For the console, this means that the route ingress that matches `Route.Spec.Host` should have an `Admitted` condition of `true`. 

([link 1686133](https://bugzilla.redhat.com/show_bug.cgi?id=1686133))

@spadgett 
@deads2k 