### PR TITLE
Bug 1724977: Invalid customization values should not make operator hotloop

### DIFF
--- a/pkg/console/operator/operator.go
+++ b/pkg/console/operator/operator.go
@@ -235,8 +235,6 @@ func (c *consoleOperator) handleSync(configs configSet) error {
 		return fmt.Errorf("console is in an unknown state: %v", updatedStatus.Spec.ManagementState)
 	}
 
-	// set default conditions ok first, sync can toggle if conditions are invalid
-	c.ConditionsDefault(updatedStatus)
 	err := c.sync_v400(updatedStatus, configs)
 
 	c.HandleDegraded(updatedStatus, "SyncError", func() error {


### PR DESCRIPTION
Based on https://github.com/openshift/cluster-authentication-operator/pull/142#issue-293463578 we should handle degraded condition more carefully, meaning update only after there are changes.

/assign @benjaminapetersen @zherman0 