### PR TITLE
Update Available condition to use handlers

### DIFF
--- a/pkg/console/operator/sync_v400.go
+++ b/pkg/console/operator/sync_v400.go
@@ -132,29 +132,30 @@ func (co *consoleOperator) sync_v400(updatedOperatorConfig *operatorv1.Console, 
 		return nil
 	}())
 
-	// the operand is available if all resources are:
-	// - present
-	// - if we have at least one ready replica
-	// - route is admitted
-	// available is currently defined as "met the users intent"
-	if !deploymentsub.IsReady(actualDeployment) {
-		msg := fmt.Sprintf("%v pods available for console deployment", actualDeployment.Status.ReadyReplicas)
-		klog.V(4).Infoln(msg)
-		co.ConditionDeploymentNotAvailable(updatedOperatorConfig, msg)
-	} else if !routesub.IsAdmitted(rt) {
-		klog.V(4).Infoln("console route is not admitted")
-		co.SetStatusCondition(
-			updatedOperatorConfig,
-			operatorv1.OperatorStatusTypeAvailable,
-			operatorv1.ConditionFalse,
-			"RouteNotAdmitted",
-			"console route is not admitted",
-		)
-	} else if actualDeployment.Status.Replicas == actualDeployment.Status.ReadyReplicas && actualDeployment.Status.Replicas == actualDeployment.Status.UpdatedReplicas {
-		co.ConditionDeploymentAvailable(updatedOperatorConfig, fmt.Sprintf("%v replicas ready at version %s", actualDeployment.Status.ReadyReplicas, os.Getenv("RELEASE_VERSION")))
-	} else {
-		co.ConditionDeploymentAvailable(updatedOperatorConfig, fmt.Sprintf("%v replicas ready", actualDeployment.Status.ReadyReplicas))
-	}
+	co.HandleAvailable(updatedOperatorConfig, "DeploymentIsReady", func() error {
+		if !deploymentsub.IsReady(actualDeployment) {
+			msg := fmt.Sprintf("%v pods available for console deployment", actualDeployment.Status.ReadyReplicas)
+			klog.V(4).Infoln(msg)
+			return errors.New(msg)
+		}
+		return nil
+	}())
+	co.HandleAvailable(updatedOperatorConfig, "DeploymentIsUpdated", func() error {
+		if !deploymentsub.IsReadyAndUpdated(actualDeployment) {
+			msg := fmt.Sprintf("%v replicas ready at version %s", actualDeployment.Status.ReadyReplicas, os.Getenv("RELEASE_VERSION"))
+			klog.V(4).Infoln(msg)
+			return errors.New(msg)
+		}
+		return nil
+	}())
+	co.HandleAvailable(updatedOperatorConfig, "RouteNotAdmitted", func() error {
+		if !routesub.IsAdmitted(rt) {
+			msg := "console route is not admitted"
+			klog.V(4).Infoln(msg)
+			return errors.New(msg)
+		}
+		return nil
+	}())
 
 	// if we survive the gauntlet, we need to update the console config with the
 	// public hostname so that the world can know the console is ready to roll

--- a/pkg/console/starter/starter.go
+++ b/pkg/console/starter/starter.go
@@ -184,7 +184,7 @@ func RunOperator(ctx *controllercmd.ControllerContext) error {
 			"Degraded",
 			// in follow-up PRs, we should stop using the rest directly:
 			"Progressing",
-			// "Available"
+			"Available",
 			// "Faililng"
 		},
 		operatorClient,

--- a/pkg/console/subresource/deployment/deployment.go
+++ b/pkg/console/subresource/deployment/deployment.go
@@ -349,6 +349,11 @@ func IsReady(deployment *appsv1.Deployment) bool {
 	return avail
 }
 
+func IsReadyAndUpdated(deployment *appsv1.Deployment) bool {
+	return deployment.Status.Replicas == deployment.Status.ReadyReplicas &&
+		deployment.Status.Replicas == deployment.Status.UpdatedReplicas
+}
+
 func IsAvailableAndUpdated(deployment *appsv1.Deployment) bool {
 	return deployment.Status.AvailableReplicas > 0 &&
 		deployment.Status.ObservedGeneration >= deployment.Generation &&


### PR DESCRIPTION
Depends on #269 & #271 & will be rebased once it is merged.
Re [bugzilla 1740387](https://bugzilla.redhat.com/show_bug.cgi?id=1740387) - partial fix.

WIP until rebase.
@jhadvig I think #253 can be rebased on this change now as we no longer need the `ConditionsDefault()` as a dependency for the rest of the statuses.

/assign @jhadvig 
@spadgett fyi

This is should handle the rest of the status transition.