### PR TITLE
Configmap/builder

### DIFF
--- a/pkg/console/subresource/configmap/configmap.go
+++ b/pkg/console/subresource/configmap/configmap.go
@@ -3,29 +3,20 @@ package configmap
 import (
 	"fmt"
 
-	"k8s.io/klog"
-
-	yaml2 "github.com/ghodss/yaml"
-	yaml "gopkg.in/yaml.v2"
-
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog"
 
 	configv1 "github.com/openshift/api/config/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	routev1 "github.com/openshift/api/route/v1"
 	"github.com/openshift/console-operator/pkg/api"
+	"github.com/openshift/console-operator/pkg/console/subresource/consoleserver"
 	"github.com/openshift/console-operator/pkg/console/subresource/util"
-	"github.com/openshift/library-go/pkg/operator/resource/resourcemerge"
 )
 
 const (
-	consoleConfigYamlFile   = "console-config.yaml"
-	clientSecretFilePath    = "/var/oauth-config/clientSecret"
-	oauthEndpointCAFilePath = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
-	// serving info
-	certFilePath = "/var/serving-cert/tls.crt"
-	keyFilePath  = "/var/serving-cert/tls.key"
+	consoleConfigYamlFile = "console-config.yaml"
 )
 
 // overridden by console config
@@ -40,54 +31,62 @@ func getApiUrl(infrastructureConfig *configv1.Infrastructure) string {
 	return ""
 }
 
