### PR TITLE
Bug 1745772: manifests/07-downloads-deployment: Exec Python for signal handling

### DIFF
--- a/manifests/07-downloads-deployment.yaml
+++ b/manifests/07-downloads-deployment.yaml
@@ -98,4 +98,4 @@ spec:
           [Thread(i, socket=sock) for i in range(100)]
           time.sleep(9e9)
           EOF
-          python2 /tmp/serve.py  # the cli image only has Python 2.7
+          exec python2 /tmp/serve.py  # the cli image only has Python 2.7


### PR DESCRIPTION
Instead of setting up signal forwarding between the shell process and Python, just drop the shell process entirely after it has served its purpose.  This might help with SIGTERM and SIGKILL handling; currently this Pod occasionally [takes ~600ms to drain][1]:

    I0826 19:02:54.769125   25457 update.go:89] pod "downloads-769755ddf9-jbhdw" removed (evicted)

which may have eventually resulted [in][3]:

    Aug 26 19:05:01.689 E clusteroperator/machine-config changed Degraded to True: RequiredPoolsFailed: Unable to apply 0.0.1-2019-08-26-172415: timed out waiting for the condition during syncRequiredMachineConfigPools: error pool master is not ready, retrying. Status: (pool degraded: false total: 3, ready 1, updated: 1, unavailable: 1)

I'm not entirely clear on whether this `exec` will fix the issue, but removing a layer of process indirection can't hurt :p.

[1]: https://storage.googleapis.com/origin-ci-test/pr-logs/pull/openshift_cluster-openshift-apiserver-operator/226/pull-ci-openshift-cluster-openshift-apiserver-operator-master-e2e-aws-upgrade/117/artifacts/e2e-aws-upgrade/pods/openshift-machine-config-operator_machine-config-daemon-njwz4_machine-config-daemon_previous.log
[3]: https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/pr-logs/pull/openshift_cluster-openshift-apiserver-operator/226/pull-ci-openshift-cluster-openshift-apiserver-operator-master-e2e-aws-upgrade/117#0:build-log.txt%3A5770