### PR TITLE
Add public console config to publish console URL

### DIFF
--- a/manifests/03-rbac-role-ns-openshift-config-managed.yaml
+++ b/manifests/03-rbac-role-ns-openshift-config-managed.yaml
@@ -12,3 +12,26 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  resourceNames:
+  - console-public
+  verbs:
+  - update
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: console-public
+  namespace: openshift-config-managed
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  resourceNames:
+  - console-public
+  verbs:
+  - get

--- a/manifests/04-rbac-rolebinding.yaml
+++ b/manifests/04-rbac-rolebinding.yaml
@@ -51,3 +51,17 @@ subjects:
   - kind: ServiceAccount
     name: console-operator
     namespace: openshift-console-operator
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: console-public
+  namespace: openshift-config-managed
+roleRef:
+  kind: Role
+  name: console-public
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: Group
+    name: system:authenticated
+    apiGroup: rbac.authorization.k8s.io

--- a/manifests/08-config-public.yaml
+++ b/manifests/08-config-public.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: console-public
+  namespace: openshift-config-managed
+  annotations:
+    "release.openshift.io/create-only": "true"

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -7,14 +7,16 @@ const (
 
 // consts to maintain existing names of various sub-resources
 const (
-	OpenShiftConsoleName              = "console"
-	OpenShiftConsoleNamespace         = TargetNamespace
-	OpenShiftConsoleOperatorNamespace = "openshift-console-operator"
-	OpenShiftConsoleOperator          = "console-operator"
-	OpenShiftConsoleConfigMapName     = "console-config"
-	OpenShiftConsoleDeploymentName    = OpenShiftConsoleName
-	OpenShiftConsoleServiceName       = OpenShiftConsoleName
-	OpenShiftConsoleRouteName         = OpenShiftConsoleName
-	OAuthClientName                   = OpenShiftConsoleName
-	OpenshiftConfigManagedNamespace   = "openshift-config-managed"
+	OpenShiftConsoleName                = "console"
+	OpenShiftConsoleNamespace           = TargetNamespace
+	OpenShiftConsoleOperatorNamespace   = "openshift-console-operator"
+	OpenShiftConsoleOperator            = "console-operator"
+	OpenShiftConsoleConfigMapName       = "console-config"
+	OpenShiftConsolePublicConfigMapName = "console-public"
+	ServiceCAConfigMapName              = "service-ca"
+	OpenShiftConsoleDeploymentName      = OpenShiftConsoleName
+	OpenShiftConsoleServiceName         = OpenShiftConsoleName
+	OpenShiftConsoleRouteName           = OpenShiftConsoleName
+	OAuthClientName                     = OpenShiftConsoleName
+	OpenShiftConfigManagedNamespace     = "openshift-config-managed"
 )

--- a/pkg/console/starter/starter.go
+++ b/pkg/console/starter/starter.go
@@ -86,7 +86,7 @@ func RunOperator(ctx *controllercmd.ControllerContext) error {
 	kubeInformersManagedNamespaced := informers.NewSharedInformerFactoryWithOptions(
 		kubeClient,
 		resync,
-		informers.WithNamespace(api.OpenshiftConfigManagedNamespace),
+		informers.WithNamespace(api.OpenShiftConfigManagedNamespace),
 	)
 	// configs are all named "cluster", but our clusteroperator is named "console"
 	configInformers := configinformers.NewSharedInformerFactoryWithOptions(
@@ -156,6 +156,7 @@ func RunOperator(ctx *controllercmd.ControllerContext) error {
 			{Group: oauth.GroupName, Resource: "oauthclients", Name: api.OAuthClientName},
 			{Group: corev1.GroupName, Resource: "namespaces", Name: api.OpenShiftConsoleOperatorNamespace},
 			{Group: corev1.GroupName, Resource: "namespaces", Name: api.OpenShiftConsoleNamespace},
+			{Group: corev1.GroupName, Resource: "configmaps", Name: api.OpenShiftConsolePublicConfigMapName, Namespace: api.OpenShiftConfigManagedNamespace},
 		},
 		// clusteroperator client
 		configClient.ConfigV1(),

--- a/pkg/console/subresource/configmap/configmap.go
+++ b/pkg/console/subresource/configmap/configmap.go
@@ -9,6 +9,7 @@ import (
 	yaml "gopkg.in/yaml.v2"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	configv1 "github.com/openshift/api/config/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
@@ -19,7 +20,6 @@ import (
 )
 
 const (
-	ConsoleConfigMapName    = "console-config"
 	consoleConfigYamlFile   = "console-config.yaml"
 	clientSecretFilePath    = "/var/oauth-config/clientSecret"
 	oauthEndpointCAFilePath = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
@@ -104,9 +104,31 @@ func DefaultConfigMap(operatorConfig *operatorv1.Console, consoleConfig *configv
 	return configMap, didMerge, nil
 }
 
+func DefaultPublicConfig(consoleURL string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      api.OpenShiftConsolePublicConfigMapName,
+			Namespace: api.OpenShiftConfigManagedNamespace,
+		},
+		Data: map[string]string{
+			"consoleURL": consoleURL,
+		},
+	}
+}
+
+func EmptyPublicConfig() *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      api.OpenShiftConsolePublicConfigMapName,
+			Namespace: api.OpenShiftConfigManagedNamespace,
+		},
+		Data: map[string]string{},
+	}
+}
+
 func Stub() *corev1.ConfigMap {
 	meta := util.SharedMeta()
-	meta.Name = ConsoleConfigMapName
+	meta.Name = api.OpenShiftConsoleConfigMapName
 	configMap := &corev1.ConfigMap{
 		ObjectMeta: meta,
 	}

--- a/pkg/console/subresource/configmap/configmap_test.go
+++ b/pkg/console/subresource/configmap/configmap_test.go
@@ -18,10 +18,11 @@ import (
 )
 
 const (
-	host          = "localhost"
-	mockAPIServer = "https://api.some.cluster.openshift.com:6443"
-	configKey     = "console-config.yaml"
-	exampleYaml   = `kind: ConsoleConfig
+	host           = "localhost"
+	mockAPIServer  = "https://api.some.cluster.openshift.com:6443"
+	mockConsoleURL = "https://console-openshift-console.apps.some.cluster.openshift.com"
+	configKey      = "console-config.yaml"
+	exampleYaml    = `kind: ConsoleConfig
 apiVersion: console.openshift.io/v1
 auth:
   clientID: console
@@ -112,7 +113,7 @@ func TestDefaultConfigMap(t *testing.T) {
 			want: &corev1.ConfigMap{
 				TypeMeta: metav1.TypeMeta{},
 				ObjectMeta: metav1.ObjectMeta{
-					Name:        ConsoleConfigMapName,
+					Name:        api.OpenShiftConsoleConfigMapName,
 					Namespace:   api.OpenShiftConsoleNamespace,
 					Labels:      map[string]string{"app": api.OpenShiftConsoleName},
 					Annotations: map[string]string{},
@@ -162,7 +163,7 @@ func TestDefaultConfigMap(t *testing.T) {
 			want: &corev1.ConfigMap{
 				TypeMeta: metav1.TypeMeta{},
 				ObjectMeta: metav1.ObjectMeta{
-					Name:        ConsoleConfigMapName,
+					Name:        api.OpenShiftConsoleConfigMapName,
 					Namespace:   api.OpenShiftConsoleNamespace,
 					Labels:      map[string]string{"app": api.OpenShiftConsoleName},
 					Annotations: map[string]string{},
@@ -225,7 +226,7 @@ func TestStub(t *testing.T) {
 			want: &corev1.ConfigMap{
 				TypeMeta: metav1.TypeMeta{},
 				ObjectMeta: metav1.ObjectMeta{
-					Name:                       ConsoleConfigMapName,
+					Name:                       api.OpenShiftConsoleConfigMapName,
 					GenerateName:               "",
 					Namespace:                  api.OpenShiftConsoleNamespace,
 					SelfLink:                   "",
@@ -250,6 +251,46 @@ func TestStub(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if diff := deep.Equal(Stub(), tt.want); diff != nil {
+				t.Error(diff)
+			}
+		})
+	}
+}
+
+func TestDefaultPublicConfigMap(t *testing.T) {
+	tests := []struct {
+		name string
+		want *corev1.ConfigMap
+	}{
+		{
+			name: "Test generating default public configmap with console URL",
+			want: &corev1.ConfigMap{
+				TypeMeta: metav1.TypeMeta{},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:                       api.OpenShiftConsolePublicConfigMapName,
+					GenerateName:               "",
+					Namespace:                  api.OpenShiftConfigManagedNamespace,
+					SelfLink:                   "",
+					UID:                        "",
+					ResourceVersion:            "",
+					Generation:                 0,
+					CreationTimestamp:          metav1.Time{},
+					DeletionTimestamp:          nil,
+					DeletionGracePeriodSeconds: nil,
+					Labels:          nil,
+					Annotations:     nil,
+					OwnerReferences: nil,
+					Initializers:    nil,
+					Finalizers:      nil,
+					ClusterName:     "",
+				},
+				Data: map[string]string{"consoleURL": mockConsoleURL},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if diff := deep.Equal(DefaultPublicConfig(mockConsoleURL), tt.want); diff != nil {
 				t.Error(diff)
 			}
 		})

--- a/pkg/console/subresource/configmap/service_ca.go
+++ b/pkg/console/subresource/configmap/service_ca.go
@@ -4,12 +4,12 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
+
+	"github.com/openshift/console-operator/pkg/api"
 	"github.com/openshift/console-operator/pkg/console/subresource/util"
 )
 
 const (
-	// ServiceCAConfigMapName is the name of the config map that contains the service CA bundle.
-	ServiceCAConfigMapName = "service-ca"
 	// See https://github.com/openshift/service-serving-cert-signer
 	injectCABundleAnnotation = "service.alpha.openshift.io/inject-cabundle"
 )
@@ -25,7 +25,7 @@ func DefaultServiceCAConfigMap(cr *operatorv1.Console) *corev1.ConfigMap {
 
 func ServiceCAStub() *corev1.ConfigMap {
 	meta := util.SharedMeta()
-	meta.Name = ServiceCAConfigMapName
+	meta.Name = api.ServiceCAConfigMapName
 	meta.Annotations = map[string]string{
 		injectCABundleAnnotation: "true",
 	}

--- a/pkg/console/subresource/configmap/service_ca_test.go
+++ b/pkg/console/subresource/configmap/service_ca_test.go
@@ -32,7 +32,7 @@ func TestDefaultServiceCAConfigMap(t *testing.T) {
 			},
 			want: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:                       ServiceCAConfigMapName,
+					Name:                       api.ServiceCAConfigMapName,
 					Namespace:                  api.OpenShiftConsoleNamespace,
 					Generation:                 0,
 					CreationTimestamp:          metav1.Time{},
@@ -66,7 +66,7 @@ func TestServiceCAStub(t *testing.T) {
 			want: &corev1.ConfigMap{
 				TypeMeta: metav1.TypeMeta{},
 				ObjectMeta: metav1.ObjectMeta{
-					Name:                       ServiceCAConfigMapName,
+					Name:                       api.ServiceCAConfigMapName,
 					Namespace:                  api.OpenShiftConsoleNamespace,
 					Generation:                 0,
 					CreationTimestamp:          metav1.Time{},

--- a/pkg/console/subresource/deployment/deployment.go
+++ b/pkg/console/subresource/deployment/deployment.go
@@ -17,7 +17,6 @@ import (
 	operatorv1 "github.com/openshift/api/operator/v1"
 	routev1 "github.com/openshift/api/route/v1"
 	"github.com/openshift/console-operator/pkg/api"
-	"github.com/openshift/console-operator/pkg/console/subresource/configmap"
 	"github.com/openshift/console-operator/pkg/console/subresource/util"
 )
 
@@ -70,13 +69,13 @@ var volumeConfigList = []volumeConfig{
 		isSecret: true,
 	},
 	{
-		name:        configmap.ConsoleConfigMapName,
+		name:        api.OpenShiftConsoleConfigMapName,
 		readOnly:    true,
 		path:        "/var/console-config",
 		isConfigMap: true,
 	},
 	{
-		name:        configmap.ServiceCAConfigMapName,
+		name:        api.ServiceCAConfigMapName,
 		readOnly:    true,
 		path:        "/var/service-ca",
 		isConfigMap: true,

--- a/pkg/console/subresource/deployment/deployment_test.go
+++ b/pkg/console/subresource/deployment/deployment_test.go
@@ -12,7 +12,6 @@ import (
 	operatorsv1 "github.com/openshift/api/operator/v1"
 	v1 "github.com/openshift/api/route/v1"
 	"github.com/openshift/console-operator/pkg/api"
-	"github.com/openshift/console-operator/pkg/console/subresource/configmap"
 	"github.com/openshift/console-operator/pkg/console/subresource/util"
 )
 
@@ -267,11 +266,11 @@ func Test_consoleVolumes(t *testing.T) {
 					},
 				},
 				{
-					Name: configmap.ConsoleConfigMapName,
+					Name: api.OpenShiftConsoleConfigMapName,
 					VolumeSource: corev1.VolumeSource{
 						ConfigMap: &corev1.ConfigMapVolumeSource{
 							LocalObjectReference: corev1.LocalObjectReference{
-								Name: configmap.ConsoleConfigMapName,
+								Name: api.OpenShiftConsoleConfigMapName,
 							},
 							Items:       nil,
 							DefaultMode: nil,
@@ -280,11 +279,11 @@ func Test_consoleVolumes(t *testing.T) {
 					},
 				},
 				{
-					Name: configmap.ServiceCAConfigMapName,
+					Name: api.ServiceCAConfigMapName,
 					VolumeSource: corev1.VolumeSource{
 						ConfigMap: &corev1.ConfigMapVolumeSource{
 							LocalObjectReference: corev1.LocalObjectReference{
-								Name: configmap.ServiceCAConfigMapName,
+								Name: api.ServiceCAConfigMapName,
 							},
 							Items:       nil,
 							DefaultMode: nil,
@@ -329,12 +328,12 @@ func Test_consoleVolumeMounts(t *testing.T) {
 					MountPath: "/var/oauth-config",
 				},
 				{
-					Name:      configmap.ConsoleConfigMapName,
+					Name:      api.OpenShiftConsoleConfigMapName,
 					ReadOnly:  true,
 					MountPath: "/var/console-config",
 				},
 				{
-					Name:      configmap.ServiceCAConfigMapName,
+					Name:      api.ServiceCAConfigMapName,
 					ReadOnly:  true,
 					MountPath: "/var/service-ca",
 				},

--- a/pkg/testframework/framework.go
+++ b/pkg/testframework/framework.go
@@ -50,6 +50,8 @@ func GetResource(client *Clientset, resource string) (runtime.Object, error) {
 	switch resource {
 	case "ConfigMap":
 		res, err = GetConsoleConfigMap(client)
+	case "ConfigMapPublic":
+		res, err = GetPublicConsoleConfigMap(client)
 	case "Service":
 		res, err = GetConsoleService(client)
 	case "Route":
@@ -64,6 +66,10 @@ func GetResource(client *Clientset, resource string) (runtime.Object, error) {
 
 func GetConsoleConfigMap(client *Clientset) (*corev1.ConfigMap, error) {
 	return client.ConfigMaps(consoleapi.OpenShiftConsoleNamespace).Get(consoleapi.OpenShiftConsoleConfigMapName, metav1.GetOptions{})
+}
+
+func GetPublicConsoleConfigMap(client *Clientset) (*corev1.ConfigMap, error) {
+	return client.ConfigMaps(consoleapi.OpenShiftConfigManagedNamespace).Get(consoleapi.OpenShiftConsolePublicConfigMapName, metav1.GetOptions{})
 }
 
 func GetConsoleService(client *Clientset) (*corev1.Service, error) {
@@ -141,6 +147,7 @@ func DeleteCompletely(getObject func() (runtime.Object, error), deleteObject fun
 func ConsoleResourcesAvailable(client *Clientset) error {
 	errChan := make(chan error)
 	go IsResourceAvailable(errChan, client, "ConfigMap")
+	go IsResourceAvailable(errChan, client, "ConfigMapPublic")
 	go IsResourceAvailable(errChan, client, "Route")
 	go IsResourceAvailable(errChan, client, "Service")
 	go IsResourceAvailable(errChan, client, "Deployment")


### PR DESCRIPTION
The global config resource is not readable by normal users. Add a public
config map that has the console URL so it can be discovered by all
authenticated users.