### PR TITLE
Custom brand revisions

### DIFF
--- a/manifests/03-rbac-role-ns-openshift-config.yaml
+++ b/manifests/03-rbac-role-ns-openshift-config.yaml
@@ -1,0 +1,14 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: console-operator
+  namespace: openshift-config
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch

--- a/manifests/04-rbac-rolebinding.yaml
+++ b/manifests/04-rbac-rolebinding.yaml
@@ -65,3 +65,17 @@ subjects:
   - kind: Group
     name: system:authenticated
     apiGroup: rbac.authorization.k8s.io
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: console-operator
+  namespace: openshift-config
+roleRef:
+  kind: Role
+  name: console-operator
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: console-operator
+    namespace: openshift-console-operator

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -19,4 +19,6 @@ const (
 	OpenShiftConsoleRouteName           = OpenShiftConsoleName
 	OAuthClientName                     = OpenShiftConsoleName
 	OpenShiftConfigManagedNamespace     = "openshift-config-managed"
+	OpenShiftConfigNamespace            = "openshift-config"
+	OpenShiftCustomLogoConfigMap        = "custom-logo"
 )

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -20,5 +20,5 @@ const (
 	OAuthClientName                     = OpenShiftConsoleName
 	OpenShiftConfigManagedNamespace     = "openshift-config-managed"
 	OpenShiftConfigNamespace            = "openshift-config"
-	OpenShiftCustomLogoConfigMap        = "custom-logo"
+	OpenShiftCustomLogoConfigMapName    = "custom-logo"
 )

--- a/pkg/console/clientwrapper/without_secret.go
+++ b/pkg/console/clientwrapper/without_secret.go
@@ -1,0 +1,39 @@
+package clientwrapper
+
+import (
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+)
+
+func WithoutSecret(client kubernetes.Interface) kubernetes.Interface {
+	return &clientWrapper{
+		Interface: client,
+		core: &coreWrapper{
+			CoreV1Interface: client.CoreV1(),
+			secrets:         fake.NewSimpleClientset().CoreV1(),
+		},
+	}
+}
+
+type clientWrapper struct {
+	kubernetes.Interface
+	core *coreWrapper
+}
+
+func (c *clientWrapper) CoreV1() corev1.CoreV1Interface {
+	return c.core
+}
+
+func (c *clientWrapper) Secrets(namespace string) corev1.SecretInterface {
+	return c.core.Secrets(namespace)
+}
+
+type coreWrapper struct {
+	corev1.CoreV1Interface
+	secrets corev1.SecretsGetter
+}
+
+func (c *coreWrapper) Secrets(namespace string) corev1.SecretInterface {
+	return c.secrets.Secrets(namespace)
+}

--- a/pkg/console/errors/custom_logo_errors.go
+++ b/pkg/console/errors/custom_logo_errors.go
@@ -1,0 +1,22 @@
+package errors
+
+type CustomLogoError struct {
+	message string
+}
+
+// implement the error interface
+func (e *CustomLogoError) Error() string {
+	return e.message
+}
+
+func NewCustomLogoError(msg string) *CustomLogoError {
+	err := &CustomLogoError{
+		message: msg,
+	}
+	return err
+}
+
+func IsCustomLogoError(err error) bool {
+	_, ok := err.(*CustomLogoError)
+	return ok
+}

--- a/pkg/console/errors/custom_logo_errors_test.go
+++ b/pkg/console/errors/custom_logo_errors_test.go
@@ -1,0 +1,38 @@
+package errors
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/go-test/deep"
+)
+
+func TestIsCustomLogoError(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  error
+		output bool
+	}{
+		{
+			name:   "IsCustomLogoError returns true if passed a CustomLogoError",
+			input:  NewCustomLogoError("Yup, its a custom logo error"),
+			output: true,
+		}, {
+			name:   "IsCustomLogoError returns false if passed a regular Error",
+			input:  fmt.Errorf("A regular error"),
+			output: false,
+		}, {
+			name:   "IsCustomLogoError returns true if passed nil",
+			input:  nil,
+			output: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if diff := deep.Equal(IsCustomLogoError(tt.input), tt.output); diff != nil {
+				t.Error(diff)
+			}
+		})
+	}
+
+}

--- a/pkg/console/operator/operator.go
+++ b/pkg/console/operator/operator.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
+	"github.com/openshift/library-go/pkg/operator/resourcesynccontroller"
 	"github.com/openshift/library-go/pkg/operator/status"
 
 	"monis.app/go/openshift/operator"
