### PR TITLE
manifests/07-downloads-deployment: Serve from cli-artifacts

### DIFF
--- a/manifests/07-downloads-deployment.yaml
+++ b/manifests/07-downloads-deployment.yaml
@@ -33,7 +33,7 @@ spec:
       containers:
       - name: download-server
         terminationMessagePolicy: FallbackToLogsOnError
-        image: registry.svc.ci.openshift.org/openshift:cli
+        image: registry.svc.ci.openshift.org/openshift:cli-artifacts
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8080
@@ -85,18 +85,22 @@ spec:
           os.chdir(temp_dir)
           for arch in ['amd64']:
               os.mkdir(arch)
-              for operating_system in ['linux']:
+              for operating_system in ['linux', 'mac', 'windows']:
                   os.mkdir(os.path.join(arch, operating_system))
 
-          for path in [ # TODO: get binaries for other platforms
-                  '/usr/bin/oc',
+          for arch, operating_system, path in [
+                  ('amd64', 'linux', '/usr/bin/oc'),
+                  ('amd64', 'mac', '/usr/share/openshift/mac/oc'),
+                  ('amd64', 'windows', '/usr/share/openshift/windows/oc.exe'),
                   ]:
               basename = os.path.basename(path)
-              target_path = os.path.join('amd64', 'linux', basename)
+              target_path = os.path.join(arch, operating_system, basename)
               os.symlink(path, target_path)
-              with tarfile.open('{}.tar'.format(target_path), 'w') as tar:
+              base_root, _ = os.path.splitext(basename)
+              archive_path_root = os.path.join(arch, operating_system, base_root)
+              with tarfile.open('{}.tar'.format(archive_path_root), 'w') as tar:
                   tar.add(path, basename)
-              with zipfile.ZipFile('{}.zip'.format(target_path), 'w') as zip:
+              with zipfile.ZipFile('{}.zip'.format(archive_path_root), 'w') as zip:
                   zip.write(path, basename)
 
           # Create socket

--- a/manifests/07-downloads-deployment.yaml
+++ b/manifests/07-downloads-deployment.yaml
@@ -33,7 +33,7 @@ spec:
       containers:
       - name: download-server
         terminationMessagePolicy: FallbackToLogsOnError
-        image: docker.io/openshift/origin-cli:latest
+        image: registry.svc.ci.openshift.org/openshift:cli
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8080

--- a/manifests/07-operator.yaml
+++ b/manifests/07-operator.yaml
@@ -32,7 +32,7 @@ spec:
       containers:
       - name: console-operator
         terminationMessagePolicy: FallbackToLogsOnError
-        image: docker.io/openshift/origin-console-operator:latest
+        image: registry.svc.ci.openshift.org/openshift:console-operator
         ports:
         - containerPort: 60000
           name: metrics
@@ -48,7 +48,7 @@ spec:
           name: config
         env:
         - name: IMAGE
-          value: docker.io/openshift/origin-console:latest
+          value: registry.svc.ci.openshift.org/openshift:console
         - name: RELEASE_VERSION
           value: "0.0.1-snapshot"
         - name: OPERATOR_NAME

--- a/manifests/image-references
+++ b/manifests/image-references
@@ -5,12 +5,12 @@ spec:
   - name: console-operator
     from:
       kind: DockerImage
-      name: docker.io/openshift/origin-console-operator:latest
+      name: registry.svc.ci.openshift.org/openshift:console-operator
   - name: console
     from:
       kind: DockerImage
-      name: docker.io/openshift/origin-console:latest
+      name: registry.svc.ci.openshift.org/openshift:console
   - name: cli
     from:
       kind: DockerImage
-      name: docker.io/openshift/origin-cli:latest
+      name: registry.svc.ci.openshift.org/openshift:cli

--- a/manifests/image-references
+++ b/manifests/image-references
@@ -10,7 +10,7 @@ spec:
     from:
       kind: DockerImage
       name: registry.svc.ci.openshift.org/openshift:console
-  - name: cli
+  - name: cli-artifacts
     from:
       kind: DockerImage
-      name: registry.svc.ci.openshift.org/openshift:cli
+      name: registry.svc.ci.openshift.org/openshift:cli-artifacts


### PR DESCRIPTION
This gets us (currently) oc binaries built for Windows and Darwin as well ([cli-artifacts Dockerfile][1]).

While I was bumping cli -> cli-artifacts, I dropped docker.io from the other image references.  Compare openshift/machine-config-operator#750 for that commit.  I can spin that out into its own PR if you want to review separately.

[1]: https://github.com/openshift/oc/blob/58a901446e84410b2b754575fac1f45117f6eece/images/cli-artifacts/Dockerfile.rhel#L7