-// DefaultConfigMap returns
-// - a new configmap,
-// - a bool indicating if config was merged (unsupportedConfigOverrides)
-// - an error
-func DefaultConfigMap(operatorConfig *operatorv1.Console, consoleConfig *configv1.Console, managedConfig *corev1.ConfigMap, infrastructureConfig *configv1.Infrastructure, rt *routev1.Route) (*corev1.ConfigMap, bool, error) {
+func statusPageId(operatorConfig *operatorv1.Console) string {
+	if operatorConfig.Spec.Providers.Statuspage != nil {
+		return operatorConfig.Spec.Providers.Statuspage.PageID
+	}
+	return ""
+}
 
-	// Build a default config that can be overwritten from other sources
-	host := rt.Spec.Host
-	apiServerURL := getApiUrl(infrastructureConfig)
-	defaultProviders := operatorv1.ConsoleProviders{}
-	defaultConfig := NewYamlConfig(host, defaultLogoutURL, DEFAULT_BRAND, DEFAULT_DOC_URL, apiServerURL, defaultProviders)
-	// Get console config from the openshift-config-managed namespace
+func DefaultConfigMap(
+	operatorConfig *operatorv1.Console,
+	consoleConfig *configv1.Console,
+	managedConfig *corev1.ConfigMap,
+	infrastructureConfig *configv1.Infrastructure,
+	rt *routev1.Route) (consoleConfigmap *corev1.ConfigMap, unsupportedOverridesHaveMerged bool, err error) {
+
+	defaultBuilder := &consoleserver.ConsoleServerCLIConfigBuilder{}
+	defaultConfig, err := defaultBuilder.Host(rt.Spec.Host).
+		LogoutURL(defaultLogoutURL).
+		Brand(DEFAULT_BRAND).
+		DocURL(DEFAULT_DOC_URL).
+		APIServerURL(getApiUrl(infrastructureConfig)).
+		ConfigYAML()
+
 	extractedManagedConfig := extractYAML(managedConfig)
 
-	// Derive a user defined config using operator config
-	logoutRedirect := consoleConfig.Spec.Authentication.LogoutRedirect
-	brand := operatorConfig.Spec.Customization.Brand
-	docURL := operatorConfig.Spec.Customization.DocumentationBaseURL
-	providers := operatorConfig.Spec.Providers
-	userDefinedConfig := NewYamlConfig(host, logoutRedirect, brand, docURL, apiServerURL, providers)
+	userDefinedBuilder := &consoleserver.ConsoleServerCLIConfigBuilder{}
+	userDefinedConfig, err := userDefinedBuilder.Host(rt.Spec.Host).
+		LogoutURL(consoleConfig.Spec.Authentication.LogoutRedirect).
+		Brand(operatorConfig.Spec.Customization.Brand).
+		DocURL(operatorConfig.Spec.Customization.DocumentationBaseURL).
+		APIServerURL(getApiUrl(infrastructureConfig)).
+		StatusPageID(statusPageId(operatorConfig)).
+		ConfigYAML()
 
 	unsupportedConfigOverride := operatorConfig.Spec.UnsupportedConfigOverrides.Raw
-
-	// merge configs with overrides, if we have them
-	mergedConfig, err := resourcemerge.MergeProcessConfig(nil, defaultConfig, extractedManagedConfig, userDefinedConfig, unsupportedConfigOverride)
-	if err != nil {
-		klog.Errorf("failed to merge configmap: %v", err)
-		return nil, false, err
+	willMergeConfigOverrides := len(unsupportedConfigOverride) != 0
+	if willMergeConfigOverrides {
+		klog.V(4).Infoln(fmt.Sprintf("with UnsupportedConfigOverrides: %v", string(unsupportedConfigOverride)))
 	}
 
-	outConfigYaml, err := yaml2.JSONToYAML(mergedConfig)
+	merger := &consoleserver.ConsoleYAMLMerger{}
+	mergedConfig, err := merger.Merge(
+		defaultConfig,
+		extractedManagedConfig,
+		userDefinedConfig,
+		unsupportedConfigOverride)
 	if err != nil {
 		klog.Errorf("failed to generate configmap: %v", err)
 		return nil, false, err
 	}
 
-	// if we actually merged config overrides, log this information
-	didMerge := len(operatorConfig.Spec.UnsupportedConfigOverrides.Raw) != 0
-	if didMerge {
-		klog.V(4).Infoln(fmt.Sprintf("with UnsupportedConfigOverrides: %v", string(unsupportedConfigOverride)))
-	}
-
 	configMap := Stub()
 	configMap.Data = map[string]string{}
-	configMap.Data[consoleConfigYamlFile] = string(outConfigYaml)
+	configMap.Data[consoleConfigYamlFile] = string(mergedConfig)
 	util.AddOwnerRef(configMap, util.OwnerRefFrom(operatorConfig))
 
-	return configMap, didMerge, nil
+	return configMap, willMergeConfigOverrides, nil
 }
 
 func DefaultPublicConfig(consoleURL string) *corev1.ConfigMap {
@@ -119,93 +118,6 @@ func Stub() *corev1.ConfigMap {
 		ObjectMeta: meta,
 	}
 	return configMap
-}
-
-func NewYamlConfig(host string, logoutRedirect string, brand operatorv1.Brand, docURL string, apiServerURL string, providers operatorv1.ConsoleProviders) []byte {
-	conf := yaml.MapSlice{
-		{
-			Key: "kind", Value: "ConsoleConfig",
-		}, {
-			Key: "apiVersion", Value: "console.openshift.io/v1",
-		}, {
-			Key: "auth", Value: authServerYaml(logoutRedirect),
-		}, {
-			Key: "clusterInfo", Value: clusterInfo(host, apiServerURL),
-		}, {
-			Key: "customization", Value: customization(brand, docURL),
-		}, {
-			Key: "servingInfo", Value: servingInfo(),
-		}, {
-			Key: "providers", Value: consoleProviders(providers),
-		},
-	}
-	yml, err := yaml.Marshal(conf)
-	if err != nil {
-		klog.V(4).Infof("Could not create config yaml %v", err)
-		return nil
-	}
-	return yml
-}
-
-func servingInfo() yaml.MapSlice {
-	return yaml.MapSlice{
-		{
-			Key: "bindAddress", Value: "https://0.0.0.0:8443",
-		}, {
-			Key: "certFile", Value: certFilePath,
-		}, {
-			Key: "keyFile", Value: keyFilePath,
-		},
-	}
-}
-
-func consoleProviders(providers operatorv1.ConsoleProviders) yaml.MapSlice {
-	if providers.Statuspage != nil && len(providers.Statuspage.PageID) > 0 {
-		return yaml.MapSlice{
-			{
-				Key: "statuspageID", Value: providers.Statuspage.PageID,
-			},
-		}
-	}
-	return yaml.MapSlice{}
-}
-
-func customization(brand operatorv1.Brand, docURL string) map[string]string {
-	tmpMap := make(map[string]string)
-	if brand != "" {
-		tmpMap["branding"] = string(brand)
-	}
-	if docURL != "" {
-		tmpMap["documentationBaseURL"] = docURL
-	}
-	return tmpMap
-}
-
-func clusterInfo(host string, apiServerURL string) yaml.MapSlice {
-	return yaml.MapSlice{
-		{
-			Key: "consoleBaseAddress", Value: consoleBaseAddr(host),
-		}, {
-			Key: "consoleBasePath", Value: "",
-		}, {
-			Key: "masterPublicURL", Value: apiServerURL,
-		},
-	}
-
-}
-
-func authServerYaml(logoutRedirect string) yaml.MapSlice {
-	return yaml.MapSlice{
-		{
-			Key: "clientID", Value: api.OpenShiftConsoleName,
-		}, {
-			Key: "clientSecretFile", Value: clientSecretFilePath,
-		}, {
-			Key: "logoutRedirect", Value: logoutRedirect,
-		}, {
-			Key: "oauthEndpointCAFile", Value: oauthEndpointCAFilePath,
-		},
-	}
 }
 
 func consoleBaseAddr(host string) string {

--- a/pkg/console/subresource/configmap/configmap_test.go
+++ b/pkg/console/subresource/configmap/configmap_test.go
@@ -23,94 +23,6 @@ const (
 	mockConsoleURL     = "https://console-openshift-console.apps.some.cluster.openshift.com"
 	configKey          = "console-config.yaml"
 	mockOperatorDocURL = "https://operator.config/doc/link/"
-	mockStatuspageID   = "id-1234"
-	finalCMDefaultOKD  = `kind: ConsoleConfig
-apiVersion: console.openshift.io/v1
-auth:
-  clientID: console
-  clientSecretFile: /var/oauth-config/clientSecret
-  logoutRedirect: ""
-  oauthEndpointCAFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-clusterInfo:
-  consoleBaseAddress: https://` + host + `
-  consoleBasePath: ""
-  masterPublicURL: ` + mockAPIServer + `
-customization:
-  branding: ` + DEFAULT_BRAND + `
-  documentationBaseURL: ` + DEFAULT_DOC_URL + `
-servingInfo:
-  bindAddress: https://0.0.0.0:8443
-  certFile: /var/serving-cert/tls.crt
-  keyFile: /var/serving-cert/tls.key
-providers: {}
-`
-	finalCMStatuspageProvider = `kind: ConsoleConfig
-apiVersion: console.openshift.io/v1
-auth:
-  clientID: console
-  clientSecretFile: /var/oauth-config/clientSecret
-  logoutRedirect: ""
-  oauthEndpointCAFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-clusterInfo:
-  consoleBaseAddress: https://` + host + `
-  consoleBasePath: ""
-  masterPublicURL: ` + mockAPIServer + `
-customization:
-  branding: ` + DEFAULT_BRAND + `
-  documentationBaseURL: ` + DEFAULT_DOC_URL + `
-servingInfo:
-  bindAddress: https://0.0.0.0:8443
-  certFile: /var/serving-cert/tls.crt
-  keyFile: /var/serving-cert/tls.key
-providers:
-  statuspageID: id-1234
-`
-	finalCMOnline = `kind: ConsoleConfig
-apiVersion: console.openshift.io/v1
-customization:
-  branding: online
-  documentationBaseURL: https://docs.okd.io/4.1/
-`
-	managedCMOnline = `kind: ConsoleConfig
-apiVersion: console.openshift.io/v1
-auth:
-  clientID: console
-  clientSecretFile: /var/oauth-config/clientSecret
-  logoutRedirect: ""
-  oauthEndpointCAFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-clusterInfo:
-  consoleBaseAddress: https://` + host + `
-  consoleBasePath: ""
-  masterPublicURL: ` + mockAPIServer + `
-customization:
-  branding: online 
-  documentationBaseURL: https://docs.okd.io/4.1/
-servingInfo:
-  bindAddress: https://0.0.0.0:8443
-  certFile: /var/serving-cert/tls.crt
-  keyFile: /var/serving-cert/tls.key
-providers: {}
-`
-	finalCMDedicated = `kind: ConsoleConfig
-apiVersion: console.openshift.io/v1
-auth:
-  clientID: console
-  clientSecretFile: /var/oauth-config/clientSecret
-  logoutRedirect: ""
-  oauthEndpointCAFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-clusterInfo:
-  consoleBaseAddress: https://` + host + `
-  consoleBasePath: ""
-  masterPublicURL: ` + mockAPIServer + `
-customization:
-  branding: ` + string(operatorv1.BrandDedicated) + `
-  documentationBaseURL: ` + mockOperatorDocURL + `
-servingInfo:
-  bindAddress: https://0.0.0.0:8443
-  certFile: /var/serving-cert/tls.crt
-  keyFile: /var/serving-cert/tls.key
-providers: {}
-`
 )
 
 // To manually run these tests: go test -v ./pkg/console/subresource/configmap/...
@@ -151,7 +63,25 @@ func TestDefaultConfigMap(t *testing.T) {
 					Labels:      map[string]string{"app": api.OpenShiftConsoleName},
 					Annotations: map[string]string{},
 				},
-				Data: map[string]string{configKey: finalCMDefaultOKD},
+				Data: map[string]string{configKey: `kind: ConsoleConfig
+apiVersion: console.openshift.io/v1
+auth:
+  clientID: console
+  clientSecretFile: /var/oauth-config/clientSecret
+  oauthEndpointCAFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+clusterInfo:
+  consoleBaseAddress: https://` + host + `
+  masterPublicURL: ` + mockAPIServer + `
+customization:
+  branding: ` + DEFAULT_BRAND + `
+  documentationBaseURL: ` + DEFAULT_DOC_URL + `
+servingInfo:
+  bindAddress: https://0.0.0.0:8443
+  certFile: /var/serving-cert/tls.crt
+  keyFile: /var/serving-cert/tls.key
+providers: {}
+`,
+				},
 			},
 		},
 		{
@@ -160,7 +90,13 @@ func TestDefaultConfigMap(t *testing.T) {
 				operatorConfig: &operatorv1.Console{},
 				consoleConfig:  &configv1.Console{},
 				managedConfig: &corev1.ConfigMap{
-					Data: map[string]string{configKey: finalCMOnline},
+					Data: map[string]string{configKey: `kind: ConsoleConfig
+apiVersion: console.openshift.io/v1
+customization:
+  branding: online
+  documentationBaseURL: https://docs.okd.io/4.1/
+`,
+					},
 				},
 				infrastructureConfig: &configv1.Infrastructure{
 					Status: configv1.InfrastructureStatus{
@@ -180,7 +116,25 @@ func TestDefaultConfigMap(t *testing.T) {
 					Labels:      map[string]string{"app": api.OpenShiftConsoleName},
 					Annotations: map[string]string{},
 				},
-				Data: map[string]string{configKey: managedCMOnline},
+				Data: map[string]string{configKey: `kind: ConsoleConfig
+apiVersion: console.openshift.io/v1
+auth:
+  clientID: console
+  clientSecretFile: /var/oauth-config/clientSecret
+  oauthEndpointCAFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+clusterInfo:
+  consoleBaseAddress: https://` + host + `
+  masterPublicURL: ` + mockAPIServer + `
+customization:
+  branding: online 
+  documentationBaseURL: https://docs.okd.io/4.1/
+servingInfo:
+  bindAddress: https://0.0.0.0:8443
+  certFile: /var/serving-cert/tls.crt
+  keyFile: /var/serving-cert/tls.key
+providers: {}
+`,
+				},
 			},
 		},
 		{
@@ -198,7 +152,13 @@ func TestDefaultConfigMap(t *testing.T) {
 				},
 				consoleConfig: &configv1.Console{},
 				managedConfig: &corev1.ConfigMap{
-					Data: map[string]string{configKey: finalCMOnline},
+					Data: map[string]string{configKey: `kind: ConsoleConfig
+apiVersion: console.openshift.io/v1
+customization:
+  branding: online
+  documentationBaseURL: https://docs.okd.io/4.1/
+`,
+					},
 				},
 				infrastructureConfig: &configv1.Infrastructure{
 					Status: configv1.InfrastructureStatus{
@@ -218,7 +178,92 @@ func TestDefaultConfigMap(t *testing.T) {
 					Labels:      map[string]string{"app": api.OpenShiftConsoleName},
 					Annotations: map[string]string{},
 				},
-				Data: map[string]string{configKey: finalCMDedicated},
+				Data: map[string]string{configKey: `kind: ConsoleConfig
+apiVersion: console.openshift.io/v1
+auth:
+  clientID: console
+  clientSecretFile: /var/oauth-config/clientSecret
+  oauthEndpointCAFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+clusterInfo:
+  consoleBaseAddress: https://` + host + `
+  masterPublicURL: ` + mockAPIServer + `
+customization:
+  branding: ` + string(operatorv1.BrandDedicated) + `
+  documentationBaseURL: ` + mockOperatorDocURL + `
+servingInfo:
+  bindAddress: https://0.0.0.0:8443
+  certFile: /var/serving-cert/tls.crt
+  keyFile: /var/serving-cert/tls.key
+providers: {}
+`,
+				},
+			},
+		}, {
+			name: "Test operator config with Statuspage pageID",
+			args: args{
+				operatorConfig: &operatorv1.Console{
+					Spec: operatorv1.ConsoleSpec{
+						OperatorSpec: operatorv1.OperatorSpec{},
+						Customization: operatorv1.ConsoleCustomization{
+							Brand:                operatorv1.BrandDedicated,
+							DocumentationBaseURL: mockOperatorDocURL,
+						},
+						Providers: operatorv1.ConsoleProviders{
+							Statuspage: &operatorv1.StatuspageProvider{
+								PageID: "id-1234",
+							},
+						},
+					},
+					Status: operatorv1.ConsoleStatus{},
+				},
+				consoleConfig: &configv1.Console{},
+				managedConfig: &corev1.ConfigMap{
+					Data: map[string]string{configKey: `kind: ConsoleConfig
+apiVersion: console.openshift.io/v1
+customization:
+  branding: online
+  documentationBaseURL: https://docs.okd.io/4.1/
+`,
+					},
+				},
+				infrastructureConfig: &configv1.Infrastructure{
+					Status: configv1.InfrastructureStatus{
+						APIServerURL: mockAPIServer,
+					},
+				},
+				rt: &routev1.Route{
+					Spec: routev1.RouteSpec{
+						Host: host,
+					},
+				},
+			},
+			want: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        api.OpenShiftConsoleConfigMapName,
+					Namespace:   api.OpenShiftConsoleNamespace,
+					Labels:      map[string]string{"app": api.OpenShiftConsoleName},
+					Annotations: map[string]string{},
+				},
+				Data: map[string]string{configKey: `kind: ConsoleConfig
+apiVersion: console.openshift.io/v1
+auth:
+  clientID: console
+  clientSecretFile: /var/oauth-config/clientSecret
+  oauthEndpointCAFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+clusterInfo:
+  consoleBaseAddress: https://` + host + `
+  masterPublicURL: ` + mockAPIServer + `
+customization:
+  branding: ` + string(operatorv1.BrandDedicated) + `
+  documentationBaseURL: ` + mockOperatorDocURL + `
+servingInfo:
+  bindAddress: https://0.0.0.0:8443
+  certFile: /var/serving-cert/tls.crt
+  keyFile: /var/serving-cert/tls.key
+providers: 
+  statuspageID: id-1234
+`,
+				},
 			},
 		},
 	}
@@ -318,60 +363,6 @@ func TestDefaultPublicConfigMap(t *testing.T) {
 	}
 }
 
