### PR TITLE
Add monitoring to console (operand)

### DIFF
--- a/manifests/0000_90_console-operator_01_prometheusrbac.yaml
+++ b/manifests/0000_90_console-operator_01_prometheusrbac.yaml
@@ -30,3 +30,36 @@ subjects:
   - kind: ServiceAccount
     name: prometheus-k8s
     namespace: openshift-monitoring
+---
+# Role for accessing metrics exposed by console resources
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: prometheus-k8s
+  namespace: openshift-console
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - services
+      - endpoints
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+---
+# Grant cluster-monitoring access to openshift-console metrics
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: prometheus-k8s
+  namespace: openshift-console
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: prometheus-k8s
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-k8s
+    namespace: openshift-monitoring

--- a/manifests/0000_90_console-operator_02_servicemonitor.yaml
+++ b/manifests/0000_90_console-operator_02_servicemonitor.yaml
@@ -18,4 +18,25 @@ spec:
   selector:
     matchLabels:
       name: console-operator
-
+---
+# Configure cluster-monitoring for cluster console resources
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: console
+  namespace: openshift-console
+spec:
+  endpoints:
+    - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      interval: 30s
+      path: /metrics
+      port: https
+      scheme: https
+      tlsConfig:
+        caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+        serverName: console.openshift-console.svc
+  jobLabel: component
+  selector:
+    matchLabels:
+      app: console
+      component: ui

--- a/manifests/02-namespace.yaml
+++ b/manifests/02-namespace.yaml
@@ -4,6 +4,8 @@ metadata:
   name: openshift-console
   annotations:
     openshift.io/node-selector: ""
+  labels:
+    openshift.io/cluster-monitoring: "true"
 ---
 apiVersion: v1
 kind: Namespace
@@ -13,3 +15,4 @@ metadata:
     openshift.io/node-selector: ""
   labels:
     openshift.io/cluster-monitoring: "true"
+


### PR DESCRIPTION
Instructs monitoring to scrape the console at `/metrics` endpoint 

- Depends on https://github.com/openshift/console/pull/2821 which will add the `/metrics` endpoint.