### PR TITLE
Add node-selector annotation to namespace

### DIFF
--- a/manifests/02-namespace.yaml
+++ b/manifests/02-namespace.yaml
@@ -2,8 +2,12 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: openshift-console
+  annotations:
+    openshift.io/node-selector: ""
 ---
 apiVersion: v1
 kind: Namespace
 metadata:
   name: openshift-console-operator
+  annotations:
+    openshift.io/node-selector: ""


### PR DESCRIPTION
**Why this change?**
When https://github.com/openshift/cluster-kube-apiserver-operator/pull/394 merges, all the pods running openshift cluster will have a [defaultNodeSelector](https://docs.openshift.com/container-platform/3.11/admin_guide/managing_projects.html#setting-the-cluster-wide-default-node-selector) if it has been set by cluster-admin including pods running in `openshift-*` namespace. The main advantage of having that feature is in a multi-tenant environment, any new project created can be steered towards compute nodes(non-master nodes).

**What should I do?**
If you think, the pods in your namespace shouldn't have defaultNodeSelector set, please review this PR. If not feel free to close this. The annotation added as part of this PR lets all the pods created within your project to not have the defaultNodeSelector set.


/cc @deads2k @sjenning 
