### PR TITLE
Add custom branding to config map

### DIFF
--- a/manifests/03-rbac-role-ns-openshift-config.yaml
+++ b/manifests/03-rbac-role-ns-openshift-config.yaml
@@ -1,0 +1,14 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: console-operator
+  namespace: openshift-config
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch

--- a/manifests/04-rbac-rolebinding.yaml
+++ b/manifests/04-rbac-rolebinding.yaml
@@ -65,3 +65,17 @@ subjects:
   - kind: Group
     name: system:authenticated
     apiGroup: rbac.authorization.k8s.io
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: console-operator
+  namespace: openshift-config
+roleRef:
+  kind: Role
+  name: console-operator
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: console-operator
+    namespace: openshift-console-operator

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -19,4 +19,6 @@ const (
 	OpenShiftConsoleRouteName           = OpenShiftConsoleName
 	OAuthClientName                     = OpenShiftConsoleName
 	OpenShiftConfigManagedNamespace     = "openshift-config-managed"
+	OpenShiftConfigNamespace            = "openshift-config"
+	OpenShiftCustomLogoConfigMap        = "custom-logo"
 )

--- a/pkg/console/clientwrapper/without_secret.go
+++ b/pkg/console/clientwrapper/without_secret.go
@@ -1,0 +1,39 @@
+package clientwrapper
+
+import (
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+)
+
+func WithoutSecret(client kubernetes.Interface) kubernetes.Interface {
+	return &clientWrapper{
+		Interface: client,
+		core: &coreWrapper{
+			CoreV1Interface: client.CoreV1(),
+			secrets:         fake.NewSimpleClientset().CoreV1(),
+		},
+	}
+}
+
+type clientWrapper struct {
+	kubernetes.Interface
+	core *coreWrapper
+}
+
+func (c *clientWrapper) CoreV1() corev1.CoreV1Interface {
+	return c.core
+}
+
+func (c *clientWrapper) Secrets(namespace string) corev1.SecretInterface {
+	return c.core.Secrets(namespace)
+}
+
+type coreWrapper struct {
+	corev1.CoreV1Interface
+	secrets corev1.SecretsGetter
+}
+
+func (c *coreWrapper) Secrets(namespace string) corev1.SecretInterface {
+	return c.secrets.Secrets(namespace)
+}

--- a/pkg/console/operator/status.go
+++ b/pkg/console/operator/status.go
@@ -58,6 +58,7 @@ const (
 	reasonSyncError           = "SynchronizationError"
 	reasonNoPodsAvailable     = "NoPodsAvailable"
 	reasonSyncLoopError       = "SyncLoopError"
+	reasonCustomLogoInvalid   = "CustomLogoInvalid"
 )
 
 // TODO:

--- a/pkg/console/operator/sync_v400.go
+++ b/pkg/console/operator/sync_v400.go
@@ -109,6 +109,14 @@ func sync_v400(co *consoleOperator, operatorConfig *operatorv1.Console, consoleC
 	}
 	toUpdate = toUpdate || depChanged
 
+	sErr := co.SyncCustomLogoConfigMap(operatorConfig)
+	if sErr != nil {
+		msg := fmt.Sprintf("%q: %v", "customLogoSync", sErr)
+		klog.V(4).Infof("incomplete sync: %v", msg)
+		co.ConditionResourceSyncProgressing(operatorConfig, msg)
+		return sErr
+	}
+
 	resourcemerge.SetDeploymentGeneration(&operatorConfig.Status.Generations, actualDeployment)
 	operatorConfig.Status.ObservedGeneration = operatorConfig.ObjectMeta.Generation
 

