### PR TITLE
Update downloads deployment node selector and tolerations

### DIFF
--- a/manifests/07-downloads-deployment.yaml
+++ b/manifests/07-downloads-deployment.yaml
@@ -16,8 +16,12 @@ spec:
         app: console
         component: downloads
     spec:
+      nodeSelector:
+        beta.kubernetes.io/os: linux
       tolerations:
-      - operator: Exists
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
       containers:
       - name: download-server
         terminationMessagePolicy: FallbackToLogsOnError


### PR DESCRIPTION
Don't tolerate all taints, only `node-role.kubernetes.io/master`.

/cc @sjenning @benjaminapetersen @wking 