### PR TITLE
[WIP] Remove SyncError from Degraded reporting

### DIFF
--- a/pkg/console/operator/operator.go
+++ b/pkg/console/operator/operator.go
@@ -239,15 +239,9 @@ func (c *consoleOperator) handleSync(configs configSet) error {
 	c.ConditionsDefault(updatedStatus)
 	err := c.sync_v400(updatedStatus, configs)
 
-	c.HandleDegraded(updatedStatus, "SyncError", func() error {
-		if !customerrors.IsSyncError(err) {
-			return err
-		}
-		return nil
-	}())
-
+	// anything wrong with custom logo should be reported as degraded
 	c.HandleDegraded(updatedStatus, "CustomLogo", func() error {
-		if !customerrors.IsCustomLogoError(err) {
+		if customerrors.IsCustomLogoError(err) {
 			return err
 		}
 		return nil


### PR DESCRIPTION
/assign @jhadvig @spadgett 

items:
- Small bug fixes around `Degraded`
- Pointing out that our handling of `Degraded` is not great.  We have only 1 Degraded at this point.  Need to clarify this and ensure we are capturing what we need.