### PR TITLE
Add group to managed and umanaged ClusterVersion overrides

### DIFF
--- a/examples/cvo-manage-operator.yaml
+++ b/examples/cvo-manage-operator.yaml
@@ -9,3 +9,4 @@ spec:
     name: console-operator
     namespace: openshift-console-operator
     unmanaged: false
+    group: apps/v1

--- a/examples/cvo-unmanage-operator.yaml
+++ b/examples/cvo-unmanage-operator.yaml
@@ -9,3 +9,4 @@ spec:
     name: console-operator
     namespace: openshift-console-operator
     unmanaged: true
+    group: apps/v1


### PR DESCRIPTION
We need to add the group, since the overrides are not accepted without it.

/assign @benjaminapetersen 