### PR TITLE
CONSOLE-1523: Change log level values to use klog types

### DIFF
--- a/pkg/console/subresource/deployment/deployment.go
+++ b/pkg/console/subresource/deployment/deployment.go
@@ -236,15 +236,15 @@ func consoleVolumeMounts(vc []volumeConfig) []corev1.VolumeMount {
 
 func GetLogLevelFlag(logLevel operatorv1.LogLevel) string {
 	flag := ""
-	// Since the console-operator logging has different logging levels then the capnslog,
-	// that we use for console server(bridge) we need to map them to each other
 	switch logLevel {
 	case operatorv1.Normal:
-		flag = "--log-level=*=NOTICE"
+		flag = "--v=2"
 	case operatorv1.Debug:
-		flag = "--log-level=*=DEBUG"
-	case operatorv1.Trace, operatorv1.TraceAll:
-		flag = "--log-level=*=TRACE"
+		flag = "--v=4"
+	case operatorv1.Trace:
+		flag = "--v=6"
+	case operatorv1.TraceAll:
+		flag = "--v=10"
 	}
 	return flag
 }


### PR DESCRIPTION
This changes the capnslog values to accepted klog log level values.  I have just converted them as best I can but we might want to re-evaluate what each maps to.

[CONSOLE-1523](https://issues.redhat.com/browse/CONSOLE-1523)