### PR TITLE
Refactor priotrity of config maps for console

### DIFF
--- a/pkg/console/subresource/configmap/configmap.go
+++ b/pkg/console/subresource/configmap/configmap.go
@@ -33,27 +33,6 @@ const (
 	defaultLogoutURL = ""
 )
 
-func getLogoutRedirect(consoleConfig *configv1.Console) string {
-	if len(consoleConfig.Spec.Authentication.LogoutRedirect) > 0 {
-		return consoleConfig.Spec.Authentication.LogoutRedirect
-	}
-	return defaultLogoutURL
-}
-
-func getBrand(operatorConfig *operatorv1.Console) operatorv1.Brand {
-	if len(operatorConfig.Spec.Customization.Brand) > 0 {
-		return operatorConfig.Spec.Customization.Brand
-	}
-	return DEFAULT_BRAND
-}
-
-func getDocURL(operatorConfig *operatorv1.Console) string {
-	if len(operatorConfig.Spec.Customization.DocumentationBaseURL) > 0 {
-		return operatorConfig.Spec.Customization.DocumentationBaseURL
-	}
-	return DEFAULT_DOC_URL
-}
-
 func getApiUrl(infrastructureConfig *configv1.Infrastructure) string {
 	if infrastructureConfig != nil {
 		return infrastructureConfig.Status.APIServerURL
@@ -66,21 +45,24 @@ func getApiUrl(infrastructureConfig *configv1.Infrastructure) string {
 // - a bool indicating if config was merged (unsupportedConfigOverrides)
 // - an error
 func DefaultConfigMap(operatorConfig *operatorv1.Console, consoleConfig *configv1.Console, managedConfig *corev1.ConfigMap, infrastructureConfig *configv1.Infrastructure, rt *routev1.Route) (*corev1.ConfigMap, bool, error) {
-	logoutRedirect := getLogoutRedirect(consoleConfig)
-	brand := getBrand(operatorConfig)
-	docURL := getDocURL(operatorConfig)
-	apiServerURL := getApiUrl(infrastructureConfig)
 
+	// Build a default config that can be overwritten from other sources
 	host := rt.Spec.Host
-	config := NewYamlConfig(host, logoutRedirect, brand, docURL, apiServerURL)
+	apiServerURL := getApiUrl(infrastructureConfig)
+	defaultConfig := NewYamlConfig(host, defaultLogoutURL, DEFAULT_BRAND, DEFAULT_DOC_URL, apiServerURL)
+	// Get console config from the openshift-config-managed namespace
+	extractedManagedConfig := extractYAML(managedConfig)
 
-	configMap := Stub()
-	configMap.Data = map[string]string{}
-	unsupportedRaw := operatorConfig.Spec.UnsupportedConfigOverrides.Raw
-	newConfig := extractYAML(managedConfig)
+	// Derive a user defined config using operator config
+	logoutRedirect := consoleConfig.Spec.Authentication.LogoutRedirect
+	brand := operatorConfig.Spec.Customization.Brand
+	docURL := operatorConfig.Spec.Customization.DocumentationBaseURL
+	userDefinedConfig := NewYamlConfig(host, logoutRedirect, brand, docURL, apiServerURL)
 
-	// merge config overrides, if we have them
-	mergedConfig, err := resourcemerge.MergeProcessConfig(nil, config, newConfig, unsupportedRaw)
+	unsupportedConfigOverride := operatorConfig.Spec.UnsupportedConfigOverrides.Raw
+
+	// merge configs with overrides, if we have them
+	mergedConfig, err := resourcemerge.MergeProcessConfig(nil, defaultConfig, extractedManagedConfig, userDefinedConfig, unsupportedConfigOverride)
 	if err != nil {
 		logrus.Errorf("failed to merge configmap: %v \n", err)
 		return nil, false, err
@@ -95,9 +77,11 @@ func DefaultConfigMap(operatorConfig *operatorv1.Console, consoleConfig *configv
 	// if we actually merged config overrides, log this information
 	didMerge := len(operatorConfig.Spec.UnsupportedConfigOverrides.Raw) != 0
 	if didMerge {
-		logrus.Println(fmt.Sprintf("with UnsupportedConfigOverrides: %v", string(unsupportedRaw)))
+		logrus.Println(fmt.Sprintf("with UnsupportedConfigOverrides: %v", string(unsupportedConfigOverride)))
 	}
 
+	configMap := Stub()
+	configMap.Data = map[string]string{}
 	configMap.Data[consoleConfigYamlFile] = string(outConfigYaml)
 	util.AddOwnerRef(configMap, util.OwnerRefFrom(operatorConfig))
 
@@ -171,16 +155,15 @@ func servingInfo() yaml.MapSlice {
 	}
 }
 
-func customization(brand operatorv1.Brand, docURL string) yaml.MapSlice {
-	return yaml.MapSlice{
-		{
-			// TODO: branding will need to be provided by higher level config.
-			// it should not be configurable in the CR, but needs to be configured somewhere.
-			Key: "branding", Value: brand,
-		}, {
-			Key: "documentationBaseURL", Value: docURL,
-		},
+func customization(brand operatorv1.Brand, docURL string) map[string]string {
+	tmpMap := make(map[string]string)
+	if brand != "" {
+		tmpMap["branding"] = string(brand)
 	}
+	if docURL != "" {
+		tmpMap["documentationBaseURL"] = docURL
+	}
+	return tmpMap
 }
 
 func clusterInfo(host string, apiServerURL string) yaml.MapSlice {


### PR DESCRIPTION
Refactor how the config map for console is created in terms of what has priority over each config map.  In our case, we are now defining this order:
1. Default values (i.e. Brand = okd)
2. console-config from openshift-config-managed namespace
3. config map from operator config
4. UnsupportRaw which usurps everything else

Also added new unit test for to cover all 1,2,3, not 4 yet.