### PR TITLE
Tolerate every taint

### DIFF
--- a/manifests/07-operator.yaml
+++ b/manifests/07-operator.yaml
@@ -16,9 +16,7 @@ spec:
       nodeSelector:
         node-role.kubernetes.io/master: ""
       tolerations:
-      - key: node-role.kubernetes.io/master
         operator: Exists
-        effect: NoSchedule
       priorityClassName: system-cluster-critical
       serviceAccountName: console-operator
       containers:


### PR DESCRIPTION
As of now, we are tolerating only `node-role.kubernetes.io/master` taint during scheduling stage. If we don't have the blanket toleration, there is a very good chance that these pods won't tolerate other taints that got added to the node, for example `disk-pressure` etc. The side-effect is that we will tolerate `NoExecute` taints as well

Please feel free to close this PR, if you think, you just need to tolerate the current taint(s) you have.

/cc @sjenning @derekwaynecarr 
