### PR TITLE
Reduce default log level

### DIFF
--- a/manifests/07-operator.yaml
+++ b/manifests/07-operator.yaml
@@ -32,9 +32,8 @@ spec:
         - console
         - operator
         args:
-        - "-v=4"
+        - "-v=2"
         - "--create-default-console=true"
-        # 04-config.yaml provides this config for the operator
         - "--config=/var/run/configmaps/config/controller-config.yaml"
         imagePullPolicy: IfNotPresent
         volumeMounts:


### PR DESCRIPTION
Default logs should not be `debug` (developer centric), should be `info`.  I hesitated to want to reduce this earlier on, but for development we should all be deploying our own `deployment` of a custom `operator` image based on feature branches anyway, so it doesn't make sense to leave our log levels so high.

This doesn't affect our explicit `logrus` based logging.  We will have to handle that when we swap to `klog`, and ensure the update uses `debug`,`info`, etc.