### PR TITLE
manifests/07-downloads-deployment: Add container probes

### DIFF
--- a/manifests/07-downloads-deployment.yaml
+++ b/manifests/07-downloads-deployment.yaml
@@ -39,6 +39,17 @@ spec:
         - containerPort: 8080
           name: http
           protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 8080
+            scheme: HTTP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /
+            port: 8080
+            scheme: HTTP
         command: ["/bin/sh"]
         resources:
           requests:


### PR DESCRIPTION
Docs [here][1].  Precedent [here][2].  Doesn't seem all that likely that this container will take long to come up or hang afterwards, but doesn't hurt to check.

[1]: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
[2]: https://github.com/openshift/release/commit/866514e635edd5b23939cc6f8eb34da0e5ba1d5f#diff-ed49f06f2ad46798c08292c4aecccee2R65-R75