-// This unit test relies on both NewYamlConfig and NewYamlConfigString
-// to ensure the serialized data is created from host name
-func TestNewYamlConfig(t *testing.T) {
-	type args struct {
-		host           string
-		logoutRedirect string
-		brand          operatorv1.Brand
-		docURL         string
-		apiServerURL   string
-		providers      operatorv1.ConsoleProviders
-	}
-	tests := []struct {
-		name string
-		args args
-		want string
-	}{
-		{
-			name: "Test NewYamlConfig() with defaults",
-			args: args{
-				host:           host,
-				logoutRedirect: "",
-				brand:          DEFAULT_BRAND,
-				docURL:         DEFAULT_DOC_URL,
-				apiServerURL:   mockAPIServer,
-				providers:      operatorv1.ConsoleProviders{},
-			},
-			want: finalCMDefaultOKD,
-		},
-		{
-			name: "Test NewYamlConfig() with Statuspage.io provider",
-			args: args{
-				host:           host,
-				logoutRedirect: "",
-				brand:          DEFAULT_BRAND,
-				docURL:         DEFAULT_DOC_URL,
-				apiServerURL:   mockAPIServer,
-				providers: operatorv1.ConsoleProviders{
-					Statuspage: &operatorv1.StatuspageProvider{
-						PageID: mockStatuspageID,
-					},
-				},
-			},
-			want: finalCMStatuspageProvider,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if diff := deep.Equal(string(NewYamlConfig(tt.args.host, tt.args.logoutRedirect, tt.args.brand, tt.args.docURL, tt.args.apiServerURL, tt.args.providers)), tt.want); diff != nil {
-				t.Error(diff)
-			}
-		})
-	}
-}
-
 func Test_consoleBaseAddr(t *testing.T) {
 	type args struct {
 		host string
@@ -419,7 +410,13 @@ func Test_extractYAML(t *testing.T) {
 						Name:      "console-config",
 						Namespace: "openshift-config-managed",
 					},
-					Data:       map[string]string{configKey: finalCMOnline},
+					Data: map[string]string{configKey: `kind: ConsoleConfig
+apiVersion: console.openshift.io/v1
+customization:
+  branding: online
+  documentationBaseURL: https://docs.okd.io/4.1/
+`,
+					},
 					BinaryData: nil,
 				},
 			},

