### PR TITLE
Check if OAuth is already updated when in Removed state to prevent hotloop

### DIFF
--- a/pkg/console/operator/operator.go
+++ b/pkg/console/operator/operator.go
@@ -249,8 +249,10 @@ func (c *consoleOperator) deleteAllResources(cr *operatorsv1.Console) error {
 	// existingOAuthClient is not a delete, it is a deregister/neutralize
 	existingOAuthClient, getAuthErr := c.oauthClient.OAuthClients().Get(oauthclient.Stub().Name, metav1.GetOptions{})
 	errs = append(errs, getAuthErr)
-	_, updateAuthErr := c.oauthClient.OAuthClients().Update(oauthclient.DeRegisterConsoleFromOAuthClient(existingOAuthClient))
-	errs = append(errs, updateAuthErr)
+	if len(existingOAuthClient.RedirectURIs) != 0 {
+		_, updateAuthErr := c.oauthClient.OAuthClients().Update(oauthclient.DeRegisterConsoleFromOAuthClient(existingOAuthClient))
+		errs = append(errs, updateAuthErr)
+	}
 	// deployment
 	// NOTE: CVO controls the deployment for downloads, console-operator cannot delete it.
 	errs = append(errs, c.deploymentClient.Deployments(api.TargetNamespace).Delete(deployment.Stub().Name, &metav1.DeleteOptions{}))


### PR DESCRIPTION
To prevent hot-looping in `Removed` state, we need to add condition check (added the check to the `Unmanaged` state as well)

Tested the change locally and the hot-looping is gone, also e2e are green

Bug: https://jira.coreos.com/browse/CONSOLE-1430?filter=-1

/assign @spadgett 

@benjaminapetersen fyi 