### PR TITLE
Proxy e2e test

### DIFF
--- a/test/e2e/framework/clientset.go
+++ b/test/e2e/framework/clientset.go
@@ -22,6 +22,7 @@ type ClientSet struct {
 	Operator        operatorclientv1.ConsolesGetter
 	Console         configv1.ConsolesGetter
 	ClusterOperator configv1.ClusterOperatorsGetter
+	Proxy           configv1.ProxiesGetter
 }
 
 // NewClientset creates a set of Kubernetes clients. The default kubeconfig is
@@ -59,6 +60,7 @@ func NewClientset(kubeconfig *restclient.Config) (*ClientSet, error) {
 		return nil, err
 	}
 	clientset.Console = configClient
+	clientset.Proxy = configClient
 	clientset.ClusterOperator = configClient
 
 	return clientset, nil

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	consoleapi "github.com/openshift/console-operator/pkg/api"
@@ -27,6 +28,16 @@ var (
 
 	AsyncOperationTimeout = 5 * time.Minute
 )
+
+func SetClusterProxyConfig(proxyConfig configv1.ProxySpec, client *ClientSet) error {
+	_, err := client.Proxy.Proxies().Patch(consoleapi.ConfigResourceName, types.MergePatchType, []byte(fmt.Sprintf(`{"spec": {"httpProxy": "%s", "httpsProxy": "%s", "noProxy": "%s"}}`, proxyConfig.HTTPProxy, proxyConfig.HTTPSProxy, proxyConfig.NoProxy)))
+	return err
+}
+
+func ResetClusterProxyConfig(client *ClientSet) error {
+	_, err := client.Proxy.Proxies().Patch(consoleapi.ConfigResourceName, types.MergePatchType, []byte(`{"spec": {"httpProxy": "", "httpsProxy": "", "noProxy": ""}}`))
+	return err
+}
 
 func DeleteAll(t *testing.T, client *ClientSet) {
 	resources := []string{"Deployment", "Service", "Route", "ConfigMap"}

--- a/test/e2e/framework/utils.go
+++ b/test/e2e/framework/utils.go
@@ -1,9 +1,13 @@
 package framework
 
 import (
+	"fmt"
+	"reflect"
+	"strings"
 	"testing"
 
 	v1 "github.com/openshift/api/operator/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/util/retry"
 )
 
@@ -40,4 +44,31 @@ func StandardCleanup(t *testing.T, client *ClientSet) {
 		t.Fatal(err)
 	}
 	WaitForSettledState(t, client)
+}
+
+func CheckEnvVars(want []corev1.EnvVar, have []corev1.EnvVar, includes bool) []error {
+	var errs []error
+
+	for _, val := range want {
+		found := false
+		for _, v := range have {
+			if v.Name == val.Name {
+				found = true
+				if includes {
+					if !strings.Contains(v.Value, val.Value) {
+						errs = append(errs, fmt.Errorf("environment variable does not contain the expected value: expected %#v, got %#v", val, v))
+					}
+				} else {
+					if !reflect.DeepEqual(v, val) {
+						errs = append(errs, fmt.Errorf("environment variable does not equal the expected value: expected %#v, got %#v", val, v))
+					}
+				}
+			}
+		}
+		if !found {
+			errs = append(errs, fmt.Errorf("unable to find environment variable: wanted %s", val.Name))
+		}
+	}
+
+	return errs
 }

--- a/test/e2e/proxy_test.go
+++ b/test/e2e/proxy_test.go
@@ -1,0 +1,86 @@
+package e2e
+
+import (
+	"testing"
+	"time"
+
+	apps1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	configv1 "github.com/openshift/api/config/v1"
+	operatorsv1 "github.com/openshift/api/operator/v1"
+	"github.com/openshift/console-operator/test/e2e/framework"
+)
+
+func setupProxyTest(t *testing.T) (*framework.ClientSet, *operatorsv1.Console) {
+	clientSet, operatorConfig := framework.StandardSetup(t)
+	return clientSet, operatorConfig
+}
+
+func cleanupProxyTest(t *testing.T, clientSet *framework.ClientSet) {
+	framework.ResetClusterProxyConfig(clientSet)
+	framework.StandardCleanup(t, clientSet)
+}
+
+func TestProxy(t *testing.T) {
+	client, _ := setupProxyTest(t)
+	defer cleanupProxyTest(t, client)
+
+	clusterProxyConfig := configv1.ProxySpec{
+		NoProxy:    "clusternoproxy.example.com",
+		HTTPProxy:  "http://clusterhttpproxy.example.com",
+		HTTPSProxy: "https://clusterhttpsproxy.example.com",
+	}
+
+	proxyEnvVars := map[string][]corev1.EnvVar{
+		"emtpyVars": {
+			{Name: "NO_PROXY", Value: "", ValueFrom: nil},
+			{Name: "HTTP_PROXY", Value: "", ValueFrom: nil},
+			{Name: "HTTPS_PROXY", Value: "", ValueFrom: nil},
+		},
+		"clusterVars": {
+			{Name: "NO_PROXY", Value: clusterProxyConfig.NoProxy, ValueFrom: nil},
+			{Name: "HTTP_PROXY", Value: clusterProxyConfig.HTTPProxy, ValueFrom: nil},
+			{Name: "HTTPS_PROXY", Value: clusterProxyConfig.HTTPSProxy, ValueFrom: nil},
+		},
+	}
+
+	consoleDeployment, err := framework.GetConsoleDeployment(client)
+	if err != nil {
+		t.Fatalf("error: %s", err)
+	}
+
+	for _, err = range framework.CheckEnvVars(proxyEnvVars["emptyVars"], consoleDeployment.Spec.Template.Spec.Containers[0].Env, true) {
+		t.Errorf("%v", err)
+	}
+
+	if err := framework.SetClusterProxyConfig(clusterProxyConfig, client); err != nil {
+		t.Errorf("unable to patch cluster proxy instance: %v", err)
+	}
+
+	t.Logf("waiting for the new console deployment with proxy environment variables...")
+	var newConsoleDeployment *apps1.Deployment
+	err = wait.Poll(1*time.Second, framework.AsyncOperationTimeout, func() (stop bool, err error) {
+		newConsoleDeployment, err = framework.GetConsoleDeployment(client)
+		if err != nil {
+			return false, err
+		}
+		if errors.IsNotFound(err) {
+			return false, nil
+		}
+		if newConsoleDeployment.Status.ObservedGeneration != consoleDeployment.Status.ObservedGeneration {
+			return true, nil
+		}
+		return false, nil
+	})
+
+	for _, err = range framework.CheckEnvVars(proxyEnvVars["clusterVars"], newConsoleDeployment.Spec.Template.Spec.Containers[0].Env, true) {
+		t.Fatal(err)
+	}
+
+	if err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
Test scenario: 
- e2e test for setting `NoProxy` & `HTTPProxy` & `HTTPSProxy` to the Proxy CR and checking the new rolledout console deployment pod for corresponding environment variables (`NO_PROXY` & `HTTP_PROXY` & `HTTPS_PROXY`) 

/assign @benjaminapetersen 