### PR TITLE
Improve cluster operator status reporting during upgrades

### DIFF
--- a/pkg/console/operator/status.go
+++ b/pkg/console/operator/status.go
@@ -133,10 +133,11 @@ func (c *consoleOperator) ConditionResourceSyncSuccess(operatorConfig *operators
 	return operatorConfig
 }
 
-func (c *consoleOperator) ConditionDeploymentAvailable(operatorConfig *operatorsv1.Console) *operatorsv1.Console {
+func (c *consoleOperator) ConditionDeploymentAvailable(operatorConfig *operatorsv1.Console, message string) *operatorsv1.Console {
 	v1helpers.SetOperatorCondition(&operatorConfig.Status.Conditions, operatorsv1.OperatorCondition{
 		Type:               operatorsv1.OperatorStatusTypeAvailable,
 		Status:             operatorsv1.ConditionTrue,
+		Message:            message,
 		LastTransitionTime: metav1.Now(),
 	})
 


### PR DESCRIPTION
We should show the version as-is instead of stripping everything after
the `-`. Note for release versions, the version number will be short
like `4.1.1`. For prerelease builds, stripping content after `-` removes
the unique part of the version number.

We should also show informative messages in the cluster operator status
even when there are no errors.