### PR TITLE
Bug 1753672: Redeploy console deployment upon proxy changes

### DIFF
--- a/pkg/console/starter/starter.go
+++ b/pkg/console/starter/starter.go
@@ -139,7 +139,6 @@ func RunOperator(ctx *controllercmd.ControllerContext) error {
 		kubeInformersNamespaced.Apps().V1().Deployments(), // Deployments
 		routesInformersNamespaced.Route().V1().Routes(),   // Route
 		oauthInformers.Oauth().V1().OAuthClients(),        // OAuth clients
-		configInformers.Config().V1().Proxies(),           // Proxy
 		// clients
 		operatorConfigClient.OperatorV1(),
 		configClient.ConfigV1(),

--- a/pkg/console/subresource/deployment/deployment.go
+++ b/pkg/console/subresource/deployment/deployment.go
@@ -32,6 +32,7 @@ const (
 
 const (
 	configMapResourceVersionAnnotation          = "console.openshift.io/console-config-version"
+	proxyConfigResourceVersionAnnotation        = "console.openshift.io/proxy-config-version"
 	serviceCAConfigMapResourceVersionAnnotation = "console.openshift.io/service-ca-config-version"
 	trustedCAConfigMapResourceVersionAnnotation = "console.openshift.io/trusted-ca-config-version"
 	secretResourceVersionAnnotation             = "console.openshift.io/oauth-secret-version"
@@ -41,6 +42,7 @@ const (
 var (
 	resourceAnnotations = []string{
 		configMapResourceVersionAnnotation,
+		proxyConfigResourceVersionAnnotation,
 		serviceCAConfigMapResourceVersionAnnotation,
 		trustedCAConfigMapResourceVersionAnnotation,
 		secretResourceVersionAnnotation,
@@ -67,6 +69,7 @@ func DefaultDeployment(operatorConfig *operatorv1.Console, cm *corev1.ConfigMap,
 		configMapResourceVersionAnnotation:          cm.GetResourceVersion(),
 		serviceCAConfigMapResourceVersionAnnotation: serviceCAConfigMap.GetResourceVersion(),
 		trustedCAConfigMapResourceVersionAnnotation: trustedCAConfigMap.GetResourceVersion(),
+		proxyConfigResourceVersionAnnotation:        proxyConfig.GetResourceVersion(),
 		secretResourceVersionAnnotation:             sec.GetResourceVersion(),
 		consoleImageAnnotation:                      util.GetImageEnv(),
 	}

--- a/pkg/console/subresource/deployment/deployment_test.go
+++ b/pkg/console/subresource/deployment/deployment_test.go
@@ -62,6 +62,7 @@ func TestDefaultDeployment(t *testing.T) {
 			secretResourceVersionAnnotation:             "",
 			serviceCAConfigMapResourceVersionAnnotation: "",
 			trustedCAConfigMapResourceVersionAnnotation: "",
+			proxyConfigResourceVersionAnnotation:        "",
 			consoleImageAnnotation:                      "",
 		},
 		OwnerReferences: nil,
@@ -119,6 +120,7 @@ func TestDefaultDeployment(t *testing.T) {
 		secretResourceVersionAnnotation:             "",
 		serviceCAConfigMapResourceVersionAnnotation: "",
 		trustedCAConfigMapResourceVersionAnnotation: "",
+		proxyConfigResourceVersionAnnotation:        "",
 		consoleImageAnnotation:                      "",
 	}
 


### PR DESCRIPTION
The console deployment has not been rollout upon changes made to the Proxy CR.
+ refact a the Proxy codebase

Tested manually on latest cluster and it's fixing the issue.

/assign @benjaminapetersen 

FYI @spadgett 