### PR TITLE
Bug 1746966: manifests/07-downloads-route: Set redirect termination

### DIFF
--- a/manifests/07-downloads-route.yaml
+++ b/manifests/07-downloads-route.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   tls:
     termination: edge
+    insecureEdgeTerminationPolicy: Redirect
   port:
     targetPort: http
   to:


### PR DESCRIPTION
Following [the pattern set by other OpenShift routes][1].  [The 4.1 docs][2] around this don't go into much detail on `insecureEdgeTerminationPolicy`, spending the time on HTTP Strict Transport Security (HSTS) instead.  Since HSTS client support is optional, and since we should be using https:// download links anyway, I haven't bothered with the HSTS annotation.

[The 3.11 docs][3] go into more detail on `insecureEdgeTerminationPolicy`, including an example with both edge and redirect termination together.

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=1746966
[2]: https://docs.openshift.com/container-platform/4.1/networking/routes/route-configuration.html#nw-enabling-hsts_route-configuration
[3]: https://docs.openshift.com/container-platform/3.11/architecture/networking/routes.html#secured-routes