### PR TITLE
Add support for proxies TrustedCA

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -22,4 +22,8 @@ const (
 	OpenShiftConfigManagedNamespace     = "openshift-config-managed"
 	OpenShiftConfigNamespace            = "openshift-config"
 	OpenShiftCustomLogoConfigMapName    = "custom-logo"
+	TrustedCAConfigMapName              = "trusted-ca-bundle"
+	TrustedCABundleKey                  = "ca-bundle.crt"
+	TrustedCABundleMountDir             = "/etc/pki/ca-trust/extracted/pem"
+	TrustedCABundleMountFile            = "tls-ca-bundle.pem"
 )

--- a/pkg/console/operator/operator.go
+++ b/pkg/console/operator/operator.go
@@ -147,7 +147,7 @@ func NewConsoleOperator(
 		operator.WithInformer(serviceInformer, targetNameFilter),
 		operator.WithInformer(oauthClients, targetNameFilter),
 		// special resources with unique names
-		operator.WithInformer(configMapInformer, operator.FilterByNames(api.OpenShiftConsoleConfigMapName, api.ServiceCAConfigMapName, api.OpenShiftCustomLogoConfigMapName)),
+		operator.WithInformer(configMapInformer, operator.FilterByNames(api.OpenShiftConsoleConfigMapName, api.ServiceCAConfigMapName, api.OpenShiftCustomLogoConfigMapName, api.TrustedCAConfigMapName)),
 		operator.WithInformer(managedConfigMapInformer, operator.FilterByNames(api.OpenShiftConsoleConfigMapName, api.OpenShiftConsolePublicConfigMapName)),
 		operator.WithInformer(secretsInformer, operator.FilterByNames(deployment.ConsoleOauthConfigName)),
 	)

--- a/pkg/console/subresource/configmap/trusted_ca.go
+++ b/pkg/console/subresource/configmap/trusted_ca.go
@@ -1,0 +1,35 @@
+package configmap
+
+import (
+	corev1 "k8s.io/api/core/v1"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+
+	"github.com/openshift/console-operator/pkg/api"
+	"github.com/openshift/console-operator/pkg/console/subresource/util"
+)
+
+const (
+	injectTrustedCABundleLabel = "config.openshift.io/inject-trusted-cabundle"
+)
+
+func DefaultTrustedCAConfigMap(cr *operatorv1.Console) *corev1.ConfigMap {
+	configMap := TrustedCAStub()
+	util.AddOwnerRef(configMap, util.OwnerRefFrom(cr))
+	return configMap
+}
+
+func TrustedCAStub() *corev1.ConfigMap {
+	meta := util.SharedMeta()
+	meta.Name = api.TrustedCAConfigMapName
+	meta.Labels = map[string]string{
+		injectTrustedCABundleLabel: "true",
+	}
+	configMap := &corev1.ConfigMap{
+		ObjectMeta: meta,
+		Data: map[string]string{
+			api.TrustedCABundleKey: "",
+		},
+	}
+	return configMap
+}


### PR DESCRIPTION
Story: https://jira.coreos.com/browse/CONSOLE-1669

The `volumes` and `volumeMounts`  are set properly but the `merger.Merge()` in the `configmap.go` is for some reason is dropping the `TrustedCA` variable.