### PR TITLE
Use CVO to create operator config

### DIFF
--- a/manifests/01-operator-config.yaml
+++ b/manifests/01-operator-config.yaml
@@ -1,0 +1,8 @@
+apiVersion: operator.openshift.io/v1
+kind: Console
+metadata:
+  name: cluster
+  annotations:
+    release.openshift.io/create-only: "true"
+spec:
+  managementState: Managed

--- a/manifests/07-operator.yaml
+++ b/manifests/07-operator.yaml
@@ -33,7 +33,6 @@ spec:
         - operator
         args:
         - "-v=2"
-        - "--create-default-console=true"
         - "--config=/var/run/configmaps/config/controller-config.yaml"
         imagePullPolicy: IfNotPresent
         volumeMounts:

--- a/pkg/cmd/operator/cmd.go
+++ b/pkg/cmd/operator/cmd.go
@@ -1,7 +1,6 @@
 package operator
 
 import (
-	"github.com/openshift/console-operator/pkg/console/operator"
 	// 3rd party
 	"github.com/spf13/cobra"
 	// kube / openshift
@@ -26,15 +25,5 @@ func NewOperator() *cobra.Command {
 	// https://github.com/spf13/cobra#create-rootcmd
 	cmd.Long = `An Operator for a web console for OpenShift.
 				`
-	cmd.Flags().BoolVarP(
-		&operator.CreateDefaultConsoleFlag,
-		"create-default-console",
-		"d",
-		false,
-		`Instructs the operator to create a console
-        custom resource on startup if one does not exist. 
-        `,
-	)
-
 	return cmd
 }

--- a/pkg/console/operator/operator.go
+++ b/pkg/console/operator/operator.go
@@ -52,8 +52,6 @@ const (
 	controllerName = "Console"
 )
 
-var CreateDefaultConsoleFlag bool
-
 type consoleOperator struct {
 	operatorConfigClient operatorclientv1.ConsoleInterface
 	consoleConfigClient  configclientv1.ConsoleInterface
@@ -140,15 +138,7 @@ func NewConsoleOperator(
 
 // key is actually the pivot point for the operator, which is our Console custom resource
 func (c *consoleOperator) Key() (metav1.Object, error) {
-	operatorConfig, err := c.operatorConfigClient.Get(api.ConfigResourceName, metav1.GetOptions{})
-	if errors.IsNotFound(err) && CreateDefaultConsoleFlag {
-		if _, err := c.operatorConfigClient.Create(c.defaultConsoleOperatorConfig()); err != nil {
-			logrus.Errorf("no console operator config found. Creating. %v \n", err)
-			return nil, err
-		}
-	}
-
-	return operatorConfig, err
+	return c.operatorConfigClient.Get(api.ConfigResourceName, metav1.GetOptions{})
 }
 
 func (c *consoleOperator) Sync(obj metav1.Object) error {
@@ -161,12 +151,9 @@ func (c *consoleOperator) Sync(obj metav1.Object) error {
 
 	// ensure we have top level console config
 	consoleConfig, err := c.consoleConfigClient.Get(api.ConfigResourceName, metav1.GetOptions{})
-	if errors.IsNotFound(err) && CreateDefaultConsoleFlag {
-		logrus.Infof("no console config found. creating default config.")
-		if _, err := c.consoleConfigClient.Create(c.defaultConsoleConfig()); err != nil {
-			logrus.Errorf("error creating console config: %v \n", err)
-			return err
-		}
+	if err != nil {
+		logrus.Errorf("console config error: %v \n", err)
+		return err
 	}
 
 	// we need infrastructure config for apiServerURL
@@ -254,28 +241,4 @@ func (c *consoleOperator) deleteAllResources(cr *operatorsv1.Console) error {
 	errs = append(errs, c.deploymentClient.Deployments(api.TargetNamespace).Delete(deployment.Stub().Name, &metav1.DeleteOptions{}))
 
 	return utilerrors.FilterOut(utilerrors.NewAggregate(errs), errors.IsNotFound)
-}
-
-// see https://github.com/openshift/api/blob/master/config/v1/types_console.go
-func (c *consoleOperator) defaultConsoleConfig() *configv1.Console {
-	return &configv1.Console{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: api.ConfigResourceName,
-		},
-	}
-}
-
-// see https://github.com/openshift/api/blob/master/operator/v1/types_console.go
-func (c *consoleOperator) defaultConsoleOperatorConfig() *operatorsv1.Console {
-	return &operatorsv1.Console{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: api.ConfigResourceName,
-		},
-		Spec: operatorsv1.ConsoleSpec{
-			OperatorSpec: operatorsv1.OperatorSpec{
-				ManagementState: operatorsv1.Managed,
-				LogLevel:        operatorsv1.Normal,
-			},
-		},
-	}
 }


### PR DESCRIPTION
There is an email from @damemi titled `[aos-devel] Notice: Operator configs should be managed by the CVO` instructing we should make this change.

- Includes the `create-only` annotation
- `CRD` is lexicographically ordered `00-`, `CR` is `01-`.  This is because the CR should be created after the CRD.  The CR being at the same level as the `oauthclient` should be irrelevant.
- Removes our `defaultConsoleOperatorConfig()`, which was used at the start of the `sync` loop if the `GET` on our `config` was a `404`.  The CVO will now be our single source of truth providing the config, we will simply err until it gets recreated.