@@ -68,7 +69,8 @@ type consoleOperator struct {
 	infrastructureConfigClient configclientv1.InfrastructureInterface
 	versionGetter              status.VersionGetter
 	// recorder
-	recorder events.Recorder
+	recorder       events.Recorder
+	resourceSyncer resourcesynccontroller.ResourceSyncer
 }
 
 func NewConsoleOperator(
@@ -92,6 +94,7 @@ func NewConsoleOperator(
 	versionGetter status.VersionGetter,
 	// recorder
 	recorder events.Recorder,
+	resourceSyncer resourcesynccontroller.ResourceSyncer,
 ) operator.Runner {
 	c := &consoleOperator{
 		// configs
@@ -109,7 +112,8 @@ func NewConsoleOperator(
 		oauthClient:   oauthv1Client,
 		versionGetter: versionGetter,
 		// recorder
-		recorder: recorder,
+		recorder:       recorder,
+		resourceSyncer: resourceSyncer,
 	}
 
 	secretsInformer := coreV1.Secrets()
@@ -132,7 +136,7 @@ func NewConsoleOperator(
 		operator.WithInformer(serviceInformer, targetNameFilter),
 		operator.WithInformer(oauthClients, targetNameFilter),
 		// special resources with unique names
-		operator.WithInformer(configMapInformer, operator.FilterByNames(api.OpenShiftConsoleConfigMapName, api.ServiceCAConfigMapName)),
+		operator.WithInformer(configMapInformer, operator.FilterByNames(api.OpenShiftConsoleConfigMapName, api.ServiceCAConfigMapName, api.OpenShiftCustomLogoConfigMap)),
 		operator.WithInformer(managedConfigMapInformer, operator.FilterByNames(api.OpenShiftConsoleConfigMapName, api.OpenShiftConsolePublicConfigMapName)),
 		operator.WithInformer(secretsInformer, operator.FilterByNames(deployment.ConsoleOauthConfigName)),
 	)
@@ -262,4 +266,46 @@ func (c *consoleOperator) removeConsole(cr *operatorsv1.Console) error {
 	errs = append(errs, updateConfigErr)
 
 	return utilerrors.FilterOut(utilerrors.NewAggregate(errs), errors.IsNotFound)
+}
+
+// TODO: SyncCustomLogoConfigMap
+// - when a sync loop is triggered, we need to check the operator config
+//   - if there is a custom logo defined in the operator config
+//     we need to update the resourceSyncer & ensure it knows to sync this (new?) logo configmap
+//   - sync as:
+//   	- source can be any <any-name> in openshift-config
+//      - destination must to be "custom-logo" in openshift-console
+func (c *consoleOperator) SyncCustomLogoConfigMap(operatorConfig *operatorsv1.Console) error {
+	// TODO: review this
+	c.CheckCustomLogoImageStatus(operatorConfig)
+	// TODO: if no name, then null it out via the sync
+	logoName := operatorConfig.Spec.Customization.CustomLogoFile.Name
+	if logoName != "" {
+		return c.resourceSyncer.SyncConfigMap(
+			resourcesynccontroller.ResourceLocation{Namespace: api.OpenShiftConsoleNamespace, Name: api.OpenShiftCustomLogoConfigMap},
+			resourcesynccontroller.ResourceLocation{Namespace: api.OpenShiftConfigNamespace, Name: logoName},
+		)
+	}
+	return nil
+}
+
+// TODO: visit this and see what we need to do to get it in the correct state
+// - we should not need to bury a call to c.SetStatusCondition down in here...
+func (c *consoleOperator) CheckCustomLogoImageStatus(operatorConfig *operatorsv1.Console) {
+	logo := operatorConfig.Spec.Customization.CustomLogoFile
+	if logo.Name != "" && logo.Key != "" {
+		//Check that configmap for custom logo exists
+		logoConfigMap, err := c.configMapClient.ConfigMaps(api.OpenShiftConfigNamespace).Get(logo.Name, metav1.GetOptions{})
+		if err != nil {
+			// Set Operator Status to CustomLogoInvalid
+			c.SetStatusCondition(operatorConfig, operatorsv1.OperatorStatusTypeDegraded, operatorsv1.ConditionTrue, reasonCustomLogoInvalid, "custom logo config map does not exist or has error")
+			klog.Errorf("customLogo configmap not valid, %v", err)
+		} else {
+			if logoConfigMap.BinaryData[logo.Key] == nil {
+				//Key does not exist so activate status condition
+				c.SetStatusCondition(operatorConfig, operatorsv1.OperatorStatusTypeDegraded, operatorsv1.ConditionTrue, reasonCustomLogoInvalid, "custom logo file does not exist ")
+				klog.Errorf("customLogo key is null")
+			}
+		}
+	}
 }

--- a/pkg/console/operator/status.go
+++ b/pkg/console/operator/status.go
@@ -58,6 +58,7 @@ const (
 	reasonSyncError           = "SynchronizationError"
 	reasonNoPodsAvailable     = "NoPodsAvailable"
 	reasonSyncLoopError       = "SyncLoopError"
+	reasonCustomLogoInvalid   = "CustomLogoInvalid"
 )
 
 // TODO:

--- a/pkg/console/operator/status.go
+++ b/pkg/console/operator/status.go
@@ -324,3 +324,29 @@ func (c *consoleOperator) ConditionsManagementStateInvalid(operatorConfig *opera
 
 	return operatorConfig
 }
+
+func (c *consoleOperator) ConditionsDefault(operatorConfig *operatorsv1.Console) *operatorsv1.Console {
+	v1helpers.SetOperatorCondition(&operatorConfig.Status.Conditions, operatorsv1.OperatorCondition{
+		Type:               operatorsv1.OperatorStatusTypeAvailable,
+		Status:             operatorsv1.ConditionTrue,
+		Reason:             reasonAsExpected,
+		Message:            "As expected",
+		LastTransitionTime: metav1.Now(),
+	})
+	v1helpers.SetOperatorCondition(&operatorConfig.Status.Conditions, operatorsv1.OperatorCondition{
+		Type:               operatorsv1.OperatorStatusTypeProgressing,
+		Status:             operatorsv1.ConditionFalse,
+		Reason:             reasonAsExpected,
+		Message:            "As expected",
+		LastTransitionTime: metav1.Now(),
+	})
+	v1helpers.SetOperatorCondition(&operatorConfig.Status.Conditions, operatorsv1.OperatorCondition{
+		Type:               operatorsv1.OperatorStatusTypeDegraded,
+		Status:             operatorsv1.ConditionFalse,
+		Reason:             reasonAsExpected,
+		Message:            "As expected",
+		LastTransitionTime: metav1.Now(),
+	})
+
+	return operatorConfig
+}

--- a/pkg/console/operator/sync_v400.go
+++ b/pkg/console/operator/sync_v400.go
@@ -107,6 +107,15 @@ func (co *consoleOperator) sync_v400(updatedOperatorConfig *operatorv1.Console, 
 	}
 	toUpdate = toUpdate || depChanged
 
+	// TODO: verify this
+	sErr := co.SyncCustomLogoConfigMap(updatedOperatorConfig)
+	if sErr != nil {
+		msg := fmt.Sprintf("%q: %v", "customLogoSync", sErr)
+		klog.V(4).Infof("incomplete sync: %v", msg)
+		co.ConditionResourceSyncProgressing(updatedOperatorConfig, msg)
+		return sErr
+	}
+
 	resourcemerge.SetDeploymentGeneration(&updatedOperatorConfig.Status.Generations, actualDeployment)
 	updatedOperatorConfig.Status.ObservedGeneration = set.Operator.ObjectMeta.Generation
 

--- a/pkg/console/operator/sync_v400.go
+++ b/pkg/console/operator/sync_v400.go
@@ -16,12 +16,14 @@ import (
 
 	// openshift
 	configv1 "github.com/openshift/api/config/v1"
+	operatorsv1 "github.com/openshift/api/operator/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	"github.com/openshift/console-operator/pkg/api"
 	"github.com/openshift/console-operator/pkg/console/subresource/util"
 	"github.com/openshift/console-operator/pkg/crypto"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
 	"github.com/openshift/library-go/pkg/operator/resource/resourcemerge"
+	"github.com/openshift/library-go/pkg/operator/resourcesynccontroller"
 
 	// operator
 	customerrors "github.com/openshift/console-operator/pkg/console/errors"
@@ -80,6 +82,15 @@ func (co *consoleOperator) sync_v400(updatedOperatorConfig *operatorv1.Console, 
 	}
 	toUpdate = toUpdate || serviceCAConfigMapChanged
 
+	customLogoCanMount, customLogoError := co.SyncCustomLogoConfigMap(updatedOperatorConfig)
+	if customLogoError != nil {
+		msg := fmt.Sprintf("%q: %v", "customlogoconfigmap", customLogoError)
+		klog.V(4).Infof("incomplete sync: %v", msg)
+		// If the custom logo sync fails for any reason, we are degraded, not progressing.
+		// The sync loop may not settle, we are unable to honor it in current state.
+		co.ConditionDegraded(updatedOperatorConfig, "CustomLogoInvalid", msg)
+	}
+
 	sec, secChanged, secErr := co.SyncSecret(set.Operator)
 	if secErr != nil {
 		msg := fmt.Sprintf("%q: %v", "secret", secErr)
@@ -98,7 +109,7 @@ func (co *consoleOperator) sync_v400(updatedOperatorConfig *operatorv1.Console, 
 	}
 	toUpdate = toUpdate || oauthChanged
 
-	actualDeployment, depChanged, depErr := co.SyncDeployment(set.Operator, cm, serviceCAConfigMap, sec, rt)
+	actualDeployment, depChanged, depErr := co.SyncDeployment(set.Operator, cm, serviceCAConfigMap, sec, rt, customLogoCanMount)
 	if depErr != nil {
 		msg := fmt.Sprintf("%q: %v", "deployment", depErr)
 		klog.V(4).Infof("incomplete sync: %v", msg)
@@ -107,15 +118,6 @@ func (co *consoleOperator) sync_v400(updatedOperatorConfig *operatorv1.Console, 
 	}
 	toUpdate = toUpdate || depChanged
 
-	// TODO: verify this
-	sErr := co.SyncCustomLogoConfigMap(updatedOperatorConfig)
-	if sErr != nil {
-		msg := fmt.Sprintf("%q: %v", "customLogoSync", sErr)
-		klog.V(4).Infof("incomplete sync: %v", msg)
-		co.ConditionResourceSyncProgressing(updatedOperatorConfig, msg)
-		return sErr
-	}
-
 	resourcemerge.SetDeploymentGeneration(&updatedOperatorConfig.Status.Generations, actualDeployment)
 	updatedOperatorConfig.Status.ObservedGeneration = set.Operator.ObjectMeta.Generation
 
@@ -123,11 +125,8 @@ func (co *consoleOperator) sync_v400(updatedOperatorConfig *operatorv1.Console, 
 	klog.V(4).Infof("sync loop 4.0.0 resources updated: %v", toUpdate)
 	klog.V(4).Infoln("-----------------------")
 
-	// if we made it this far, the operator is not failing
-	// but we will handle the state of the operand below
-	co.ConditionResourceSyncSuccess(updatedOperatorConfig)
 	// the operand is in a transitional state if any of the above resources changed
-	// or if we have not settled on the desired number of replicas or deployment is not uptodate.
+	// or if we have not settled on the desired number of replicas or deployment is not up to date.
 	if toUpdate {
 		co.ConditionResourceSyncProgressing(updatedOperatorConfig, "Changes made during sync updates, additional sync expected.")
 	} else {
@@ -228,8 +227,8 @@ func (co *consoleOperator) SyncConsolePublicConfig(consoleURL string) (*corev1.C
 	return resourceapply.ApplyConfigMap(co.configMapClient, co.recorder, requiredConfigMap)
 }
 
-func (co *consoleOperator) SyncDeployment(operatorConfig *operatorv1.Console, cm *corev1.ConfigMap, serviceCAConfigMap *corev1.ConfigMap, sec *corev1.Secret, rt *routev1.Route) (*appsv1.Deployment, bool, error) {
-	requiredDeployment := deploymentsub.DefaultDeployment(operatorConfig, cm, serviceCAConfigMap, sec, rt)
+func (co *consoleOperator) SyncDeployment(operatorConfig *operatorv1.Console, cm *corev1.ConfigMap, serviceCAConfigMap *corev1.ConfigMap, sec *corev1.Secret, rt *routev1.Route, canMountCustomLogo bool) (*appsv1.Deployment, bool, error) {
+	requiredDeployment := deploymentsub.DefaultDeployment(operatorConfig, cm, serviceCAConfigMap, sec, rt, canMountCustomLogo)
 	expectedGeneration := getDeploymentGeneration(co)
 	genChanged := operatorConfig.ObjectMeta.Generation != operatorConfig.Status.ObservedGeneration
 
@@ -399,6 +398,74 @@ func (co *consoleOperator) SyncRoute(operatorConfig *operatorv1.Console) (*route
 	}
 	// only return the route if it is valid with a host
 	return rt, rtIsNew, rtErr
+}
+
+func (c *consoleOperator) SyncCustomLogoConfigMap(operatorConfig *operatorsv1.Console) (okToMount bool, err error) {
+	// validate first, to avoid a broken volume mount & a crashlooping console
+	okToMount, err = c.ValidateCustomLogo(operatorConfig)
+
+	if okToMount {
+		if err := c.UpdateCustomLogoSyncSource(operatorConfig); err != nil {
+			klog.V(4).Infoln("custom logo sync source update error")
+			return false, customerrors.NewCustomLogoError("custom logo sync source update error")
+		}
+	}
+	return okToMount, err
+}
+
+// on each pass of the operator sync loop, we need to check the
+// operator config for a custom logo.  If this has been set, then
+// we notify the resourceSyncer that it needs to start watching this
+// configmap in its own sync loop.  Note that the resourceSyncer's actual
+// sync loop will run later.  Our operator is waiting to receive
+// the copied configmap into the console namespace for a future
+// sync loop to mount into the console deployment.
+func (c *consoleOperator) UpdateCustomLogoSyncSource(operatorConfig *operatorsv1.Console) error {
+	source := resourcesynccontroller.ResourceLocation{}
+	logoConfigMapName := operatorConfig.Spec.Customization.CustomLogoFile.Name
+
+	if logoConfigMapName != "" {
+		source.Name = logoConfigMapName
+		source.Namespace = api.OpenShiftConfigNamespace
+	}
+	// if no custom logo provided, sync an empty source to delete
+	return c.resourceSyncer.SyncConfigMap(
+		resourcesynccontroller.ResourceLocation{Namespace: api.OpenShiftConsoleNamespace, Name: api.OpenShiftCustomLogoConfigMapName},
+		source,
+	)
+}
+
+func (c *consoleOperator) ValidateCustomLogo(operatorConfig *operatorsv1.Console) (okToMount bool, err error) {
+	logoConfigMapName := operatorConfig.Spec.Customization.CustomLogoFile.Name
+	logoImageKey := operatorConfig.Spec.Customization.CustomLogoFile.Key
+
+	if configmapsub.FileNameOrKeyInconsistentlySet(operatorConfig) {
+		klog.V(4).Infoln("custom logo filename or key have not been set")
+		return false, customerrors.NewCustomLogoError("either custom logo filename or key have not been set")
+	}
+	// fine if nothing set, but don't mount it
+	if configmapsub.FileNameNotSet(operatorConfig) {
+		klog.V(4).Infoln("no custom logo configured")
+		return false, nil
+	}
+	logoConfigMap, err := c.configMapClient.ConfigMaps(api.OpenShiftConfigNamespace).Get(logoConfigMapName, metav1.GetOptions{})
+	// If we 404, the logo file may not have been created yet.
+	if err != nil {
+		klog.V(4).Infof("custom logo file %v not found", logoConfigMapName)
+		return false, customerrors.NewCustomLogoError(fmt.Sprintf("custom logo file %v not found", logoConfigMapName))
+	}
+	imageBytes := logoConfigMap.BinaryData[logoImageKey]
+	if configmapsub.LogoImageIsEmpty(imageBytes) {
+		klog.V(4).Infoln("custom logo file exists but no image provided")
+		return false, customerrors.NewCustomLogoError("custom logo file exists but no image provided")
+	}
+	// we will mount it anyway, but should notify the user if doesn't look right
+	if !configmapsub.IsLikelyCommonImageFormat(imageBytes) {
+		klog.V(4).Infoln("custom logo does not appear to be a common image format")
+		return true, customerrors.NewCustomLogoError("custom logo does not appear to be a common image format")
+	}
+	klog.V(4).Infoln("custom logo ok to mount")
+	return true, nil
 }
 
 func getDeploymentGeneration(co *consoleOperator) int64 {

--- a/pkg/console/starter/starter.go
+++ b/pkg/console/starter/starter.go
@@ -2,9 +2,6 @@ package starter
 
 import (
 	"fmt"
-
-	"github.com/openshift/api/oauth"
-
 	"os"
 	"time"
 
@@ -17,12 +14,15 @@ import (
 
 	// openshift
 	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/api/oauth"
 	operatorv1 "github.com/openshift/api/operator"
 	"github.com/openshift/console-operator/pkg/api"
-	operatorclient "github.com/openshift/console-operator/pkg/console/operatorclient"
+	"github.com/openshift/console-operator/pkg/console/operatorclient"
 	"github.com/openshift/library-go/pkg/controller/controllercmd"
+	"github.com/openshift/library-go/pkg/operator/resourcesynccontroller"
 	"github.com/openshift/library-go/pkg/operator/status"
 	"github.com/openshift/library-go/pkg/operator/unsupportedconfigoverridescontroller"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
 
 	// clients
 	configclient "github.com/openshift/client-go/config/clientset/versioned"
@@ -37,6 +37,7 @@ import (
 	routesclient "github.com/openshift/client-go/route/clientset/versioned"
 	routesinformers "github.com/openshift/client-go/route/informers/externalversions"
 
+	"github.com/openshift/console-operator/pkg/console/clientwrapper"
 	"github.com/openshift/console-operator/pkg/console/operator"
 )
 
@@ -88,7 +89,8 @@ func RunOperator(ctx *controllercmd.ControllerContext) error {
 		resync,
 		informers.WithNamespace(api.OpenShiftConfigManagedNamespace),
 	)
-	// configs are all named "cluster", but our clusteroperator is named "console"
+
+	//configs are all named "cluster", but our clusteroperator is named "console"
 	configInformers := configinformers.NewSharedInformerFactoryWithOptions(
 		configClient,
 		resync,
@@ -122,6 +124,8 @@ func RunOperator(ctx *controllercmd.ControllerContext) error {
 
 	versionGetter := status.NewVersionGetter()
 
+	resourceSyncerInformers, resourceSyncer := getResourceSyncer(ctx, clientwrapper.WithoutSecret(kubeClient), operatorClient)
+
 	// TODO: rearrange these into informer,client pairs, NOT separated.
 	consoleOperator := operator.NewConsoleOperator(
 		// informers
@@ -142,6 +146,7 @@ func RunOperator(ctx *controllercmd.ControllerContext) error {
 		oauthClient.OauthV1(),
 		versionGetter,
 		recorder,
+		resourceSyncer,
 	)
 
 	versionRecorder := status.NewVersionGetter()
@@ -175,6 +180,7 @@ func RunOperator(ctx *controllercmd.ControllerContext) error {
 	}{
 		kubeInformersNamespaced,
 		kubeInformersManagedNamespaced,
+		resourceSyncerInformers,
 		operatorConfigInformers,
 		configInformers,
 		routesInformersNamespaced,
@@ -184,9 +190,26 @@ func RunOperator(ctx *controllercmd.ControllerContext) error {
 	}
 
 	go consoleOperator.Run(ctx.Done())
+	go resourceSyncer.Run(1, ctx.Done())
 	go clusterOperatorStatus.Run(1, ctx.Done())
 	go configUpgradeableController.Run(1, ctx.Done())
 
 	<-ctx.Done()
 	return fmt.Errorf("stopped")
+}
+
+func getResourceSyncer(ctx *controllercmd.ControllerContext, kubeClient kubernetes.Interface, operatorClient v1helpers.OperatorClient) (v1helpers.KubeInformersForNamespaces, *resourcesynccontroller.ResourceSyncController) {
+	resourceSyncerInformers := v1helpers.NewKubeInformersForNamespaces(
+		kubeClient,
+		api.OpenShiftConfigNamespace,
+		api.OpenShiftConsoleNamespace,
+	)
+	resourceSyncer := resourcesynccontroller.NewResourceSyncController(
+		operatorClient,
+		resourceSyncerInformers,
+		v1helpers.CachedSecretGetter(kubeClient.CoreV1(), resourceSyncerInformers),
+		v1helpers.CachedConfigMapGetter(kubeClient.CoreV1(), resourceSyncerInformers),
+		ctx.EventRecorder,
+	)
+	return resourceSyncerInformers, resourceSyncer
 }

--- a/pkg/console/subresource/configmap/brand_custom_logo.go
+++ b/pkg/console/subresource/configmap/brand_custom_logo.go
@@ -1,0 +1,40 @@
+package configmap
+
+import v1 "github.com/openshift/api/operator/v1"
+
+// borrowed from the image package
+// image.RegisterFormat()
+var commonImageHeaders = []string{
+	"\xff\xd8\xff",      // "image/jpeg"
+	"\x89PNG\r\n\x1a\n", // "image/png"
+	"GIF87a",            // "image/gif"
+	"GIF89a",            // "image/gif"
+}
+
+// TODO: implement this
+// tests if bytes provided are likely an image by reading the
+// first set of bytes and checking against some well known
+// image headers.
+func IsLikelyCommonImageFormat(bytes []byte) bool {
+	// we can probably look at how RegisterFormat works:
+	// image.RegisterFormat()
+	// - uses several funcs such as match() and sniff() that give good
+	//   direction for implementing a basic check for image type.
+	// - RegisterFormat() is used to register gif,jpeg,png
+	return true
+}
+
+func FileNameOrKeyInconsistentlySet(operatorConfig *v1.Console) bool {
+	logoConfigMapName := operatorConfig.Spec.Customization.CustomLogoFile.Name
+	logoImageKey := operatorConfig.Spec.Customization.CustomLogoFile.Key
+	return (len(logoConfigMapName) == 0) != (len(logoImageKey) == 0)
+}
+
+func FileNameNotSet(operatorConfig *v1.Console) bool {
+	logoConfigMapName := operatorConfig.Spec.Customization.CustomLogoFile.Name
+	return len(logoConfigMapName) == 0
+}
+
+func LogoImageIsEmpty(image []byte) bool {
+	return len(image) == 0
+}

--- a/pkg/console/subresource/configmap/brand_custom_logo_test.go
+++ b/pkg/console/subresource/configmap/brand_custom_logo_test.go
@@ -1,0 +1,191 @@
+package configmap
+
+import (
+	"testing"
+
+	v1 "github.com/openshift/api/config/v1"
+
+	operator "github.com/openshift/api/operator/v1"
+
+	"github.com/go-test/deep"
+)
+
+func TestOnlyFileOrKeySet(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  *operator.Console
+		output bool
+	}{
+		{
+			name:   "No custom logo file or key set",
+			input:  &operator.Console{},
+			output: false,
+		}, {
+			name: "Both custom logo file and key set",
+			input: &operator.Console{
+				Spec: operator.ConsoleSpec{
+					Customization: operator.ConsoleCustomization{
+						CustomLogoFile: v1.ConfigMapFileReference{
+							Name: "custom-logo-file",
+							Key:  "img.png",
+						},
+					},
+				},
+			},
+			output: false,
+		}, {
+			name: "Custom logo file set but not key",
+			input: &operator.Console{
+				Spec: operator.ConsoleSpec{
+					Customization: operator.ConsoleCustomization{
+						CustomLogoFile: v1.ConfigMapFileReference{
+							Name: "custom-logo-file",
+						},
+					},
+				},
+			},
+			output: true,
+		}, {
+			name: "Custom logo key set but not file",
+			input: &operator.Console{
+				Spec: operator.ConsoleSpec{
+					Customization: operator.ConsoleCustomization{
+						CustomLogoFile: v1.ConfigMapFileReference{
+							Key: "img.png",
+						},
+					},
+				},
+			},
+			output: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if diff := deep.Equal(FileNameOrKeyInconsistentlySet(tt.input), tt.output); diff != nil {
+				t.Error(diff)
+			}
+		})
+	}
+}
+
+func TestFileNameNotSet(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  *operator.Console
+		output bool
+	}{
+		{
+			name:   "No custom logo file data",
+			input:  &operator.Console{},
+			output: true,
+		}, {
+			name: "Custom logo name and key set",
+			input: &operator.Console{
+				Spec: operator.ConsoleSpec{
+					Customization: operator.ConsoleCustomization{
+						CustomLogoFile: v1.ConfigMapFileReference{
+							Name: "custom-logo-file",
+							Key:  "img.png",
+						},
+					},
+				},
+			},
+			output: false,
+		}, {
+			name: "Custom logo name set",
+			input: &operator.Console{
+				Spec: operator.ConsoleSpec{
+					Customization: operator.ConsoleCustomization{
+						CustomLogoFile: v1.ConfigMapFileReference{
+							Name: "custom-logo-file",
+						},
+					},
+				},
+			},
+			output: false,
+		}, {
+			name: "Custom logo key set",
+			input: &operator.Console{
+				Spec: operator.ConsoleSpec{
+					Customization: operator.ConsoleCustomization{
+						CustomLogoFile: v1.ConfigMapFileReference{
+							Key: "img.png",
+						},
+					},
+				},
+			},
+			output: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if diff := deep.Equal(FileNameNotSet(tt.input), tt.output); diff != nil {
+				t.Error(diff)
+			}
+		})
+	}
+}
+
+func TestIsLikelyCommonImageFormat(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  []byte
+		output bool
+	}{
+		// using data generated from passing a png,jpg and a gif to `oc create configmap --from-file`
+		{
+			name:   "PNG is a common image",
+			input:  []byte("iVBORw0KGgoAAAANSUhEUgAAAGQAAABkCAYAAABw4pVUAAADmklEQVR4Xu2bv0tyURzGv1KLDoUgLoIShEODDbaHf0JbuNfSkIlR2NAf4NTgoJtQkoODq4OWlVu0NUWzoERQpmDhywm6vJh6L3bu5SmeM8bx3Od+Pvfx/jLX9vb2UDhgCLgoBMbFZxAKwfJBIWA+KIRC0AiA5eE5hELACIDFYUMoBIwAWBw2hELACIDFYUMoBIwAWBw2hELACIDFYUMoBIwAWBw2hELACIDFYUMoBIwAWBw25C8I8Xg8srCwYOxKp9OR9/d3LbvmdrtlcXHRlrW1BLR5kZkacnR0JMFg0IhWq9WkVCppiXp4eChLS0vGWpeXl1IsFrWs/RsW0SKkXq/L+fm5lv0dFXJ1dSWnp6da1v4Ni1AImCUKoZDpBKLRqKysrBiTbm5u5PHxEQybfXHgGmLfrv6OlSkEzJN2IaFQSFZXVyUcDovX65XX11d5enoSdbV0f39vuvt+v18CgYAx7+HhQV5eXkw/91cmaBNyfX0tqVRK1I3dpPH29ibZbFYU5EmDl70z/MPO6I1hu90Wn88nLpfL9EAdDoeSy+Xk7u5u7FwK0SBkHNmPjw+Zm5sbC30wGEgikRj7uIVCNApRR//FxYVUKhXp9XoyPz8vsVhMNjY2vskpFArSbDa/CaMQTUKmfRWp517qa+7/oU7wJycnFDJCQMtJXa2pHi6qh4yTRjqdFnUF9jVarZYcHx9TiB1C+v2+7O7uTj2hb25ufn59fY3n52c5ODigEDuEqMvYTCYzVcj6+rrE43FjTrfblWQySSF2CLm9vZV8Pj9VyNrammxtbRlz1D3J3t4ehdghpNFoyNnZGYWY3oWZT9ByUrfygooNMZehZlCINU6OzaIQx1Bb2xCFWOPk2CwKcQy1tQ1RiDVOjs2iEMdQW9sQhVjj5NgsCnEMtbUNUYg1To7NmknI6EukarUq5XJ5auhIJCI7OzvGHPXDBfUOfnTs7+/L8vKy8Wedvxt2jOoPNjSTkB9sjx81IUAhYIcIhVAIGAGwOGwIhYARAIvDhlAIGAGwOGwIhYARAIvDhlAIGAGwOGwIhYARAIvDhlAIGAGwOGwIhYARAIvDhlAIGAGwOGwIhYARAIvDhlAIGAGwOGwIhYARAIvDhlAIGAGwOGwIhYARAIvDhlAIGAGwOGwIhYARAIvDhlAIGAGwOGwIhYARAIvDhlAIGAGwOGwIhYARAIvDhlAIGAGwOGwIhYARAIvDhoAJ+QeTS82niTWiVwAAAABJRU5ErkJggg=="),
+			output: true,
+		}, {
+			name:   "JGEG is a common image",
+			input:  []byte("/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQH/wAALCABkAGQBAREA/8QAGwABAQADAQEBAAAAAAAAAAAAAAkGBwgDBAL/xAAxEAAABwACAQIDBgYDAAAAAAAAAQIDBAUGBwgJESESd7YKFDE2OHYTFSI3QbUjObf/2gAIAQEAAD8A4vAAAAAAAAAAAAAAAAAB7xosqY6TESM/KeMlKJmMy4+6aUl6qUTbSVLMkl7qMi9CL3MebrTrDi2Xm3GXmlqbcadQptxtaTMlIWhZEpC0mRkpKiIyMjIyIx+B9UWDNnLUiDDlTFoT8a0RY70haEGfoSlJZQs0p9TIviMiL1P09fUfKZGRmRkZGR+hkfsZGX4kZf4MgAAAAAWt8C362ND8hN19WceDnDyF4HdcieQvs7Scf4rW7m5LepdOox2cuNNZk0dBSl/FOBSQ5somzMjL4za+H1I/f1IxwFqMjrMPcP57a5jQ5C/ioack0eopbLP3Edt5PxsuP1ltGiTWUOp/qaU4wlLifdBmXuKf+LDu9S9MdDzJMueKt9ygjkKmxkZhjAtxH5dMvMTtC6t2wYlkRHGmlepQ06hxJtuxjQaFk8Sm5p8kaZva8ib3ZNQXqxrW7TU6ZqtkLS6/Xt315OtUQX3EobS49ETLJh1aW0JWttSiQkjJJYWAAAAAtb4Fv1saH5Cbr6s48FEO/vlie6ec1afg3rXxPxvO2FfaQtRzLrdnUWi6i11unoquzTGjV2Tu8rYXV63QPUCLTU215JNlLTWcZrfgqEPtZ1zfqOP/ACXeKbadgNHhajNch8dZDebGtcjqTazsRsuLHnbHSQ6C5eYjTU0O5ztMgplZKJxtqBdwilffrSir7VPJf2d3819qf29xJ/suQRBjsB/fjmz5uckfWV0NRgAAAALW+Bb9bGh+Qm6+rOPByL5PlrX357NqWo1GW/aQRqMzMkN5yibbT7/4QhKUJL8CSkiL2IWb6D/9J3bT9q9q/wDypga0+zu/mvtT+3uJP9lyCIMdgP78c2fNzkj6yuhqMAAAABQzxndtOOemXYe05b5QpdrfZudxlpMW1CwVdRWl2m0uLvLWUWQ5G0Ojy8AoDbFHKQ+6myVIQ65HJuK6hTi2tE9xeZcx2E7Ncxc0YyBfVeX5B1P87pYGnjV8O/jRCrK+CTdpFqrO5rmJJuQ3FmiJaTWiQpH/ADGo1JTQLrJ5EuFuF/Hhzj1K1OW5Rn8j8l03NVbQXdBTZOViYrvJGKazlI5b2Njtaq9jtxJ6Vu2v3LN2CmYhJciJmvKOOnEfFV3z4h6N3fNNlyzm+SNDH5HqsNBpE8d1GYtnoj2Zl6h+cq1TpdhkkMNPIu4pRFRHJylrbkE8hgktqdmdyfp4O25K5D2dWzLj1mu3Ot09dHnoZbnMQb6/sLWIzNbjvyo7ctqPLbRJQxJkMpeStLT7qCS4rBgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB//9k="),
+			output: true,
+		}, {
+			name:   "GIF is a common image",
+			input:  []byte("R0lGODlhZABkAPUyAGZmZmpqam9vb3BwcHNzc3x8fH5+foKCgoSEhIWFhYiIiIqKipCQkJSUlJeXl5mZmZqamqCgoKWlpaioqKurq7S0tLm5ub29vb6+vsDAwMHBwcLCwsPDw8zMzM3NzdXV1dra2tvb297e3t/f3+Dg4OHh4efn5+rq6uvr6+/v7/Ly8vT09PX19fb29vf39/r6+vz8/P7+/v///wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACH5BAAAAAAALAAAAABkAGQAAAb+QIBwSCwaj8ikcslsOp/QqHRKrVqv2Kx2y+16v+CweEwum8/otHrNbrvf8Lh8Tq/b7/i8fs/v+/+AgYKDYwMGhwFSAocGiYRDJTKSF1IikjIZj5CXGJWXG5pCkZKdUZaSoKGjMqVQpzKpmqutTw8ctwqhALO6V7y9Vb8JFSAoIx4MSQUOzAS6swctl9MsC0evsY+rJzHT3jEORtjP3pcw5S+OQ+Oq3xgCAAEU55cRReyy0+BFCNMf95/IXZpwhMQlEwBRCZThAgmGSykSwloYAomESyskZiO0qgMSCJdYaFyo4WPIke1ImZQkkgg+bZxWymi5LmBKVjJpCnnJMeZyEZAsUeZT+fOkS5tDcRYNelThTVpEgM4UCpOoEak6AfAc9Ouq0ZpOk0IdgpUqoVcWkDS4pKJIiEuUgMmdS7eu3bt48+rdy7ev37+AAwseTLiw4cOIEytezLix48eQI0ueTLmy5cuYM2vezLmz58+g6wYBADs="),
+			output: true,
+		}, {
+			name:   "Random noise is not an image",
+			input:  []byte("&^%$#&*"),
+			output: true,
+		}, {
+			name:   "Plain text is not an image",
+			input:  []byte("this is not an image"),
+			output: true,
+		},
+		// TODO: include some other file types as binary imput
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if diff := deep.Equal(IsLikelyCommonImageFormat(tt.input), tt.output); diff != nil {
+				t.Error(diff)
+			}
+		})
+	}
+}
+
+func TestLogoImageIsEmpty(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  []byte
+		output bool
+	}{
+		{
+			name:   "Byte array has data",
+			input:  []byte("data that would represent an image"),
+			output: false,
+		}, {
+			name:   "Byte array is empty",
+			input:  []byte(""),
+			output: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if diff := deep.Equal(LogoImageIsEmpty(tt.input), tt.output); diff != nil {
+				t.Error(diff)
+			}
+		})
+	}
+}

--- a/pkg/console/subresource/configmap/configmap.go
+++ b/pkg/console/subresource/configmap/configmap.go
@@ -17,11 +17,7 @@ import (
 
 const (
 	consoleConfigYamlFile = "console-config.yaml"
-)
-
-// overridden by console config
-const (
-	defaultLogoutURL = ""
+	defaultLogoutURL      = ""
 )
 
 func getApiUrl(infrastructureConfig *configv1.Infrastructure) string {
@@ -54,13 +50,14 @@ func DefaultConfigMap(
 		ConfigYAML()
 
 	extractedManagedConfig := extractYAML(managedConfig)
-
 	userDefinedBuilder := &consoleserver.ConsoleServerCLIConfigBuilder{}
 	userDefinedConfig, err := userDefinedBuilder.Host(rt.Spec.Host).
 		LogoutURL(consoleConfig.Spec.Authentication.LogoutRedirect).
 		Brand(operatorConfig.Spec.Customization.Brand).
 		DocURL(operatorConfig.Spec.Customization.DocumentationBaseURL).
 		APIServerURL(getApiUrl(infrastructureConfig)).
+		CustomLogoFile(operatorConfig.Spec.Customization.CustomLogoFile.Key).
+		CustomProductName(operatorConfig.Spec.Customization.CustomProductName).
 		StatusPageID(statusPageId(operatorConfig)).
 		ConfigYAML()
 

--- a/pkg/console/subresource/consoleserver/config_builder.go
+++ b/pkg/console/subresource/consoleserver/config_builder.go
@@ -34,8 +34,6 @@ type ConsoleServerCLIConfigBuilder struct {
 	docURL            string
 	apiServerURL      string
 	statusPageID      string
-	// TODO: pipe these in when they are added via the future custom branding PR
-	// This should be trivial
 	customProductName string
 	customLogoFile    string
 }
@@ -58,6 +56,16 @@ func (b *ConsoleServerCLIConfigBuilder) DocURL(docURL string) *ConsoleServerCLIC
 }
 func (b *ConsoleServerCLIConfigBuilder) APIServerURL(apiServerURL string) *ConsoleServerCLIConfigBuilder {
 	b.apiServerURL = apiServerURL
+	return b
+}
+func (b *ConsoleServerCLIConfigBuilder) CustomProductName(customProductName string) *ConsoleServerCLIConfigBuilder {
+	b.customProductName = customProductName
+	return b
+}
+func (b *ConsoleServerCLIConfigBuilder) CustomLogoFile(customLogoFile string) *ConsoleServerCLIConfigBuilder {
+	if customLogoFile != "" {
+		b.customLogoFile = "/var/logo/" + customLogoFile // append path here to prevent customLogoFile from always being just /var/logo/
+	}
 	return b
 }
 
@@ -129,6 +137,12 @@ func (b *ConsoleServerCLIConfigBuilder) customization() Customization {
 	}
 	if len(b.docURL) > 0 {
 		conf.DocumentationBaseURL = b.docURL
+	}
+	if len(b.customProductName) > 0 {
+		conf.CustomProductName = string(b.customProductName)
+	}
+	if len(b.customLogoFile) > 0 {
+		conf.CustomLogoFile = b.customLogoFile
 	}
 	return conf
 

--- a/pkg/console/subresource/consoleserver/config_builder.go
+++ b/pkg/console/subresource/consoleserver/config_builder.go
@@ -139,7 +139,7 @@ func (b *ConsoleServerCLIConfigBuilder) customization() Customization {
 		conf.DocumentationBaseURL = b.docURL
 	}
 	if len(b.customProductName) > 0 {
-		conf.CustomProductName = string(b.customProductName)
+		conf.CustomProductName = b.customProductName
 	}
 	if len(b.customLogoFile) > 0 {
 		conf.CustomLogoFile = b.customLogoFile

--- a/pkg/console/subresource/deployment/deployment.go
+++ b/pkg/console/subresource/deployment/deployment.go
@@ -54,33 +54,6 @@ type volumeConfig struct {
 	isConfigMap bool
 }
 
-var volumeConfigList = []volumeConfig{
-	{
-		name:     ConsoleServingCertName,
-		readOnly: true,
-		path:     "/var/serving-cert",
-		isSecret: true,
-	},
-	{
-		name:     ConsoleOauthConfigName,
-		readOnly: true,
-		path:     "/var/oauth-config",
-		isSecret: true,
-	},
-	{
-		name:        api.OpenShiftConsoleConfigMapName,
-		readOnly:    true,
-		path:        "/var/console-config",
-		isConfigMap: true,
-	},
-	{
-		name:        api.ServiceCAConfigMapName,
-		readOnly:    true,
-		path:        "/var/service-ca",
-		isConfigMap: true,
-	},
-}
-
 func DefaultDeployment(operatorConfig *operatorv1.Console, cm *corev1.ConfigMap, serviceCAConfigMap *corev1.ConfigMap, sec *corev1.Secret, rt *routev1.Route) *appsv1.Deployment {
 	labels := util.LabelsForConsole()
 	meta := util.SharedMeta()
@@ -95,6 +68,10 @@ func DefaultDeployment(operatorConfig *operatorv1.Console, cm *corev1.ConfigMap,
 	replicas := int32(ConsoleReplicas)
 	gracePeriod := int64(30)
 	tolerationSeconds := int64(120)
+	volumeConfig := defaultVolumeConfig()
+	if hasCustomLogo(operatorConfig) {
+		volumeConfig = append(volumeConfig, customLogoVolume(operatorConfig))
+	}
 
 	deployment := &appsv1.Deployment{
 		ObjectMeta: meta,
@@ -160,9 +137,9 @@ func DefaultDeployment(operatorConfig *operatorv1.Console, cm *corev1.ConfigMap,
 					TerminationGracePeriodSeconds: &gracePeriod,
 					SecurityContext:               &corev1.PodSecurityContext{},
 					Containers: []corev1.Container{
-						consoleContainer(operatorConfig),
+						consoleContainer(operatorConfig, volumeConfig),
 					},
-					Volumes: consoleVolumes(volumeConfigList),
+					Volumes: consoleVolumes(volumeConfig),
 				},
 			},
 		},
@@ -253,8 +230,8 @@ func GetLogLevelFlag(logLevel operatorv1.LogLevel) string {
 	return flag
 }
 
-func consoleContainer(cr *operatorv1.Console) corev1.Container {
-	volumeMounts := consoleVolumeMounts(volumeConfigList)
+func consoleContainer(cr *operatorv1.Console, volConfigList []volumeConfig) corev1.Container {
+	volumeMounts := consoleVolumeMounts(volConfigList)
 	// Since the console-operator logging has different logging levels then the capnslog,
 	// that we use for console server(bridge) we need to map them to each other
 	flag := GetLogLevelFlag(cr.Spec.LogLevel)
@@ -331,4 +308,47 @@ func IsAvailableAndUpdated(deployment *appsv1.Deployment) bool {
 	return deployment.Status.AvailableReplicas > 0 &&
 		deployment.Status.ObservedGeneration >= deployment.Generation &&
 		deployment.Status.UpdatedReplicas == deployment.Status.Replicas
+}
+
+func defaultVolumeConfig() []volumeConfig {
+	return []volumeConfig{
+		{
+			name:     ConsoleServingCertName,
+			readOnly: true,
+			path:     "/var/serving-cert",
+			isSecret: true,
+		},
+		{
+			name:     ConsoleOauthConfigName,
+			readOnly: true,
+			path:     "/var/oauth-config",
+			isSecret: true,
+		},
+		{
+			name:        api.OpenShiftConsoleConfigMapName,
+			readOnly:    true,
+			path:        "/var/console-config",
+			isConfigMap: true,
+		},
+		{
+			name:        api.ServiceCAConfigMapName,
+			readOnly:    true,
+			path:        "/var/service-ca",
+			isConfigMap: true,
+		},
+	}
+}
+
+func hasCustomLogo(operatorConfig *operatorv1.Console) bool {
+	if logoName := operatorConfig.Spec.Customization.CustomLogoFile.Name; logoName != "" {
+		return true
+	}
+	return false
+}
+
+func customLogoVolume(operatorConfig *operatorv1.Console) volumeConfig {
+	return volumeConfig{
+		name:        api.OpenShiftCustomLogoConfigMap,
+		path:        "/var/logo/",
+		isConfigMap: true}
 }

--- a/pkg/console/subresource/deployment/deployment.go
+++ b/pkg/console/subresource/deployment/deployment.go
@@ -54,7 +54,7 @@ type volumeConfig struct {
 	isConfigMap bool
 }
 
-func DefaultDeployment(operatorConfig *operatorv1.Console, cm *corev1.ConfigMap, serviceCAConfigMap *corev1.ConfigMap, sec *corev1.Secret, rt *routev1.Route) *appsv1.Deployment {
+func DefaultDeployment(operatorConfig *operatorv1.Console, cm *corev1.ConfigMap, serviceCAConfigMap *corev1.ConfigMap, sec *corev1.Secret, rt *routev1.Route, canMountCustomLogo bool) *appsv1.Deployment {
 	labels := util.LabelsForConsole()
 	meta := util.SharedMeta()
 	meta.Labels = labels
@@ -69,8 +69,8 @@ func DefaultDeployment(operatorConfig *operatorv1.Console, cm *corev1.ConfigMap,
 	gracePeriod := int64(30)
 	tolerationSeconds := int64(120)
 	volumeConfig := defaultVolumeConfig()
-	if hasCustomLogo(operatorConfig) {
-		volumeConfig = append(volumeConfig, customLogoVolume(operatorConfig))
+	if canMountCustomLogo {
+		volumeConfig = append(volumeConfig, customLogoVolume())
 	}
 
 	deployment := &appsv1.Deployment{
@@ -339,16 +339,9 @@ func defaultVolumeConfig() []volumeConfig {
 	}
 }
 
-func hasCustomLogo(operatorConfig *operatorv1.Console) bool {
-	if logoName := operatorConfig.Spec.Customization.CustomLogoFile.Name; logoName != "" {
-		return true
-	}
-	return false
-}
-
-func customLogoVolume(operatorConfig *operatorv1.Console) volumeConfig {
+func customLogoVolume() volumeConfig {
 	return volumeConfig{
-		name:        api.OpenShiftCustomLogoConfigMap,
+		name:        api.OpenShiftCustomLogoConfigMapName,
 		path:        "/var/logo/",
 		isConfigMap: true}
 }

--- a/pkg/console/subresource/deployment/deployment_test.go
+++ b/pkg/console/subresource/deployment/deployment_test.go
@@ -22,11 +22,12 @@ func TestDefaultDeployment(t *testing.T) {
 		gracePeriod  int64 = 30
 	)
 	type args struct {
-		config *operatorsv1.Console
-		cm     *corev1.ConfigMap
-		ca     *corev1.ConfigMap
-		sec    *corev1.Secret
-		rt     *v1.Route
+		config             *operatorsv1.Console
+		cm                 *corev1.ConfigMap
+		ca                 *corev1.ConfigMap
+		sec                *corev1.Secret
+		rt                 *v1.Route
+		canMountCustomLogo bool
 	}
 
 	consoleOperatorConfig := &operatorsv1.Console{
@@ -187,7 +188,7 @@ func TestDefaultDeployment(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if diff := deep.Equal(DefaultDeployment(tt.args.config, tt.args.cm, tt.args.cm, tt.args.sec, tt.args.rt), tt.want); diff != nil {
+			if diff := deep.Equal(DefaultDeployment(tt.args.config, tt.args.cm, tt.args.cm, tt.args.sec, tt.args.rt, tt.args.canMountCustomLogo), tt.want); diff != nil {
 				t.Error(diff)
 			}
 		})

--- a/pkg/console/subresource/deployment/deployment_test.go
+++ b/pkg/console/subresource/deployment/deployment_test.go
@@ -170,9 +170,9 @@ func TestDefaultDeployment(t *testing.T) {
 							TerminationGracePeriodSeconds: &gracePeriod,
 							SecurityContext:               &corev1.PodSecurityContext{},
 							Containers: []corev1.Container{
-								consoleContainer(consoleOperatorConfig),
+								consoleContainer(consoleOperatorConfig, defaultVolumeConfig()),
 							},
-							Volumes: consoleVolumes(volumeConfigList),
+							Volumes: consoleVolumes(defaultVolumeConfig()),
 						},
 					},
 					Strategy:                appsv1.DeploymentStrategy{},
@@ -252,7 +252,7 @@ func Test_consoleVolumes(t *testing.T) {
 		{
 			name: "Test console volumes creation",
 			args: args{
-				vc: volumeConfigList,
+				vc: defaultVolumeConfig(),
 			},
 			want: []corev1.Volume{
 				{
@@ -326,7 +326,7 @@ func Test_consoleVolumeMounts(t *testing.T) {
 	}{
 		{name: "Test console volumes Mounts",
 			args: args{
-				vc: volumeConfigList,
+				vc: defaultVolumeConfig(),
 			},
 			want: []corev1.VolumeMount{
 				{

--- a/test/e2e/brand_customization_test.go
+++ b/test/e2e/brand_customization_test.go
@@ -1,0 +1,176 @@
+package e2e
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	configv1 "github.com/openshift/api/config/v1"
+	operatorsv1 "github.com/openshift/api/operator/v1"
+	consoleapi "github.com/openshift/console-operator/pkg/api"
+	"github.com/openshift/console-operator/pkg/testframework"
+)
+
+const (
+	testCustomProductName = "test-e2e-product-name"
+	testCustomLogoName    = "test-e2e-configmap"
+	testCustomLogoKey     = "pic.jpg"
+	testMountPath         = "/var/logo/"
+)
+
+// Test prep - setup the client used by each test
+func setupCustomTestCase(t *testing.T) (*testframework.Clientset, operatorsv1.ConsoleCustomization) {
+	client := testframework.MustNewClientset(t, nil)
+	// Get the original operator config
+	originalConfig, err := client.Consoles().Get(consoleapi.ConfigResourceName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("could not get operator config, %v", err)
+	}
+	originalConfigCustomization := originalConfig.Spec.Customization
+
+	return client, originalConfigCustomization
+}
+
+func cleanupCustomizationTestCase(t *testing.T, client *testframework.Clientset, originalConfigCustomization operatorsv1.ConsoleCustomization) {
+
+	setOperatorConfigCustomization(t, client, originalConfigCustomization)
+
+	err := client.ConfigMaps("openshift-config").Delete(testCustomLogoName, &metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatalf("could not delete test configmap, %v", err)
+	}
+	testframework.WaitForSettledState(t, client)
+}
+
+// TestOperatorConfigCustomization() tests that changing the customization values on the operator-config
+// will result in the customization being set on the console-config in openshift-console.
+// Implicitly it ensures that the operator-config customization overrides customization set on
+// console-config in openshift-config-managed, if the managed configmap exists.
+func TestOperatorConfigCustomization(t *testing.T) {
+	client, originalConfigCustomization := setupCustomTestCase(t)
+	defer cleanupCustomizationTestCase(t, client, originalConfigCustomization)
+
+	// Create configmap with logo in namespace openshift-config
+	// Manual cmd: oc create configmap test-configmap --from-file=pic.jpg -n openshift-config
+	_, err := createLogoConfigMap(client)
+	if err != nil {
+		t.Fatalf("error: could not create logo configmap, %v", err)
+	}
+	// Set customization options on the operatorConfig
+	customData := operatorsv1.ConsoleCustomization{
+		CustomProductName: testCustomProductName,
+		CustomLogoFile: configv1.ConfigMapFileReference{
+			Name: testCustomLogoName,
+			Key:  testCustomLogoKey,
+		},
+	}
+	setOperatorConfigCustomization(t, client, customData)
+
+	// Verify options appear in the console-config in openshift-console
+	err = wait.Poll(1*time.Second, pollTimeout, func() (stop bool, err error) {
+		productName, logo := getConsoleCustomization(t, client)
+		return (productName == testCustomProductName) && (logo == testMountPath+testCustomLogoKey), nil
+	})
+	if err != nil {
+		t.Fatalf("error: customization values not found  %v", err)
+	}
+
+	// Verify mounts and volumes appear correctly on the deployment console in openshift-console
+	err = wait.Poll(1*time.Second, pollTimeout, func() (stop bool, err error) {
+		deployment, err := testframework.GetConsoleDeployment(client)
+		foundCustomizationVolume := findCustomizationVolume(deployment)
+		foundCustomizationMount := findCustomizationVolumeMount(deployment)
+		return foundCustomizationVolume && foundCustomizationMount, nil
+	})
+	if err != nil {
+		t.Fatalf("error: customization values not on deployment, %v", err)
+	}
+}
+
+func findCustomizationVolume(deployment *appsv1.Deployment) bool {
+	volumes := deployment.Spec.Template.Spec.Volumes
+	for _, volume := range volumes {
+		if volume.Name == testCustomLogoName {
+			return true
+		}
+	}
+	return false
+}
+
+func findCustomizationVolumeMount(deployment *appsv1.Deployment) bool {
+	mounts := deployment.Spec.Template.Spec.Containers[0].VolumeMounts
+	for _, mount := range mounts {
+		if (mount.Name == testCustomLogoName) && (mount.MountPath == testMountPath) {
+			return true
+		}
+	}
+	return false
+}
+
+// Set Customization on the operator config
+func setOperatorConfigCustomization(t *testing.T, client *testframework.Clientset, cust operatorsv1.ConsoleCustomization) {
+	operatorConfig, err := client.Consoles().Get(consoleapi.ConfigResourceName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("could not get operator config, %v", err)
+	}
+	spec := operatorsv1.ConsoleSpec{
+		OperatorSpec: operatorsv1.OperatorSpec{
+			ManagementState: "Managed",
+		},
+		Customization: cust,
+	}
+	operatorConfig.Spec = spec
+	_, err = client.Consoles().Update(operatorConfig)
+	if err != nil {
+		t.Fatalf("could not update operator config with customization=%v, %v", cust, err)
+	}
+}
+
+// Get the brand from the console-config in the data of the console CM
+func getConsoleCustomization(t *testing.T, client *testframework.Clientset) (string, string) {
+	cm, err := testframework.GetConsoleConfigMap(client)
+	if err != nil {
+		t.Fatalf("error: %s", err)
+	}
+
+	data := cm.Data["console-config.yaml"]
+	logoValue := ""
+	customProductName := ""
+	temp := strings.Split(data, "\n")
+	for _, item := range temp {
+		if strings.Contains(item, "customLogoFile") {
+			logoValue = strings.Split(strings.TrimSpace(item), ":")[1]
+		}
+		if strings.Contains(item, "customProductName") {
+			customProductName = strings.Split(strings.TrimSpace(item), ":")[1]
+		}
+	}
+	t.Logf("productName:%s, logo:%s", customProductName, logoValue)
+	return strings.TrimSpace(customProductName), strings.TrimSpace(logoValue)
+}
+
+// Helper function that creates a test configmap with binarydata
+func createLogoConfigMap(client *testframework.Clientset) (*v1.ConfigMap, error) {
+	var data = make(map[string][]byte)
+	data[testCustomLogoKey] = []byte("TESTING")
+
+	cm := &v1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ConfigMap",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              testCustomLogoName,
+			Namespace:         "openshift-config",
+			CreationTimestamp: metav1.Time{},
+		},
+		BinaryData: data,
+	}
+	return client.ConfigMaps("openshift-config").Create(cm)
+
+}

--- a/test/e2e/brand_customization_test.go
+++ b/test/e2e/brand_customization_test.go
@@ -17,10 +17,11 @@ import (
 )
 
 const (
-	testCustomProductName = "test-e2e-product-name"
-	testCustomLogoName    = "test-e2e-configmap"
-	testCustomLogoKey     = "pic.jpg"
-	testMountPath         = "/var/logo/"
+	testCustomProductName    = "custom product name"
+	customLogoVolumeName     = "custom-logo"
+	customBrandConfigMapName = "custom-brand-configmap"
+	customBrandImageKey      = "pic.png"
+	customLogoMountPath      = "/var/logo/"
 )
 
 // Test prep - setup the client used by each test
@@ -40,18 +41,18 @@ func cleanupCustomizationTestCase(t *testing.T, client *testframework.Clientset,
 
 	setOperatorConfigCustomization(t, client, originalConfigCustomization)
 
-	err := client.ConfigMaps("openshift-config").Delete(testCustomLogoName, &metav1.DeleteOptions{})
+	err := client.ConfigMaps("openshift-config").Delete(customBrandConfigMapName, &metav1.DeleteOptions{})
 	if err != nil {
 		t.Fatalf("could not delete test configmap, %v", err)
 	}
 	testframework.WaitForSettledState(t, client)
 }
 
-// TestOperatorConfigCustomization() tests that changing the customization values on the operator-config
+// TestBrandCustomization() tests that changing the customization values on the operator-config
 // will result in the customization being set on the console-config in openshift-console.
 // Implicitly it ensures that the operator-config customization overrides customization set on
 // console-config in openshift-config-managed, if the managed configmap exists.
-func TestOperatorConfigCustomization(t *testing.T) {
+func TestBrandCustomization(t *testing.T) {
 	client, originalConfigCustomization := setupCustomTestCase(t)
 	defer cleanupCustomizationTestCase(t, client, originalConfigCustomization)
 
@@ -65,23 +66,25 @@ func TestOperatorConfigCustomization(t *testing.T) {
 	customData := operatorsv1.ConsoleCustomization{
 		CustomProductName: testCustomProductName,
 		CustomLogoFile: configv1.ConfigMapFileReference{
-			Name: testCustomLogoName,
-			Key:  testCustomLogoKey,
+			Name: customBrandConfigMapName,
+			Key:  customBrandImageKey,
 		},
 	}
 	setOperatorConfigCustomization(t, client, customData)
 
 	// Verify options appear in the console-config in openshift-console
-	err = wait.Poll(1*time.Second, pollTimeout, func() (stop bool, err error) {
-		productName, logo := getConsoleCustomization(t, client)
-		return (productName == testCustomProductName) && (logo == testMountPath+testCustomLogoKey), nil
+	err = wait.Poll(1*time.Second, 10*time.Second, func() (stop bool, err error) {
+		productName, logo := getConsoleConfigCustomizations(t, client)
+		return (productName == testCustomProductName) && (logo == customLogoMountPath+customBrandImageKey), nil
 	})
 	if err != nil {
 		t.Fatalf("error: customization values not found  %v", err)
 	}
 
 	// Verify mounts and volumes appear correctly on the deployment console in openshift-console
-	err = wait.Poll(1*time.Second, pollTimeout, func() (stop bool, err error) {
+	// This can take a while to settle
+	longPollTimeout := 120 * time.Second
+	err = wait.Poll(1*time.Second, longPollTimeout, func() (stop bool, err error) {
 		deployment, err := testframework.GetConsoleDeployment(client)
 		foundCustomizationVolume := findCustomizationVolume(deployment)
 		foundCustomizationMount := findCustomizationVolumeMount(deployment)
@@ -95,7 +98,7 @@ func TestOperatorConfigCustomization(t *testing.T) {
 func findCustomizationVolume(deployment *appsv1.Deployment) bool {
 	volumes := deployment.Spec.Template.Spec.Volumes
 	for _, volume := range volumes {
-		if volume.Name == testCustomLogoName {
+		if volume.Name == customLogoVolumeName {
 			return true
 		}
 	}
@@ -105,7 +108,7 @@ func findCustomizationVolume(deployment *appsv1.Deployment) bool {
 func findCustomizationVolumeMount(deployment *appsv1.Deployment) bool {
 	mounts := deployment.Spec.Template.Spec.Containers[0].VolumeMounts
 	for _, mount := range mounts {
-		if (mount.Name == testCustomLogoName) && (mount.MountPath == testMountPath) {
+		if (mount.Name == customLogoVolumeName) && (mount.MountPath == customLogoMountPath) {
 			return true
 		}
 	}
@@ -132,7 +135,7 @@ func setOperatorConfigCustomization(t *testing.T, client *testframework.Clientse
 }
 
 // Get the brand from the console-config in the data of the console CM
-func getConsoleCustomization(t *testing.T, client *testframework.Clientset) (string, string) {
+func getConsoleConfigCustomizations(t *testing.T, client *testframework.Clientset) (string, string) {
 	cm, err := testframework.GetConsoleConfigMap(client)
 	if err != nil {
 		t.Fatalf("error: %s", err)
@@ -150,14 +153,14 @@ func getConsoleCustomization(t *testing.T, client *testframework.Clientset) (str
 			customProductName = strings.Split(strings.TrimSpace(item), ":")[1]
 		}
 	}
-	t.Logf("productName:%s, logo:%s", customProductName, logoValue)
+	t.Logf("configmap console-config contains productName:%s, logo:%s", customProductName, logoValue)
 	return strings.TrimSpace(customProductName), strings.TrimSpace(logoValue)
 }
 
 // Helper function that creates a test configmap with binarydata
 func createLogoConfigMap(client *testframework.Clientset) (*v1.ConfigMap, error) {
 	var data = make(map[string][]byte)
-	data[testCustomLogoKey] = []byte("TESTING")
+	data[customBrandImageKey] = []byte("iVBORw0KGgoAAAANSUhEUgAAAGQAAABkCAYAAABw4pVUAAADmklEQVR4Xu2bv0tyURzGv1KLDoUgLoIShEODDbaHf0JbuNfSkIlR2NAf4NTgoJtQkoODq4OWlVu0NUWzoERQpmDhywm6vJh6L3bu5SmeM8bx3Od+Pvfx/jLX9vb2UDhgCLgoBMbFZxAKwfJBIWA+KIRC0AiA5eE5hELACIDFYUMoBIwAWBw2hELACIDFYUMoBIwAWBw2hELACIDFYUMoBIwAWBw2hELACIDFYUMoBIwAWBw25C8I8Xg8srCwYOxKp9OR9/d3LbvmdrtlcXHRlrW1BLR5kZkacnR0JMFg0IhWq9WkVCppiXp4eChLS0vGWpeXl1IsFrWs/RsW0SKkXq/L+fm5lv0dFXJ1dSWnp6da1v4Ni1AImCUKoZDpBKLRqKysrBiTbm5u5PHxEQybfXHgGmLfrv6OlSkEzJN2IaFQSFZXVyUcDovX65XX11d5enoSdbV0f39vuvt+v18CgYAx7+HhQV5eXkw/91cmaBNyfX0tqVRK1I3dpPH29ibZbFYU5EmDl70z/MPO6I1hu90Wn88nLpfL9EAdDoeSy+Xk7u5u7FwK0SBkHNmPjw+Zm5sbC30wGEgikRj7uIVCNApRR//FxYVUKhXp9XoyPz8vsVhMNjY2vskpFArSbDa/CaMQTUKmfRWp517qa+7/oU7wJycnFDJCQMtJXa2pHi6qh4yTRjqdFnUF9jVarZYcHx9TiB1C+v2+7O7uTj2hb25ufn59fY3n52c5ODigEDuEqMvYTCYzVcj6+rrE43FjTrfblWQySSF2CLm9vZV8Pj9VyNrammxtbRlz1D3J3t4ehdghpNFoyNnZGYWY3oWZT9ByUrfygooNMZehZlCINU6OzaIQx1Bb2xCFWOPk2CwKcQy1tQ1RiDVOjs2iEMdQW9sQhVjj5NgsCnEMtbUNUYg1To7NmknI6EukarUq5XJ5auhIJCI7OzvGHPXDBfUOfnTs7+/L8vKy8Wedvxt2jOoPNjSTkB9sjx81IUAhYIcIhVAIGAGwOGwIhYARAIvDhlAIGAGwOGwIhYARAIvDhlAIGAGwOGwIhYARAIvDhlAIGAGwOGwIhYARAIvDhlAIGAGwOGwIhYARAIvDhlAIGAGwOGwIhYARAIvDhlAIGAGwOGwIhYARAIvDhlAIGAGwOGwIhYARAIvDhlAIGAGwOGwIhYARAIvDhlAIGAGwOGwIhYARAIvDhlAIGAGwOGwIhYARAIvDhoAJ+QeTS82niTWiVwAAAABJRU5ErkJggg==")
 
 	cm := &v1.ConfigMap{
 		TypeMeta: metav1.TypeMeta{
@@ -165,7 +168,7 @@ func createLogoConfigMap(client *testframework.Clientset) (*v1.ConfigMap, error)
 			APIVersion: "v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:              testCustomLogoName,
+			Name:              customBrandConfigMapName,
 			Namespace:         "openshift-config",
 			CreationTimestamp: metav1.Time{},
 		},


### PR DESCRIPTION
- based on #220 by @zherman0 
- with some `clientwrapper` magic by @enj 
- unsquashed to maintain original authorship of commits

Feature:
- Provide a `Custom Product Name` and `Custom Logo` to be displayed in the console via operator configuration.

Requires additional RBAC to run:
- Pull the branch & have a dev cluster handy
- Disable CVO so you can deploy your custom operator image
`oc scale deployment cluster-version-operator --replicas 0 --namespace openshift-cluster-version`
- Docker build `docker build -t quay.io/<you>/console-operator:latest .`
- Docker push `docker push quay.io/<you>/console-operator:latest`
- Apply the additional necessary Rolebinding `oc apply -f manifests/04-rbac-rolebinding.yaml`
- Apply the additional Role `oc apply -f manifests/03-rbac-role-ns-openshift-config.yaml` 
- Deploy your custom operator image ([example template](https://github.com/openshift/console-operator/blob/master/examples/07-operator-alt-image.yaml)) (`- "-v=4"` or higher recommended for logging)

To use:
- Create a `ConfigMap` with a logo image in the `openshift-config` namespace. 

If an image is needed, this fits the approximate dimensions:

![fake-logo](https://user-images.githubusercontent.com/280512/59897792-5b83a680-93bc-11e9-903e-5fb6a4240358.png)

```yaml
oc create configmap my-custom-logo-file --from-file ~/Desktop/my-logo.png
```
- Update the operator config to reference the logo created:

```yaml
oc apply -f <this-file>
apiVersion: operator.openshift.io/v1
kind: Console
metadata:
  name: cluster
spec:
  customization:
    customProductName: my-awesome-cluster
    customLogoFile:
      name: my-custom-logo-file
      key: my-logo.png
```
Expected function:
- A resource syncer is scanning `openshift-config` for configmap changes, but does nothing with observed configmaps unless specified via the operator config.
- If a `customLogoFile.name` exists in the operator config, the resource syncer will sync this configmap into `openshift-console` as a new configmap called `custom-logo`.
- The operator main sync loop will notice when the new `custom-logo` configmap appears in the `openshift-console` namespace and will trigger a sync of `console` resources, which will cause a rollout of the `deployment` with the logo file mounted via a volume mount. 
- if the source configmap is deleted, the custom logo file will be deleted
- if the custom logo is removed from the operator-config, the volume mount will be deleted 

/assign @jhadvig 
@spadgett fyi


