### PR TITLE
Add infrastructures config to operator related objects

### DIFF
--- a/pkg/console/starter/starter.go
+++ b/pkg/console/starter/starter.go
@@ -165,6 +165,7 @@ func RunOperator(ctx *controllercmd.ControllerContext) error {
 		[]configv1.ObjectReference{
 			{Group: "operator.openshift.io", Resource: "consoles", Name: api.ConfigResourceName},
 			{Group: "config.openshift.io", Resource: "consoles", Name: api.ConfigResourceName},
+			{Group: "config.openshift.io", Resource: "infrastructures", Name: api.ConfigResourceName},
 			{Group: "oauth.openshift.io", Resource: "oauthclients", Name: api.OAuthClientName},
 			{Resource: "namespaces", Name: api.OpenShiftConsoleOperatorNamespace},
 			{Resource: "namespaces", Name: api.OpenShiftConsoleNamespace},


### PR DESCRIPTION
I thought certain this was part of the PR that fixed the missing master url on our configmap (#173).

/assign @jhadvig 
