### PR TITLE
[WIP] Don't sync status twice on sync loop failures

### DIFF
--- a/pkg/console/operator/operator.go
+++ b/pkg/console/operator/operator.go
@@ -178,7 +178,6 @@ func (c *consoleOperator) Sync(obj metav1.Object) error {
 
 	// all configs needed to do a sync
 	if err := c.handleSync(operatorConfig, consoleConfig, infrastructureConfig); err != nil {
-		c.SyncStatus(c.ConditionFailing(operatorConfig, "SyncLoopError", "Operator sync loop failed to complete."))
 		return err
 	}
 	c.SyncStatus(c.ConditionNotFailing(operatorConfig))


### PR DESCRIPTION
This looks like this is related to https://bugzilla.redhat.com/show_bug.cgi?id=1694184

We try to update status *twice* on a sync loop failure. The second request fails. Somehow `Available` is getting defaulted to `True` even thought we're not setting it explicitly.

```
time="2019-04-17T18:58:36Z" level=info msg=Operator.Status.Conditions
time="2019-04-17T18:58:36Z" level=info msg="Status.Condition.UnsupportedConfigOverridesUpgradeable: True"
time="2019-04-17T18:58:36Z" level=info msg="Status.Condition.Available: Unknown | (SyncError) \"oauth\": route ingress not yet ready for console\n"
time="2019-04-17T18:58:36Z" level=info msg="Status.Condition.Progressing: True | (SyncError) \"oauth\": route ingress not yet ready for console\n"
time="2019-04-17T18:58:36Z" level=info msg="Status.Condition.Failing: True | (SyncError) \"oauth\": route ingress not yet ready for console\n"
I0417 18:58:36.093332       1 option.go:62] Console: handling update /cluster: /apis/operator.openshift.io/v1/consoles/cluster
time="2019-04-17T18:58:36Z" level=info msg=Operator.Status.Conditions
time="2019-04-17T18:58:36Z" level=info msg="Status.Condition.UnsupportedConfigOverridesUpgradeable: True"
time="2019-04-17T18:58:36Z" level=info msg="Status.Condition.Failing: True | (SyncLoopError) Operator sync loop failed to complete."
I0417 18:58:36.093775       1 status_controller.go:159] clusteroperator/console diff {"status":{"conditions":[{"lastTransitionTime":"2019-04-17T18:58:36Z","message":"Failing: \"oauth\": route ingress not yet ready for console\nFailing: ","reason":"AsExpected","status":"False","type":"Failing"},{"lastTransitionTime":"2019-04-17T18:58:36Z","message":"Progressing: \"oauth\": route ingress not yet ready for console\nProgressing: ","reason":"ProgressingSyncError","status":"True","type":"Progressing"},{"lastTransitionTime":"2019-04-17T18:58:36Z","message":"Available: \"oauth\": route ingress not yet ready for console\nAvailable: ","reason":"AsExpected","status":"True","type":"Available"},{"lastTransitionTime":"2019-04-17T18:58:34Z","reason":"AsExpected","status":"True","type":"Upgradeable"}]}}
time="2019-04-17T18:58:36Z" level=error msg="status update error: Operation cannot be fulfilled on consoles.operator.openshift.io \"cluster\": the object has been modified; please apply your changes to the latest version and try again \n"
time="2019-04-17T18:58:36Z" level=info msg="finished syncing operator \"cluster\" (35.247µs) \n\n"
E0417 18:58:36.098020       1 controller.go:130] {🐼 🐼} failed with: route ingress not yet ready for console
I0417 18:58:36.101073       1 event.go:221] Event(v1.ObjectReference{Kind:"Deployment", Namespace:"openshift-console-operator", Name:"console-operator", UID:"bf4421e7-6142-11e9-ad06-1204721f74ca", APIVersion:"apps/v1", ResourceVersion:"", FieldPath:""}): type: 'Normal' reason: 'OperatorStatusChanged' Status for operator console changed: Failing changed from Unknown to False ("Failing: \"oauth\": route ingress not yet ready for console\nFailing: "),Progressing changed from Unknown to True ("Progressing: \"oauth\": route ingress not yet ready for console\nProgressing: "),Available changed from Unknown to True ("Available: \"oauth\": route ingress not yet ready for console\nAvailable: ")
```

@benjaminapetersen 