--- a/pkg/console/subresource/consoleserver/config.go
+++ b/pkg/console/subresource/consoleserver/config.go
@@ -1,0 +1,65 @@
+package consoleserver
+
+// This file is a copy of the struct within the console itself:
+//   https://github.com/openshift/console/blob/master/cmd/bridge/config.go
+// These structs need to remain in sync.
+//
+// `yaml:",omitempty"` has not been applied to any of the properties currently
+// in use by the operator.  This is for backwards compatibilty purposes. If
+// we have been sending an empty string value, we will continue to send it.
+// Anything we have not been explicitly setting should have the `yaml:",omitempty"` tag.
+
+// Config is the top-level console server cli configuration.
+type Config struct {
+	APIVersion    string `yaml:"apiVersion"`
+	Kind          string `yaml:"kind"`
+	ServingInfo   `yaml:"servingInfo"`
+	ClusterInfo   `yaml:"clusterInfo"`
+	Auth          `yaml:"auth"`
+	Customization `yaml:"customization"`
+	Providers     `yaml:"providers"`
+}
+
+// ServingInfo holds configuration for serving HTTP.
+type ServingInfo struct {
+	BindAddress string `yaml:"bindAddress,omitempty"`
+	CertFile    string `yaml:"certFile,omitempty"`
+	KeyFile     string `yaml:"keyFile,omitempty"`
+
+	// These fields are defined in `HTTPServingInfo`, but are not supported for console. Fail if any are specified.
+	// https://github.com/openshift/api/blob/0cb4131a7636e1ada6b2769edc9118f0fe6844c8/config/v1/types.go#L7-L38
+	BindNetwork           string        `yaml:"bindNetwork,omitempty"`
+	ClientCA              string        `yaml:"clientCA,omitempty"`
+	NamedCertificates     []interface{} `yaml:"namedCertificates,omitempty"`
+	MinTLSVersion         string        `yaml:"minTLSVersion,omitempty"`
+	CipherSuites          []string      `yaml:"cipherSuites,omitempty"`
+	MaxRequestsInFlight   int64         `yaml:"maxRequestsInFlight,omitempty"`
+	RequestTimeoutSeconds int64         `yaml:"requestTimeoutSeconds,omitempty"`
+}
+
+// ClusterInfo holds information the about the cluster such as master public URL and console public URL.
+type ClusterInfo struct {
+	ConsoleBaseAddress string `yaml:"consoleBaseAddress,omitempty"`
+	ConsoleBasePath    string `yaml:"consoleBasePath,omitempty"`
+	MasterPublicURL    string `yaml:"masterPublicURL,omitempty"`
+}
+
+// Auth holds configuration for authenticating with OpenShift. The auth method is assumed to be "openshift".
+type Auth struct {
+	ClientID            string `yaml:"clientID,omitempty"`
+	ClientSecretFile    string `yaml:"clientSecretFile,omitempty"`
+	OAuthEndpointCAFile string `yaml:"oauthEndpointCAFile,omitempty"`
+	LogoutRedirect      string `yaml:"logoutRedirect,omitempty"`
+}
+
+// Customization holds configuration such as what logo to use.
+type Customization struct {
+	Branding             string `yaml:"branding,omitempty"`
+	DocumentationBaseURL string `yaml:"documentationBaseURL,omitempty"`
+	CustomProductName    string `yaml:"customProductName,omitempty"`
+	CustomLogoFile       string `yaml:"customLogoFile,omitempty"`
+}
+
+type Providers struct {
+	StatuspageID string `yaml:"statuspageID,omitempty"`
+}

