### PR TITLE
Revise branding mechanism for Console Operator

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
 FROM registry.svc.ci.openshift.org/openshift/release:golang-1.10 AS builder
-# create a work dir and copy local files in
 WORKDIR /go/src/github.com/openshift/console-operator
 COPY . .
-RUN make build
+RUN ADDITIONAL_GOTAGS="ocp" make build WHAT="cmd/console"
 
 FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
 RUN useradd console-operator
@@ -18,9 +17,4 @@ LABEL io.k8s.display-name="OpenShift console-operator" \
       maintainer="Benjamin A. Petersen <bpetersen@redhat.com>"
 
 LABEL io.openshift.release.operator true
-
-# entrypoint specified in 03-operator.yaml as `console-operator`
-# CMD ["/usr/bin/console", "operator", "--kubeconfig", "path/to/config", "--config", "./install/config.yaml", "--v", "4"]
-# CMD ["/usr/bin/console", "operator", "--v", "4"]
-
 

--- a/manifests/03-rbac-role-ns-openshift-config-managed.yaml
+++ b/manifests/03-rbac-role-ns-openshift-config-managed.yaml
@@ -1,0 +1,14 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: console-operator
+  namespace: openshift-config-managed
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch

--- a/manifests/04-rbac-rolebinding.yaml
+++ b/manifests/04-rbac-rolebinding.yaml
@@ -37,3 +37,17 @@ subjects:
 - kind: ServiceAccount
   name: console-operator
   namespace: openshift-console-operator
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: console-operator
+  namespace: openshift-config-managed
+roleRef:
+  kind: Role
+  name: console-operator
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: console-operator
+    namespace: openshift-console-operator

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -16,4 +16,5 @@ const (
 	OpenShiftConsoleServiceName       = OpenShiftConsoleName
 	OpenShiftConsoleRouteName         = OpenShiftConsoleName
 	OAuthClientName                   = OpenShiftConsoleName
+	OpenshiftConfigManagedNamespace   = "openshift-config-managed"
 )

--- a/pkg/console/operator/operator.go
+++ b/pkg/console/operator/operator.go
@@ -77,6 +77,7 @@ func NewConsoleOperator(
 	configInformer configinformer.SharedInformerFactory,
 
 	coreV1 corev1.Interface,
+	managedCoreV1 corev1.Interface,
 	deployments appsinformersv1.DeploymentInformer,
 	routes routesinformersv1.RouteInformer,
 	oauthClients oauthinformersv1.OAuthClientInformer,
@@ -113,6 +114,7 @@ func NewConsoleOperator(
 
 	secretsInformer := coreV1.Secrets()
 	configMapInformer := coreV1.ConfigMaps()
+	managedConfigMapInformer := managedCoreV1.ConfigMaps()
 	serviceInformer := coreV1.Services()
 	configV1Informers := configInformer.Config().V1()
 
@@ -131,6 +133,7 @@ func NewConsoleOperator(
 		operator.WithInformer(oauthClients, targetNameFilter),
 		// special resources with unique names
 		operator.WithInformer(configMapInformer, operator.FilterByNames(configmap.ConsoleConfigMapName, configmap.ServiceCAConfigMapName)),
+		operator.WithInformer(managedConfigMapInformer, operator.FilterByNames(configmap.ConsoleConfigMapName)),
 		operator.WithInformer(secretsInformer, operator.FilterByNames(deployment.ConsoleOauthConfigName)),
 	)
 }


### PR DESCRIPTION
Update the default behavior of branding so that the one and only docker file now builds `ocp` instead of `okd`.
If the user instead wants to manually build openshift with `go build` or `make build`, that process will default to `okd`.