### PR TITLE
Select host from admitted ingress, else fall back to route.spec.host

### DIFF
--- a/pkg/console/starter/starter.go
+++ b/pkg/console/starter/starter.go
@@ -2,10 +2,14 @@ package starter
 
 import (
 	"fmt"
+
+	"github.com/openshift/api/oauth"
+
 	"os"
 	"time"
 
 	// kube
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/client-go/informers"
@@ -13,6 +17,7 @@ import (
 
 	// openshift
 	configv1 "github.com/openshift/api/config/v1"
+	operatorv1 "github.com/openshift/api/operator"
 	"github.com/openshift/console-operator/pkg/api"
 	operatorclient "github.com/openshift/console-operator/pkg/console/operatorclient"
 	"github.com/openshift/library-go/pkg/controller/controllercmd"
@@ -139,12 +144,12 @@ func RunOperator(ctx *controllercmd.ControllerContext) error {
 	clusterOperatorStatus := status.NewClusterOperatorStatusController(
 		"console",
 		[]configv1.ObjectReference{
-			{Group: "operator.openshift.io", Resource: "consoles", Name: api.ConfigResourceName},
-			{Group: "config.openshift.io", Resource: "consoles", Name: api.ConfigResourceName},
-			{Group: "config.openshift.io", Resource: "infrastructures", Name: api.ConfigResourceName},
-			{Group: "oauth.openshift.io", Resource: "oauthclients", Name: api.OAuthClientName},
-			{Resource: "namespaces", Name: api.OpenShiftConsoleOperatorNamespace},
-			{Resource: "namespaces", Name: api.OpenShiftConsoleNamespace},
+			{Group: operatorv1.GroupName, Resource: "consoles", Name: api.ConfigResourceName},
+			{Group: configv1.GroupName, Resource: "consoles", Name: api.ConfigResourceName},
+			{Group: configv1.GroupName, Resource: "infrastructures", Name: api.ConfigResourceName},
+			{Group: oauth.GroupName, Resource: "oauthclients", Name: api.OAuthClientName},
+			{Group: corev1.GroupName, Resource: "namespaces", Name: api.OpenShiftConsoleOperatorNamespace},
+			{Group: corev1.GroupName, Resource: "namespaces", Name: api.OpenShiftConsoleNamespace},
 		},
 		// clusteroperator client
 		configClient.ConfigV1(),

--- a/pkg/console/subresource/oauthclient/oauthclient.go
+++ b/pkg/console/subresource/oauthclient/oauthclient.go
@@ -6,7 +6,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	oauthv1 "github.com/openshift/api/oauth/v1"
-	routev1 "github.com/openshift/api/route/v1"
 	oauthclient "github.com/openshift/client-go/oauth/clientset/versioned/typed/oauth/v1"
 	"github.com/openshift/library-go/pkg/operator/resource/resourcemerge"
 
@@ -54,8 +53,8 @@ func ApplyOAuth(client oauthclient.OAuthClientsGetter, required *oauthv1.OAuthCl
 }
 
 // registers the console on the oauth client as a valid application
-func RegisterConsoleToOAuthClient(client *oauthv1.OAuthClient, route *routev1.Route, randomBits string) *oauthv1.OAuthClient {
-	SetRedirectURI(client, route)
+func RegisterConsoleToOAuthClient(client *oauthv1.OAuthClient, host string, randomBits string) *oauthv1.OAuthClient {
+	SetRedirectURI(client, host)
 	// client.Secret = randomBits
 	SetSecretString(client, randomBits)
 	return client
@@ -95,9 +94,8 @@ func SetSecretString(client *oauthv1.OAuthClient, randomBits string) *oauthv1.OA
 // we are the only application for this client
 // in the future we may accept multiple routes
 // for now, we can clobber the slice & reset the entire thing
-func SetRedirectURI(client *oauthv1.OAuthClient, route *routev1.Route) *oauthv1.OAuthClient {
-	uri := route.Spec.Host
+func SetRedirectURI(client *oauthv1.OAuthClient, host string) *oauthv1.OAuthClient {
 	client.RedirectURIs = []string{}
-	client.RedirectURIs = append(client.RedirectURIs, util.HTTPS(uri)+"/auth/callback")
+	client.RedirectURIs = append(client.RedirectURIs, util.HTTPS(host)+"/auth/callback")
 	return client
 }

--- a/pkg/console/subresource/oauthclient/oauthclient_test.go
+++ b/pkg/console/subresource/oauthclient/oauthclient_test.go
@@ -1,13 +1,13 @@
 package oauthclient
 
 import (
-	"github.com/go-test/deep"
-	"github.com/openshift/console-operator/pkg/api"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	"testing"
 
+	"github.com/go-test/deep"
+	"github.com/openshift/console-operator/pkg/api"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	oauthv1 "github.com/openshift/api/oauth/v1"
-	routev1 "github.com/openshift/api/route/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -87,7 +87,7 @@ func TestStub(t *testing.T) {
 func TestSetRedirectURI(t *testing.T) {
 	type args struct {
 		client *oauthv1.OAuthClient
-		route  *routev1.Route
+		host   string
 	}
 	tests := []struct {
 		name string
@@ -109,14 +109,7 @@ func TestSetRedirectURI(t *testing.T) {
 					AccessTokenMaxAgeSeconds:            nil,
 					AccessTokenInactivityTimeoutSeconds: nil,
 				},
-				route: &routev1.Route{
-					TypeMeta:   metav1.TypeMeta{},
-					ObjectMeta: metav1.ObjectMeta{},
-					Spec: routev1.RouteSpec{
-						Host: "example.com",
-					},
-					Status: routev1.RouteStatus{},
-				},
+				host: "example.com",
 			},
 			want: &oauthv1.OAuthClient{
 				TypeMeta:                            metav1.TypeMeta{},
@@ -134,7 +127,7 @@ func TestSetRedirectURI(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if diff := deep.Equal(SetRedirectURI(tt.args.client, tt.args.route), tt.want); diff != nil {
+			if diff := deep.Equal(SetRedirectURI(tt.args.client, tt.args.host), tt.want); diff != nil {
 				t.Error(diff)
 			}
 		})


### PR DESCRIPTION
Selects `host` from the `admitted` `ingress` on the route, if it exists. Else, fallback to `spec.host` as we have been doing in the past.

[CONSOLE-1336](https://jira.coreos.com/browse/CONSOLE-1336)

/assign @spadgett @jhadvig @zherman0 