--- a/pkg/console/subresource/consoleserver/config_builder.go
+++ b/pkg/console/subresource/consoleserver/config_builder.go
@@ -1,0 +1,144 @@
+package consoleserver
+
+import (
+	operatorv1 "github.com/openshift/api/operator/v1"
+	"github.com/openshift/console-operator/pkg/api"
+	"github.com/openshift/console-operator/pkg/console/subresource/util"
+	yaml "gopkg.in/yaml.v2"
+	"k8s.io/klog"
+)
+
+const (
+	clientSecretFilePath    = "/var/oauth-config/clientSecret"
+	oauthEndpointCAFilePath = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+	// serving info
+	certFilePath = "/var/serving-cert/tls.crt"
+	keyFilePath  = "/var/serving-cert/tls.key"
+)
+
+// ConsoleServerCLIConfigBuilder
+// Director will be DefaultConfigMap()
+//
+// b := ConsoleYamlConfigBuilder{}
+// return the default config value immediately:
+//   b.Config()
+//   b.ConfigYAML()
+// set all the values:
+//   b.Host(host).LogoutURL("").Brand("").DocURL("").APIServerURL("").Config()
+// set only some values:
+//   b.Host().Brand("").Config()
+type ConsoleServerCLIConfigBuilder struct {
+	host              string
+	logoutRedirectURL string
+	brand             operatorv1.Brand
+	docURL            string
+	apiServerURL      string
+	statusPageID      string
+	// TODO: pipe these in when they are added via the future custom branding PR
+	// This should be trivial
+	customProductName string
+	customLogoFile    string
+}
+
+func (b *ConsoleServerCLIConfigBuilder) Host(host string) *ConsoleServerCLIConfigBuilder {
+	b.host = host
+	return b
+}
+func (b *ConsoleServerCLIConfigBuilder) LogoutURL(logoutRedirectURL string) *ConsoleServerCLIConfigBuilder {
+	b.logoutRedirectURL = logoutRedirectURL
+	return b
+}
+func (b *ConsoleServerCLIConfigBuilder) Brand(brand operatorv1.Brand) *ConsoleServerCLIConfigBuilder {
+	b.brand = brand
+	return b
+}
+func (b *ConsoleServerCLIConfigBuilder) DocURL(docURL string) *ConsoleServerCLIConfigBuilder {
+	b.docURL = docURL
+	return b
+}
+func (b *ConsoleServerCLIConfigBuilder) APIServerURL(apiServerURL string) *ConsoleServerCLIConfigBuilder {
+	b.apiServerURL = apiServerURL
+	return b
+}
+
+func (b *ConsoleServerCLIConfigBuilder) StatusPageID(id string) *ConsoleServerCLIConfigBuilder {
+	b.statusPageID = id
+	return b
+}
+
+func (b *ConsoleServerCLIConfigBuilder) Config() Config {
+	return Config{
+		Kind:          "ConsoleConfig",
+		APIVersion:    "console.openshift.io/v1",
+		Auth:          b.authServer(),
+		ClusterInfo:   b.clusterInfo(),
+		Customization: b.customization(),
+		ServingInfo:   b.servingInfo(),
+		Providers:     b.providers(),
+	}
+}
+
+func (b *ConsoleServerCLIConfigBuilder) ConfigYAML() (consoleConfigYAML []byte, marshallError error) {
+	conf := b.Config()
+	yml, err := yaml.Marshal(conf)
+	if err != nil {
+		klog.V(4).Infof("could not create config yaml %v", err)
+		return nil, err
+	}
+	return yml, nil
+}
+
+func (b *ConsoleServerCLIConfigBuilder) servingInfo() ServingInfo {
+	return ServingInfo{
+		BindAddress: "https://0.0.0.0:8443",
+		CertFile:    certFilePath,
+		KeyFile:     keyFilePath,
+	}
+}
+
+func (b *ConsoleServerCLIConfigBuilder) clusterInfo() ClusterInfo {
+	conf := ClusterInfo{
+		ConsoleBasePath: "",
+	}
+
+	if len(b.apiServerURL) > 0 {
+		conf.MasterPublicURL = b.apiServerURL
+	}
+	if len(b.host) > 0 {
+		conf.ConsoleBaseAddress = util.HTTPS(b.host)
+	}
+	return conf
+}
+
+func (b *ConsoleServerCLIConfigBuilder) authServer() Auth {
+	conf := Auth{
+		ClientID:            api.OpenShiftConsoleName,
+		ClientSecretFile:    clientSecretFilePath,
+		OAuthEndpointCAFile: oauthEndpointCAFilePath,
+	}
+	if len(b.logoutRedirectURL) > 0 {
+		conf.LogoutRedirect = b.logoutRedirectURL
+	}
+	return conf
+}
+
+func (b *ConsoleServerCLIConfigBuilder) customization() Customization {
+	conf := Customization{}
+	if len(b.brand) > 0 {
+		conf.Branding = string(b.brand)
+	}
+	if len(b.docURL) > 0 {
+		conf.DocumentationBaseURL = b.docURL
+	}
+	return conf
+
+}
+
+func (b *ConsoleServerCLIConfigBuilder) providers() Providers {
+	if len(b.statusPageID) > 0 {
+		return Providers{
+			StatuspageID: b.statusPageID,
+		}
+	}
+	return Providers{}
+}

