### PR TITLE
Bug 1745772: manifests/07-downloads-deployment: Set terminationGracePeriodSeconds

### DIFF
--- a/manifests/07-downloads-deployment.yaml
+++ b/manifests/07-downloads-deployment.yaml
@@ -99,3 +99,4 @@ spec:
           time.sleep(9e9)
           EOF
           exec python2 /tmp/serve.py  # the cli image only has Python 2.7
+      terminationGracePeriodSeconds: 1


### PR DESCRIPTION
A second attempt to resolve the slow terminations discussed in 777a02aa0f (#275).  This commit is a bit more direct, and matches precedent [here][1] and [here][2].

[1]: https://github.com/openshift/ci-operator/commit/f20a45fe7aa2eac495dfb3ff5c0417f1db4b745b#diff-53826ade74ebb51dda06c1eb3f69cac9R100
[2]: https://github.com/openshift/release/commit/866514e635edd5b23939cc6f8eb34da0e5ba1d5f#diff-ed49f06f2ad46798c08292c4aecccee2R82