### PR TITLE
Add proxy config to ClusterOperator status related objects

### DIFF
--- a/pkg/console/starter/starter.go
+++ b/pkg/console/starter/starter.go
@@ -162,6 +162,7 @@ func RunOperator(ctx *controllercmd.ControllerContext) error {
 			{Group: operatorv1.GroupName, Resource: "consoles", Name: api.ConfigResourceName},
 			{Group: configv1.GroupName, Resource: "consoles", Name: api.ConfigResourceName},
 			{Group: configv1.GroupName, Resource: "infrastructures", Name: api.ConfigResourceName},
+			{Group: configv1.GroupName, Resource: "proxies", Name: api.ConfigResourceName},
 			{Group: oauth.GroupName, Resource: "oauthclients", Name: api.OAuthClientName},
 			{Group: corev1.GroupName, Resource: "namespaces", Name: api.OpenShiftConsoleOperatorNamespace},
 			{Group: corev1.GroupName, Resource: "namespaces", Name: api.OpenShiftConsoleNamespace},


### PR DESCRIPTION
Related to #254 & #276 we should list the proxy config with the other configs we depend on.

/assign @jhadvig  
per your slack comment!