--- a/pkg/console/subresource/consoleserver/config_builder_test.go
+++ b/pkg/console/subresource/consoleserver/config_builder_test.go
@@ -1,0 +1,278 @@
+package consoleserver
+
+import (
+	"testing"
+
+	v1 "github.com/openshift/api/operator/v1"
+
+	"github.com/openshift/console-operator/pkg/api"
+
+	"github.com/go-test/deep"
+)
+
+// Tests that the builder will return a correctly structured
+// Console Server Config struct when builder.Config() is called
+func TestConsoleServerCLIConfigBuilder(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  func() Config
+		output Config
+	}{
+		{
+			name: "Config builder should return default config if given no inputs",
+			input: func() Config {
+				b := &ConsoleServerCLIConfigBuilder{}
+				return b.Config()
+			},
+			output: Config{
+				Kind:       "ConsoleConfig",
+				APIVersion: "console.openshift.io/v1",
+				ServingInfo: ServingInfo{
+					BindAddress: "https://0.0.0.0:8443",
+					CertFile:    certFilePath,
+					KeyFile:     keyFilePath,
+				},
+				ClusterInfo: ClusterInfo{
+					ConsoleBasePath: "",
+				},
+				Auth: Auth{
+					ClientID:            api.OpenShiftConsoleName,
+					ClientSecretFile:    clientSecretFilePath,
+					OAuthEndpointCAFile: oauthEndpointCAFilePath,
+				},
+				Customization: Customization{},
+				Providers:     Providers{},
+			},
+		}, {
+			name: "Config builder should handle cluster info",
+			input: func() Config {
+				b := &ConsoleServerCLIConfigBuilder{}
+				return b.
+					APIServerURL("https://foobar.com/api").
+					Host("https://foobar.com/host").
+					LogoutURL("https://foobar.com/logout").
+					Config()
+			},
+			output: Config{
+				Kind:       "ConsoleConfig",
+				APIVersion: "console.openshift.io/v1",
+				ServingInfo: ServingInfo{
+					BindAddress: "https://0.0.0.0:8443",
+					CertFile:    certFilePath,
+					KeyFile:     keyFilePath,
+				},
+				ClusterInfo: ClusterInfo{
+					ConsoleBasePath:    "",
+					ConsoleBaseAddress: "https://foobar.com/host",
+					MasterPublicURL:    "https://foobar.com/api",
+				},
+				Auth: Auth{
+					ClientID:            api.OpenShiftConsoleName,
+					ClientSecretFile:    clientSecretFilePath,
+					OAuthEndpointCAFile: oauthEndpointCAFilePath,
+					LogoutRedirect:      "https://foobar.com/logout",
+				},
+				Customization: Customization{},
+				Providers:     Providers{},
+			},
+		}, {
+			name: "Config builder should handle StatuspageID",
+			input: func() Config {
+				b := &ConsoleServerCLIConfigBuilder{}
+				return b.StatusPageID("status-12345").Config()
+			},
+			output: Config{
+				Kind:       "ConsoleConfig",
+				APIVersion: "console.openshift.io/v1",
+				ServingInfo: ServingInfo{
+					BindAddress: "https://0.0.0.0:8443",
+					CertFile:    certFilePath,
+					KeyFile:     keyFilePath,
+				},
+				ClusterInfo: ClusterInfo{
+					ConsoleBasePath: "",
+				},
+				Auth: Auth{
+					ClientID:            api.OpenShiftConsoleName,
+					ClientSecretFile:    clientSecretFilePath,
+					OAuthEndpointCAFile: oauthEndpointCAFilePath,
+				},
+				Customization: Customization{},
+				Providers: Providers{
+					StatuspageID: "status-12345",
+				},
+			},
+		}, {
+			name: "Config builder should handle all inputs",
+			input: func() Config {
+				b := &ConsoleServerCLIConfigBuilder{}
+				b.Host("").
+					LogoutURL("https://foobar.com/logout").
+					Brand(v1.BrandOKD).
+					DocURL("https://foobar.com/docs").
+					APIServerURL("https://foobar.com/api").
+					StatusPageID("status-12345")
+				return b.Config()
+			},
+			output: Config{
+				Kind:       "ConsoleConfig",
+				APIVersion: "console.openshift.io/v1",
+				ServingInfo: ServingInfo{
+					BindAddress: "https://0.0.0.0:8443",
+					CertFile:    certFilePath,
+					KeyFile:     keyFilePath,
+				},
+				ClusterInfo: ClusterInfo{
+					ConsoleBasePath: "",
+					MasterPublicURL: "https://foobar.com/api",
+				},
+				Auth: Auth{
+					ClientID:            api.OpenShiftConsoleName,
+					ClientSecretFile:    clientSecretFilePath,
+					OAuthEndpointCAFile: oauthEndpointCAFilePath,
+					LogoutRedirect:      "https://foobar.com/logout",
+				},
+				Customization: Customization{
+					Branding:             "okd",
+					DocumentationBaseURL: "https://foobar.com/docs",
+				},
+				Providers: Providers{
+					StatuspageID: "status-12345",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if diff := deep.Equal(tt.input(), tt.output); diff != nil {
+				t.Error(diff)
+			}
+		})
+	}
+}
+
+// Tests that the builder will return correctly formatted YAML representing a
+// Console Server Config struct when builder.ConfigYAML() is called.
+// This YAML should be an exact representation of the struct from builder.Config()
+// and the output should make use of the YAML tags embedded in the structs
+// in config.go
+func TestConsoleServerCLIConfigBuilderYAML(t *testing.T) {
+	tests := []struct {
+		name  string
+		input func() ([]byte, error)
+		// tests the YAML conversion output of the configmap
+		output string
+	}{
+		{
+			name: "Config builder should return default config if given no inputs",
+			input: func() ([]byte, error) {
+				b := &ConsoleServerCLIConfigBuilder{}
+				return b.ConfigYAML()
+			},
+			output: `apiVersion: console.openshift.io/v1
+kind: ConsoleConfig
+servingInfo:
+  bindAddress: https://0.0.0.0:8443
+  certFile: /var/serving-cert/tls.crt
+  keyFile: /var/serving-cert/tls.key
+clusterInfo: {}
+auth:
+  clientID: console
+  clientSecretFile: /var/oauth-config/clientSecret
+  oauthEndpointCAFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+customization: {}
+providers: {}
+`,
+		},
+		{
+			name: "Config builder should handle cluster info",
+			input: func() ([]byte, error) {
+				b := &ConsoleServerCLIConfigBuilder{}
+				return b.
+					APIServerURL("https://foobar.com/api").
+					Host("https://foobar.com/host").
+					LogoutURL("https://foobar.com/logout").
+					ConfigYAML()
+			},
+			output: `apiVersion: console.openshift.io/v1
+kind: ConsoleConfig
+servingInfo:
+  bindAddress: https://0.0.0.0:8443
+  certFile: /var/serving-cert/tls.crt
+  keyFile: /var/serving-cert/tls.key
+clusterInfo:
+  consoleBaseAddress: https://foobar.com/host
+  masterPublicURL: https://foobar.com/api
+auth:
+  clientID: console
+  clientSecretFile: /var/oauth-config/clientSecret
+  oauthEndpointCAFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+  logoutRedirect: https://foobar.com/logout
+customization: {}
+providers: {}
+`,
+		},
+		{
+			name: "Config builder should handle StatuspageID",
+			input: func() ([]byte, error) {
+				b := &ConsoleServerCLIConfigBuilder{}
+				return b.StatusPageID("status-12345").ConfigYAML()
+			},
+			output: `apiVersion: console.openshift.io/v1
+kind: ConsoleConfig
+servingInfo:
+  bindAddress: https://0.0.0.0:8443
+  certFile: /var/serving-cert/tls.crt
+  keyFile: /var/serving-cert/tls.key
+clusterInfo: {}
+auth:
+  clientID: console
+  clientSecretFile: /var/oauth-config/clientSecret
+  oauthEndpointCAFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+customization: {}
+providers:
+  statuspageID: status-12345
+`,
+		},
+		{
+			name: "Config builder should handle all inputs",
+			input: func() ([]byte, error) {
+				b := &ConsoleServerCLIConfigBuilder{}
+				b.Host("").
+					LogoutURL("https://foobar.com/logout").
+					Brand(v1.BrandOKD).
+					DocURL("https://foobar.com/docs").
+					APIServerURL("https://foobar.com/api").
+					StatusPageID("status-12345")
+				return b.ConfigYAML()
+			},
+			output: `apiVersion: console.openshift.io/v1
+kind: ConsoleConfig
+servingInfo:
+  bindAddress: https://0.0.0.0:8443
+  certFile: /var/serving-cert/tls.crt
+  keyFile: /var/serving-cert/tls.key
+clusterInfo:
+  masterPublicURL: https://foobar.com/api
+auth:
+  clientID: console
+  clientSecretFile: /var/oauth-config/clientSecret
+  oauthEndpointCAFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+  logoutRedirect: https://foobar.com/logout
+customization:
+  branding: okd
+  documentationBaseURL: https://foobar.com/docs
+providers:
+  statuspageID: status-12345
+`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input, _ := tt.input()
+			if diff := deep.Equal(string(input), tt.output); diff != nil {
+				t.Error(diff)
+			}
+		})
+	}
+}

