### PR TITLE
Add proxy support

### DIFF
--- a/manifests/03-rbac-role-cluster.yaml
+++ b/manifests/03-rbac-role-cluster.yaml
@@ -25,6 +25,14 @@ rules:
 - apiGroups:
   - config.openshift.io
   resources:
+  - proxies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - config.openshift.io
+  resources:
   - consoles
   - consoles/status
   - clusteroperators

--- a/pkg/console/operator/sync_v400.go
+++ b/pkg/console/operator/sync_v400.go
@@ -109,7 +109,7 @@ func (co *consoleOperator) sync_v400(updatedOperatorConfig *operatorv1.Console, 
 	}
 	toUpdate = toUpdate || oauthChanged
 
-	actualDeployment, depChanged, depErr := co.SyncDeployment(set.Operator, cm, serviceCAConfigMap, sec, rt, customLogoCanMount)
+	actualDeployment, depChanged, depErr := co.SyncDeployment(set.Operator, cm, serviceCAConfigMap, sec, rt, set.Proxy, customLogoCanMount)
 	if depErr != nil {
 		msg := fmt.Sprintf("%q: %v", "deployment", depErr)
 		klog.V(4).Infof("incomplete sync: %v", msg)
@@ -227,8 +227,8 @@ func (co *consoleOperator) SyncConsolePublicConfig(consoleURL string) (*corev1.C
 	return resourceapply.ApplyConfigMap(co.configMapClient, co.recorder, requiredConfigMap)
 }
 
-func (co *consoleOperator) SyncDeployment(operatorConfig *operatorv1.Console, cm *corev1.ConfigMap, serviceCAConfigMap *corev1.ConfigMap, sec *corev1.Secret, rt *routev1.Route, canMountCustomLogo bool) (*appsv1.Deployment, bool, error) {
-	requiredDeployment := deploymentsub.DefaultDeployment(operatorConfig, cm, serviceCAConfigMap, sec, rt, canMountCustomLogo)
+func (co *consoleOperator) SyncDeployment(operatorConfig *operatorv1.Console, cm *corev1.ConfigMap, serviceCAConfigMap *corev1.ConfigMap, sec *corev1.Secret, rt *routev1.Route, proxyConfig *configv1.Proxy, canMountCustomLogo bool) (*appsv1.Deployment, bool, error) {
+	requiredDeployment := deploymentsub.DefaultDeployment(operatorConfig, cm, serviceCAConfigMap, sec, rt, proxyConfig, canMountCustomLogo)
 	expectedGeneration := getDeploymentGeneration(co)
 	genChanged := operatorConfig.ObjectMeta.Generation != operatorConfig.Status.ObservedGeneration
 

--- a/pkg/console/starter/starter.go
+++ b/pkg/console/starter/starter.go
@@ -136,6 +136,7 @@ func RunOperator(ctx *controllercmd.ControllerContext) error {
 		kubeInformersNamespaced.Apps().V1().Deployments(), // Deployments
 		routesInformersNamespaced.Route().V1().Routes(),   // Route
 		oauthInformers.Oauth().V1().OAuthClients(),        // OAuth clients
+		configInformers.Config().V1().Proxies(),           // Proxy
 		// clients
 		operatorConfigClient.OperatorV1(),
 		configClient.ConfigV1(),

--- a/pkg/console/subresource/deployment/deployment.go
+++ b/pkg/console/subresource/deployment/deployment.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/klog"
 
 	// openshift
+	configv1 "github.com/openshift/api/config/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	routev1 "github.com/openshift/api/route/v1"
 	"github.com/openshift/console-operator/pkg/api"
@@ -54,7 +55,7 @@ type volumeConfig struct {
 	isConfigMap bool
 }
 
-func DefaultDeployment(operatorConfig *operatorv1.Console, cm *corev1.ConfigMap, serviceCAConfigMap *corev1.ConfigMap, sec *corev1.Secret, rt *routev1.Route, canMountCustomLogo bool) *appsv1.Deployment {
+func DefaultDeployment(operatorConfig *operatorv1.Console, cm *corev1.ConfigMap, serviceCAConfigMap *corev1.ConfigMap, sec *corev1.Secret, rt *routev1.Route, proxyConfig *configv1.Proxy, canMountCustomLogo bool) *appsv1.Deployment {
 	labels := util.LabelsForConsole()
 	meta := util.SharedMeta()
 	meta.Labels = labels
@@ -137,7 +138,7 @@ func DefaultDeployment(operatorConfig *operatorv1.Console, cm *corev1.ConfigMap,
 					TerminationGracePeriodSeconds: &gracePeriod,
 					SecurityContext:               &corev1.PodSecurityContext{},
 					Containers: []corev1.Container{
-						consoleContainer(operatorConfig, volumeConfig),
+						consoleContainer(operatorConfig, volumeConfig, proxyConfig),
 					},
 					Volumes: consoleVolumes(volumeConfig),
 				},
@@ -230,7 +231,7 @@ func GetLogLevelFlag(logLevel operatorv1.LogLevel) string {
 	return flag
 }
 
-func consoleContainer(cr *operatorv1.Console, volConfigList []volumeConfig) corev1.Container {
+func consoleContainer(cr *operatorv1.Console, volConfigList []volumeConfig, proxyConfig *configv1.Proxy) corev1.Container {
 	volumeMounts := consoleVolumeMounts(volConfigList)
 	// Since the console-operator logging has different logging levels then the capnslog,
 	// that we use for console server(bridge) we need to map them to each other
@@ -252,6 +253,7 @@ func consoleContainer(cr *operatorv1.Console, volConfigList []volumeConfig) core
 		//	Name:  publicURLName,
 		//	Value: consoleURL(),
 		//}},
+		Env: setEnvironmentVariables(proxyConfig),
 		Ports: []corev1.ContainerPort{{
 			Name:          consolePortName,
 			Protocol:      corev1.ProtocolTCP,
@@ -268,6 +270,32 @@ func consoleContainer(cr *operatorv1.Console, volConfigList []volumeConfig) core
 			},
 		},
 	}
+}
+
+func setEnvironmentVariables(proxyConfig *configv1.Proxy) []corev1.EnvVar {
+	envVars := []corev1.EnvVar{}
+	if proxyConfig == nil {
+		return envVars
+	}
+	if len(proxyConfig.Status.HTTPSProxy) != 0 {
+		envVars = append(envVars, corev1.EnvVar{
+			Name:  "HTTPS_PROXY",
+			Value: proxyConfig.Status.HTTPSProxy,
+		})
+	}
+	if len(proxyConfig.Status.HTTPProxy) != 0 {
+		envVars = append(envVars, corev1.EnvVar{
+			Name:  "HTTP_PROXY",
+			Value: proxyConfig.Status.HTTPProxy,
+		})
+	}
+	if len(proxyConfig.Status.NoProxy) != 0 {
+		envVars = append(envVars, corev1.EnvVar{
+			Name:  "NO_PROXY",
+			Value: proxyConfig.Status.NoProxy,
+		})
+	}
+	return envVars
 }
 
 func defaultProbe() *corev1.Probe {


### PR DESCRIPTION
Adding console support for cluster proxy. If the Proxy CRD is set, operator will read them and set proper environment variables inside the console container.
FollowUp should be setting the proxy on the console server http client [as does in.](https://github.com/openshift/console/pull/1249)

/assign @benjaminapetersen @zherman0 

Story: https://jira.coreos.com/browse/CONSOLE-1440