### PR TITLE
Improve console pod redeploy annotations

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -15,15 +15,21 @@ const (
 	OpenShiftConsoleConfigMapName       = "console-config"
 	OpenShiftConsolePublicConfigMapName = "console-public"
 	ServiceCAConfigMapName              = "service-ca"
-	OpenShiftConsoleDeploymentName      = OpenShiftConsoleName
-	OpenShiftConsoleServiceName         = OpenShiftConsoleName
-	OpenShiftConsoleRouteName           = OpenShiftConsoleName
-	OAuthClientName                     = OpenShiftConsoleName
-	OpenShiftConfigManagedNamespace     = "openshift-config-managed"
-	OpenShiftConfigNamespace            = "openshift-config"
-	OpenShiftCustomLogoConfigMapName    = "custom-logo"
-	TrustedCAConfigMapName              = "trusted-ca-bundle"
-	TrustedCABundleKey                  = "ca-bundle.crt"
-	TrustedCABundleMountDir             = "/etc/pki/ca-trust/extracted/pem"
-	TrustedCABundleMountFile            = "tls-ca-bundle.pem"
+
+	ServingCertSecretName          = "console-serving-cert"
+	OAuthConfigName                = "console-oauth-config"
+	OpenShiftConsoleDeploymentName = OpenShiftConsoleName
+	OpenShiftConsoleServiceName    = OpenShiftConsoleName
+	OpenShiftConsoleRouteName      = OpenShiftConsoleName
+	OAuthClientName                = OpenShiftConsoleName
+
+	OpenShiftConfigManagedNamespace = "openshift-config-managed"
+	OpenShiftConfigNamespace        = "openshift-config"
+
+	OpenShiftCustomLogoConfigMapName = "custom-logo"
+
+	TrustedCAConfigMapName   = "trusted-ca-bundle"
+	TrustedCABundleKey       = "ca-bundle.crt"
+	TrustedCABundleMountDir  = "/etc/pki/ca-trust/extracted/pem"
+	TrustedCABundleMountFile = "tls-ca-bundle.pem"
 )

--- a/pkg/console/subresource/service/service.go
+++ b/pkg/console/subresource/service/service.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	operatorv1 "github.com/openshift/api/operator/v1"
+	"github.com/openshift/console-operator/pkg/api"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
@@ -14,18 +15,13 @@ const (
 )
 
 const (
-	ConsoleServingCertName = "console-serving-cert"
-	consolePortName        = "https"
-	consolePort            = 443
-	consoleTargetPort      = 8443
+	consolePortName   = "https"
+	consolePort       = 443
+	consoleTargetPort = 8443
 )
 
 func DefaultService(cr *operatorv1.Console) *corev1.Service {
 	labels := util.LabelsForConsole()
-	meta := util.SharedMeta()
-	meta.Annotations = map[string]string{
-		ServingCertSecretAnnotation: ConsoleServingCertName,
-	}
 	service := Stub()
 	service.Spec = corev1.ServiceSpec{
 		Ports: []corev1.ServicePort{
@@ -48,7 +44,7 @@ func DefaultService(cr *operatorv1.Console) *corev1.Service {
 func Stub() *corev1.Service {
 	meta := util.SharedMeta()
 	meta.Annotations = map[string]string{
-		ServingCertSecretAnnotation: ConsoleServingCertName,
+		ServingCertSecretAnnotation: api.ServingCertSecretName,
 	}
 	service := &corev1.Service{
 		ObjectMeta: meta,


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1749474

Improve console deployment redeploy annotations to ensure console recovers from deletion of temporary secrets

- Convert the various `ResourceVersion`s added to the deployment annotations into a hash to make it easier to keep up with adding objects here
- Get the serving cert & add its resource version to the deployment 
- Add hash helper funcs
- Unit tests for helpers
- Reduce some noise from modified unit tests 

/assign @jhadvig 