--- a/pkg/console/subresource/consoleserver/config_merger.go
+++ b/pkg/console/subresource/consoleserver/config_merger.go
@@ -1,0 +1,24 @@
+package consoleserver
+
+import (
+	yaml2 "github.com/ghodss/yaml"
+	"github.com/openshift/library-go/pkg/operator/resource/resourcemerge"
+)
+
+type ConsoleYAMLMerger struct{}
+
+func (b *ConsoleYAMLMerger) Merge(configYAMLs ...[]byte) (converted []byte, conversionErr error) {
+	mergedConfig, err := b.combine(configYAMLs...)
+	if err != nil {
+		return nil, err
+	}
+	return yaml2.JSONToYAML(mergedConfig)
+}
+
+func (b *ConsoleYAMLMerger) combine(configYAMLs ...[]byte) (mergedConfig []byte, mergeError error) {
+	mergedConfig, err := resourcemerge.MergeProcessConfig(nil, configYAMLs...)
+	if err != nil {
+		return nil, err
+	}
+	return mergedConfig, nil
+}

--- a/pkg/console/subresource/consoleserver/config_merger_test.go
+++ b/pkg/console/subresource/consoleserver/config_merger_test.go
@@ -1,0 +1,73 @@
+package consoleserver
+
+import (
+	"testing"
+
+	"github.com/go-test/deep"
+	v1 "github.com/openshift/api/operator/v1"
+)
+
+func TestConfigMerger(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  func() ([]byte, error)
+		output string
+	}{
+		{
+			name: "Merger should accept several configs and return a single merged config",
+			input: func() ([]byte, error) {
+				b1 := &ConsoleServerCLIConfigBuilder{}
+				conf1, _ := b1.ConfigYAML()
+
+				b2 := &ConsoleServerCLIConfigBuilder{}
+				conf2, _ := b2.
+					APIServerURL("https://shizzlepop.com/api").
+					Host("https://console-openshift-console.apps.shizzlepop.com").
+					LogoutURL("https://shizzlepop.com/logout").
+					ConfigYAML()
+
+				b3 := &ConsoleServerCLIConfigBuilder{}
+				b3.
+					Host("https://console-openshift-console.apps.foobar.com").
+					LogoutURL("https://foobar.com/logout").
+					Brand(v1.BrandOKD).
+					DocURL("https://foobar.com/docs").
+					APIServerURL("https://foobar.com/api").
+					StatusPageID("status-12345")
+				conf3, _ := b3.ConfigYAML()
+
+				merger := ConsoleYAMLMerger{}
+				return merger.Merge(conf1, conf2, conf3)
+			},
+			output: `apiVersion: console.openshift.io/v1
+auth:
+  clientID: console
+  clientSecretFile: /var/oauth-config/clientSecret
+  logoutRedirect: https://foobar.com/logout
+  oauthEndpointCAFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+clusterInfo:
+  consoleBaseAddress: https://console-openshift-console.apps.foobar.com
+  masterPublicURL: https://foobar.com/api
+customization:
+  branding: okd
+  documentationBaseURL: https://foobar.com/docs
+kind: ConsoleConfig
+providers:
+  statuspageID: status-12345
+servingInfo:
+  bindAddress: https://0.0.0.0:8443
+  certFile: /var/serving-cert/tls.crt
+  keyFile: /var/serving-cert/tls.key
+`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input, _ := tt.input()
+			if diff := deep.Equal(string(input), tt.output); diff != nil {
+				t.Error(diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Now that we've released & have decent test coverage, its worth looking at the codebase to see what we can improve.  I think our `DefaultConfigmap()` func has gotten to be quite the beast.  This refactor would impl the builder pattern to build up the several intermediate configs we create in the func. 

- Clarifies related work as a chain, example: `builder.Host(host).LogoutURL(url).Brand(brand)`
- Inlines the `yaml` directly into the unit tests.  This may seem like more duplication, but I believe best practices for testing is to keep all the inputs & outputs within the test func and not to share across tests.  

TODO:
- [x] write some tests for the Builder itself.  `TestDefaultConfigmap()` continues to pass, so that assures the internals are functioning correctly. 

/assign @jhadvig 
