### PR TITLE
Allow custom-logo configmap to be removed

### DIFF
--- a/pkg/console/operator/sync_v400.go
+++ b/pkg/console/operator/sync_v400.go
@@ -404,7 +404,7 @@ func (c *consoleOperator) SyncCustomLogoConfigMap(operatorConfig *operatorsv1.Co
 	// validate first, to avoid a broken volume mount & a crashlooping console
 	okToMount, err = c.ValidateCustomLogo(operatorConfig)
 
-	if okToMount {
+	if okToMount || configmapsub.IsRemoved(operatorConfig) {
 		if err := c.UpdateCustomLogoSyncSource(operatorConfig); err != nil {
 			klog.V(4).Infoln("custom logo sync source update error")
 			return false, customerrors.NewCustomLogoError("custom logo sync source update error")

--- a/pkg/console/subresource/configmap/brand_custom_logo.go
+++ b/pkg/console/subresource/configmap/brand_custom_logo.go
@@ -38,3 +38,9 @@ func FileNameNotSet(operatorConfig *v1.Console) bool {
 func LogoImageIsEmpty(image []byte) bool {
 	return len(image) == 0
 }
+
+func IsRemoved(operatorConfig *v1.Console) bool {
+	logoConfigMapName := operatorConfig.Spec.Customization.CustomLogoFile.Name
+	logoImageKey := operatorConfig.Spec.Customization.CustomLogoFile.Key
+	return logoConfigMapName == "" && logoImageKey == ""
+}

--- a/pkg/console/subresource/configmap/brand_custom_logo_test.go
+++ b/pkg/console/subresource/configmap/brand_custom_logo_test.go
@@ -126,6 +126,64 @@ func TestFileNameNotSet(t *testing.T) {
 	}
 }
 
+func TestIsRemoved(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  *operator.Console
+		output bool
+	}{
+		{
+			name:   "Custom logo has been removed if there is no custom logo file on config",
+			input:  &operator.Console{},
+			output: true,
+		}, {
+			name: "Custom logo has not been removed if there is custom logo file config",
+			input: &operator.Console{
+				Spec: operator.ConsoleSpec{
+					Customization: operator.ConsoleCustomization{
+						CustomLogoFile: v1.ConfigMapFileReference{
+							Name: "custom-logo-file",
+							Key:  "img.png",
+						},
+					},
+				},
+			},
+			output: false,
+		}, {
+			name: "Custom logo has not been removed if custom logo file config is partially provided via name",
+			input: &operator.Console{
+				Spec: operator.ConsoleSpec{
+					Customization: operator.ConsoleCustomization{
+						CustomLogoFile: v1.ConfigMapFileReference{
+							Name: "custom-logo-file",
+						},
+					},
+				},
+			},
+			output: false,
+		}, {
+			name: "Custom logo has not been removed if custom logo file config is partially provided via key",
+			input: &operator.Console{
+				Spec: operator.ConsoleSpec{
+					Customization: operator.ConsoleCustomization{
+						CustomLogoFile: v1.ConfigMapFileReference{
+							Key: "img.png",
+						},
+					},
+				},
+			},
+			output: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if diff := deep.Equal(IsRemoved(tt.input), tt.output); diff != nil {
+				t.Error(diff)
+			}
+		})
+	}
+}
+
 func TestIsLikelyCommonImageFormat(t *testing.T) {
 	tests := []struct {
 		name   string


### PR DESCRIPTION
- Ensure removing custom logo from operator config allows for custom-logo configmap to be deleted

/assign @jhadvig @zherman0 