### PR TITLE
Bug 1740387: Better Progressing & Degraded condition handling & names

### DIFF
--- a/pkg/console/operator/operator.go
+++ b/pkg/console/operator/operator.go
@@ -45,7 +45,7 @@ import (
 	operatorclientv1 "github.com/openshift/client-go/operator/clientset/versioned/typed/operator/v1"
 
 	// operator
-	customerrors "github.com/openshift/console-operator/pkg/console/errors"
+
 	"github.com/openshift/console-operator/pkg/console/subresource/configmap"
 	"github.com/openshift/console-operator/pkg/console/subresource/deployment"
 	"github.com/openshift/console-operator/pkg/console/subresource/oauthclient"
@@ -237,26 +237,12 @@ func (c *consoleOperator) handleSync(configs configSet) error {
 
 	err := c.sync_v400(updatedStatus, configs)
 
-	c.HandleDegraded(updatedStatus, "SyncError", func() error {
-		if !customerrors.IsSyncError(err) {
-			return err
-		}
-		return nil
-	}())
-
-	c.HandleDegraded(updatedStatus, "CustomLogo", func() error {
-		if !customerrors.IsCustomLogoError(err) {
-			return err
-		}
-		return nil
-	}())
-
 	// finally write out the set of conditions currently set if anything has changed
 	// to avoid a hot loop
 	if !reflect.DeepEqual(updatedStatus, configs.Operator) {
 		c.SyncStatus(updatedStatus)
 	}
-	return nil
+	return err
 }
 
 // this may need to move to sync_v400 if versions ever have custom delete logic

--- a/pkg/console/subresource/route/route.go
+++ b/pkg/console/subresource/route/route.go
@@ -27,16 +27,15 @@ const (
 // returns any other error
 func GetOrCreate(client routeclient.RoutesGetter, required *routev1.Route) (*routev1.Route, bool, error) {
 	isNew := false
-	existing, err := client.Routes(required.Namespace).Get(required.Name, metav1.GetOptions{})
+	route, err := client.Routes(required.Namespace).Get(required.Name, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
 		isNew = true
-		actual, err := client.Routes(required.Namespace).Create(required)
-		return actual, isNew, err
+		route, err = client.Routes(required.Namespace).Create(required)
 	}
 	if err != nil {
 		return nil, isNew, err
 	}
-	return existing, isNew, nil
+	return route, isNew, nil
 }
 
 func DefaultRoute(cr *operatorv1.Console) *routev1.Route {


### PR DESCRIPTION
- Expands from `Progressing`, `Degraded`, `Available` as generic conditions into a plethora of specific `Types`, using these as `Suffix` for categorization & relying on the `ClusterOperatorStatusController()` to condense back down on the `clusteroperator`.  
- Provides specific `Reasons` when state is flipped (with error as `Message`)

New example:

```
# ServiceCASync is not progressing. all is well.
  - lastTransitionTime: "2019-08-26T19:18:52Z"
    status: "False"
    type: ServiceCASyncProgressing

# when not well, reason & message added:

# problems syncing custom logo source file. correction needed. 
  - lastTransitionTime: "2019-08-28T15:47:52Z"
    message: custom logo sync source update error
    reason: FailedSyncSource
    status: "True"
    type: CustomLogoDegraded

# route is not admitted, so no way to access console. (will resolve automatically)
  - lastTransitionTime: "2019-08-28T15:47:52Z"
    message: console route is not admitted
    reason: FailedAdmittedIngress
    status: "True"
    type: RouteAvailable

# etc
```

@jhadvig @spadgett 