--- a/pkg/console/starter/starter.go
+++ b/pkg/console/starter/starter.go
@@ -2,9 +2,6 @@ package starter
 
 import (
 	"fmt"
-
-	"github.com/openshift/api/oauth"
-
 	"os"
 	"time"
 
@@ -17,12 +14,15 @@ import (
 
 	// openshift
 	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/api/oauth"
 	operatorv1 "github.com/openshift/api/operator"
 	"github.com/openshift/console-operator/pkg/api"
-	operatorclient "github.com/openshift/console-operator/pkg/console/operatorclient"
+	"github.com/openshift/console-operator/pkg/console/operatorclient"
 	"github.com/openshift/library-go/pkg/controller/controllercmd"
+	"github.com/openshift/library-go/pkg/operator/resourcesynccontroller"
 	"github.com/openshift/library-go/pkg/operator/status"
 	"github.com/openshift/library-go/pkg/operator/unsupportedconfigoverridescontroller"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
 
 	// clients
 	configclient "github.com/openshift/client-go/config/clientset/versioned"
@@ -37,6 +37,7 @@ import (
 	routesclient "github.com/openshift/client-go/route/clientset/versioned"
 	routesinformers "github.com/openshift/client-go/route/informers/externalversions"
 
+	"github.com/openshift/console-operator/pkg/console/clientwrapper"
 	"github.com/openshift/console-operator/pkg/console/operator"
 )
 
@@ -88,7 +89,8 @@ func RunOperator(ctx *controllercmd.ControllerContext) error {
 		resync,
 		informers.WithNamespace(api.OpenShiftConfigManagedNamespace),
 	)
-	// configs are all named "cluster", but our clusteroperator is named "console"
+
+	//configs are all named "cluster", but our clusteroperator is named "console"
 	configInformers := configinformers.NewSharedInformerFactoryWithOptions(
 		configClient,
 		resync,
@@ -122,6 +124,8 @@ func RunOperator(ctx *controllercmd.ControllerContext) error {
 
 	versionGetter := status.NewVersionGetter()
 
+	resourceSyncerInformers, resourceSyncer := getResourceSyncer(ctx, clientwrapper.WithoutSecret(kubeClient), operatorClient)
+
 	// TODO: rearrange these into informer,client pairs, NOT separated.
 	consoleOperator := operator.NewConsoleOperator(
 		// informers
@@ -142,6 +146,7 @@ func RunOperator(ctx *controllercmd.ControllerContext) error {
 		oauthClient.OauthV1(),
 		versionGetter,
 		recorder,
+		resourceSyncer,
 	)
 
 	versionRecorder := status.NewVersionGetter()
@@ -175,6 +180,7 @@ func RunOperator(ctx *controllercmd.ControllerContext) error {
 	}{
 		kubeInformersNamespaced,
 		kubeInformersManagedNamespaced,
+		resourceSyncerInformers,
 		operatorConfigInformers,
 		configInformers,
 		routesInformersNamespaced,
@@ -184,9 +190,26 @@ func RunOperator(ctx *controllercmd.ControllerContext) error {
 	}
 
 	go consoleOperator.Run(ctx.Done())
+	go resourceSyncer.Run(1, ctx.Done())
 	go clusterOperatorStatus.Run(1, ctx.Done())
 	go configUpgradeableController.Run(1, ctx.Done())
 
 	<-ctx.Done()
 	return fmt.Errorf("stopped")
+}
+
+func getResourceSyncer(ctx *controllercmd.ControllerContext, kubeClient kubernetes.Interface, operatorClient v1helpers.OperatorClient) (v1helpers.KubeInformersForNamespaces, *resourcesynccontroller.ResourceSyncController) {
+	resourceSyncerInformers := v1helpers.NewKubeInformersForNamespaces(
+		kubeClient,
+		api.OpenShiftConfigNamespace,
+		api.OpenShiftConsoleNamespace,
+	)
+	resourceSyncer := resourcesynccontroller.NewResourceSyncController(
+		operatorClient,
+		resourceSyncerInformers,
+		v1helpers.CachedSecretGetter(kubeClient.CoreV1(), resourceSyncerInformers),
+		v1helpers.CachedConfigMapGetter(kubeClient.CoreV1(), resourceSyncerInformers),
+		ctx.EventRecorder,
+	)
+	return resourceSyncerInformers, resourceSyncer
 }

--- a/pkg/console/subresource/configmap/configmap.go
+++ b/pkg/console/subresource/configmap/configmap.go
@@ -17,11 +17,7 @@ import (
 
 const (
 	consoleConfigYamlFile = "console-config.yaml"
-)
-
-// overridden by console config
-const (
-	defaultLogoutURL = ""
+	defaultLogoutURL      = ""
 )
 
 func getApiUrl(infrastructureConfig *configv1.Infrastructure) string {
@@ -54,13 +50,14 @@ func DefaultConfigMap(
 		ConfigYAML()
 
 	extractedManagedConfig := extractYAML(managedConfig)
-
 	userDefinedBuilder := &consoleserver.ConsoleServerCLIConfigBuilder{}
 	userDefinedConfig, err := userDefinedBuilder.Host(rt.Spec.Host).
 		LogoutURL(consoleConfig.Spec.Authentication.LogoutRedirect).
 		Brand(operatorConfig.Spec.Customization.Brand).
 		DocURL(operatorConfig.Spec.Customization.DocumentationBaseURL).
 		APIServerURL(getApiUrl(infrastructureConfig)).
+		CustomLogoFile(operatorConfig.Spec.Customization.CustomLogoFile.Key).
+		CustomProductName(operatorConfig.Spec.Customization.CustomProductName).
 		StatusPageID(statusPageId(operatorConfig)).
 		ConfigYAML()
 

--- a/pkg/console/subresource/consoleserver/config_builder.go
+++ b/pkg/console/subresource/consoleserver/config_builder.go
@@ -34,8 +34,6 @@ type ConsoleServerCLIConfigBuilder struct {
 	docURL            string
 	apiServerURL      string
 	statusPageID      string
-	// TODO: pipe these in when they are added via the future custom branding PR
-	// This should be trivial
 	customProductName string
 	customLogoFile    string
 }
@@ -58,6 +56,16 @@ func (b *ConsoleServerCLIConfigBuilder) DocURL(docURL string) *ConsoleServerCLIC
 }
 func (b *ConsoleServerCLIConfigBuilder) APIServerURL(apiServerURL string) *ConsoleServerCLIConfigBuilder {
 	b.apiServerURL = apiServerURL
+	return b
+}
+func (b *ConsoleServerCLIConfigBuilder) CustomProductName(customProductName string) *ConsoleServerCLIConfigBuilder {
+	b.customProductName = customProductName
+	return b
+}
+func (b *ConsoleServerCLIConfigBuilder) CustomLogoFile(customLogoFile string) *ConsoleServerCLIConfigBuilder {
+	if customLogoFile != "" {
+		b.customLogoFile = "/var/logo/" + customLogoFile // append path here to prevent customLogoFile from always being just /var/logo/
+	}
 	return b
 }
 
@@ -129,6 +137,12 @@ func (b *ConsoleServerCLIConfigBuilder) customization() Customization {
 	}
 	if len(b.docURL) > 0 {
 		conf.DocumentationBaseURL = b.docURL
+	}
+	if len(b.customProductName) > 0 {
+		conf.CustomProductName = string(b.customProductName)
+	}
+	if len(b.customLogoFile) > 0 {
+		conf.CustomLogoFile = b.customLogoFile
 	}
 	return conf
 

--- a/pkg/console/subresource/deployment/deployment.go
+++ b/pkg/console/subresource/deployment/deployment.go
@@ -54,33 +54,6 @@ type volumeConfig struct {
 	isConfigMap bool
 }
 
-var volumeConfigList = []volumeConfig{
-	{
-		name:     ConsoleServingCertName,
-		readOnly: true,
-		path:     "/var/serving-cert",
-		isSecret: true,
-	},
-	{
-		name:     ConsoleOauthConfigName,
-		readOnly: true,
-		path:     "/var/oauth-config",
-		isSecret: true,
-	},
-	{
-		name:        api.OpenShiftConsoleConfigMapName,
-		readOnly:    true,
-		path:        "/var/console-config",
-		isConfigMap: true,
-	},
-	{
-		name:        api.ServiceCAConfigMapName,
-		readOnly:    true,
-		path:        "/var/service-ca",
-		isConfigMap: true,
-	},
-}
-
 func DefaultDeployment(operatorConfig *operatorv1.Console, cm *corev1.ConfigMap, serviceCAConfigMap *corev1.ConfigMap, sec *corev1.Secret, rt *routev1.Route) *appsv1.Deployment {
 	labels := util.LabelsForConsole()
 	meta := util.SharedMeta()
@@ -95,6 +68,10 @@ func DefaultDeployment(operatorConfig *operatorv1.Console, cm *corev1.ConfigMap,
 	replicas := int32(ConsoleReplicas)
 	gracePeriod := int64(30)
 	tolerationSeconds := int64(120)
+	volumeConfig := defaultVolumeConfig()
+	if hasCustomLogo(operatorConfig) {
+		volumeConfig = append(volumeConfig, customLogoVolume(operatorConfig))
+	}
 
 	deployment := &appsv1.Deployment{
 		ObjectMeta: meta,
@@ -160,9 +137,9 @@ func DefaultDeployment(operatorConfig *operatorv1.Console, cm *corev1.ConfigMap,
 					TerminationGracePeriodSeconds: &gracePeriod,
 					SecurityContext:               &corev1.PodSecurityContext{},
 					Containers: []corev1.Container{
-						consoleContainer(operatorConfig),
+						consoleContainer(operatorConfig, volumeConfig),
 					},
-					Volumes: consoleVolumes(volumeConfigList),
+					Volumes: consoleVolumes(volumeConfig),
 				},
 			},
 		},
@@ -253,8 +230,8 @@ func GetLogLevelFlag(logLevel operatorv1.LogLevel) string {
 	return flag
 }
 
-func consoleContainer(cr *operatorv1.Console) corev1.Container {
-	volumeMounts := consoleVolumeMounts(volumeConfigList)
+func consoleContainer(cr *operatorv1.Console, volConfigList []volumeConfig) corev1.Container {
+	volumeMounts := consoleVolumeMounts(volConfigList)
 	// Since the console-operator logging has different logging levels then the capnslog,
 	// that we use for console server(bridge) we need to map them to each other
 	flag := GetLogLevelFlag(cr.Spec.LogLevel)
@@ -331,4 +308,47 @@ func IsAvailableAndUpdated(deployment *appsv1.Deployment) bool {
 	return deployment.Status.AvailableReplicas > 0 &&
 		deployment.Status.ObservedGeneration >= deployment.Generation &&
 		deployment.Status.UpdatedReplicas == deployment.Status.Replicas
+}
+
+func defaultVolumeConfig() []volumeConfig {
+	return []volumeConfig{
+		{
+			name:     ConsoleServingCertName,
+			readOnly: true,
+			path:     "/var/serving-cert",
+			isSecret: true,
+		},
+		{
+			name:     ConsoleOauthConfigName,
+			readOnly: true,
+			path:     "/var/oauth-config",
+			isSecret: true,
+		},
+		{
+			name:        api.OpenShiftConsoleConfigMapName,
+			readOnly:    true,
+			path:        "/var/console-config",
+			isConfigMap: true,
+		},
+		{
+			name:        api.ServiceCAConfigMapName,
+			readOnly:    true,
+			path:        "/var/service-ca",
+			isConfigMap: true,
+		},
+	}
+}
+
+func hasCustomLogo(operatorConfig *operatorv1.Console) bool {
+	if logoName := operatorConfig.Spec.Customization.CustomLogoFile.Name; logoName != "" {
+		return true
+	}
+	return false
+}
+
+func customLogoVolume(operatorConfig *operatorv1.Console) volumeConfig {
+	return volumeConfig{
+		name:        api.OpenShiftCustomLogoConfigMap,
+		path:        "/var/logo/",
+		isConfigMap: true}
 }

--- a/pkg/console/subresource/deployment/deployment_test.go
+++ b/pkg/console/subresource/deployment/deployment_test.go
@@ -170,9 +170,9 @@ func TestDefaultDeployment(t *testing.T) {
 							TerminationGracePeriodSeconds: &gracePeriod,
 							SecurityContext:               &corev1.PodSecurityContext{},
 							Containers: []corev1.Container{
-								consoleContainer(consoleOperatorConfig),
+								consoleContainer(consoleOperatorConfig, defaultVolumeConfig()),
 							},
-							Volumes: consoleVolumes(volumeConfigList),
+							Volumes: consoleVolumes(defaultVolumeConfig()),
 						},
 					},
 					Strategy:                appsv1.DeploymentStrategy{},
@@ -252,7 +252,7 @@ func Test_consoleVolumes(t *testing.T) {
 		{
 			name: "Test console volumes creation",
 			args: args{
-				vc: volumeConfigList,
+				vc: defaultVolumeConfig(),
 			},
 			want: []corev1.Volume{
 				{
@@ -326,7 +326,7 @@ func Test_consoleVolumeMounts(t *testing.T) {
 	}{
 		{name: "Test console volumes Mounts",
 			args: args{
-				vc: volumeConfigList,
+				vc: defaultVolumeConfig(),
 			},
 			want: []corev1.VolumeMount{
 				{

--- a/test/e2e/brand_customization_test.go
+++ b/test/e2e/brand_customization_test.go
@@ -1,0 +1,176 @@
+package e2e
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	configv1 "github.com/openshift/api/config/v1"
+	operatorsv1 "github.com/openshift/api/operator/v1"
+	consoleapi "github.com/openshift/console-operator/pkg/api"
+	"github.com/openshift/console-operator/pkg/testframework"
+)
+
+const (
+	testCustomProductName = "test-e2e-product-name"
+	testCustomLogoName    = "test-e2e-configmap"
+	testCustomLogoKey     = "pic.jpg"
+	testMountPath         = "/var/logo/"
+)
+
+// Test prep - setup the client used by each test
+func setupCustomTestCase(t *testing.T) (*testframework.Clientset, operatorsv1.ConsoleCustomization) {
+	client := testframework.MustNewClientset(t, nil)
+	// Get the original operator config
+	originalConfig, err := client.Consoles().Get(consoleapi.ConfigResourceName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("could not get operator config, %v", err)
+	}
+	originalConfigCustomization := originalConfig.Spec.Customization
+
+	return client, originalConfigCustomization
+}
+
+func cleanupCustomizationTestCase(t *testing.T, client *testframework.Clientset, originalConfigCustomization operatorsv1.ConsoleCustomization) {
+
+	setOperatorConfigCustomization(t, client, originalConfigCustomization)
+
+	err := client.ConfigMaps("openshift-config").Delete(testCustomLogoName, &metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatalf("could not delete test configmap, %v", err)
+	}
+	testframework.WaitForSettledState(t, client)
+}
+
+// TestOperatorConfigCustomization() tests that changing the customization values on the operator-config
+// will result in the customization being set on the console-config in openshift-console.
+// Implicitly it ensures that the operator-config customization overrides customization set on
+// console-config in openshift-config-managed, if the managed configmap exists.
+func TestOperatorConfigCustomization(t *testing.T) {
+	client, originalConfigCustomization := setupCustomTestCase(t)
+	defer cleanupCustomizationTestCase(t, client, originalConfigCustomization)
+
+	// Create configmap with logo in namespace openshift-config
+	// Manual cmd: oc create configmap test-configmap --from-file=pic.jpg -n openshift-config
+	_, err := createLogoConfigMap(client)
+	if err != nil {
+		t.Fatalf("error: could not create logo configmap, %v", err)
+	}
+	// Set customization options on the operatorConfig
+	customData := operatorsv1.ConsoleCustomization{
+		CustomProductName: testCustomProductName,
+		CustomLogoFile: configv1.ConfigMapFileReference{
+			Name: testCustomLogoName,
+			Key:  testCustomLogoKey,
+		},
+	}
+	setOperatorConfigCustomization(t, client, customData)
+
+	// Verify options appear in the console-config in openshift-console
+	err = wait.Poll(1*time.Second, pollTimeout, func() (stop bool, err error) {
+		productName, logo := getConsoleCustomization(t, client)
+		return (productName == testCustomProductName) && (logo == testMountPath+testCustomLogoKey), nil
+	})
+	if err != nil {
+		t.Fatalf("error: customization values not found  %v", err)
+	}
+
+	// Verify mounts and volumes appear correctly on the deployment console in openshift-console
+	err = wait.Poll(1*time.Second, pollTimeout, func() (stop bool, err error) {
+		deployment, err := testframework.GetConsoleDeployment(client)
+		foundCustomizationVolume := findCustomizationVolume(deployment)
+		foundCustomizationMount := findCustomizationVolumeMount(deployment)
+		return foundCustomizationVolume && foundCustomizationMount, nil
+	})
+	if err != nil {
+		t.Fatalf("error: customization values not on deployment, %v", err)
+	}
+}
+
+func findCustomizationVolume(deployment *appsv1.Deployment) bool {
+	volumes := deployment.Spec.Template.Spec.Volumes
+	for _, volume := range volumes {
+		if volume.Name == testCustomLogoName {
+			return true
+		}
+	}
+	return false
+}
+
+func findCustomizationVolumeMount(deployment *appsv1.Deployment) bool {
+	mounts := deployment.Spec.Template.Spec.Containers[0].VolumeMounts
+	for _, mount := range mounts {
+		if (mount.Name == testCustomLogoName) && (mount.MountPath == testMountPath) {
+			return true
+		}
+	}
+	return false
+}
+
+// Set Customization on the operator config
+func setOperatorConfigCustomization(t *testing.T, client *testframework.Clientset, cust operatorsv1.ConsoleCustomization) {
+	operatorConfig, err := client.Consoles().Get(consoleapi.ConfigResourceName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("could not get operator config, %v", err)
+	}
+	spec := operatorsv1.ConsoleSpec{
+		OperatorSpec: operatorsv1.OperatorSpec{
+			ManagementState: "Managed",
+		},
+		Customization: cust,
+	}
+	operatorConfig.Spec = spec
+	_, err = client.Consoles().Update(operatorConfig)
+	if err != nil {
+		t.Fatalf("could not update operator config with customization=%v, %v", cust, err)
+	}
+}
+
+// Get the brand from the console-config in the data of the console CM
+func getConsoleCustomization(t *testing.T, client *testframework.Clientset) (string, string) {
+	cm, err := testframework.GetConsoleConfigMap(client)
+	if err != nil {
+		t.Fatalf("error: %s", err)
+	}
+
+	data := cm.Data["console-config.yaml"]
+	logoValue := ""
+	customProductName := ""
+	temp := strings.Split(data, "\n")
+	for _, item := range temp {
+		if strings.Contains(item, "customLogoFile") {
+			logoValue = strings.Split(strings.TrimSpace(item), ":")[1]
+		}
+		if strings.Contains(item, "customProductName") {
+			customProductName = strings.Split(strings.TrimSpace(item), ":")[1]
+		}
+	}
+	t.Logf("productName:%s, logo:%s", customProductName, logoValue)
+	return strings.TrimSpace(customProductName), strings.TrimSpace(logoValue)
+}
+
+// Helper function that creates a test configmap with binarydata
+func createLogoConfigMap(client *testframework.Clientset) (*v1.ConfigMap, error) {
+	var data = make(map[string][]byte)
+	data[testCustomLogoKey] = []byte("TESTING")
+
+	cm := &v1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ConfigMap",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              testCustomLogoName,
+			Namespace:         "openshift-config",
+			CreationTimestamp: metav1.Time{},
+		},
+		BinaryData: data,
+	}
+	return client.ConfigMaps("openshift-config").Create(cm)
+
+}


### PR DESCRIPTION
Add custom product name and logo to the config map and update unit/e2e tests.

For testing:
Creating config map with image (image needs to be less than 1MB)
`oc create configmap myconfig --from-file=/mypic.jpg -n openshift-config`
Creating operator config:
```
apiVersion: operator.openshift.io/v1
kind: Console
metadata:
  annotations:
    release.openshift.io/create-only: "true"
  name: cluster
spec:
  customization:
    brand: azure
    customProductName: my-custom-name
    customLogoFile:
      name:  myconfig
      key: mypic.jpg
  managementState: Managed
```
Update Operator Config:
`oc apply -f custom.yaml`

Verify Changes in Deployment:
`oc get deployment console -n openshift-console -o yaml`

If testing this locally before merge, you will need to make sure console code is the latest along with the console-operator code.
Additionally, you will need to manually run the `oc apply -f manifests/03-rbac-role-ns-openshift-config.yaml ` and `oc apply -f manifests/04-rbac-rolebinding.yaml`

