### PR TITLE
manifests/07-downloads-deployment: Catch and exit on TERM

### DIFF
--- a/manifests/07-downloads-deployment.yaml
+++ b/manifests/07-downloads-deployment.yaml
@@ -59,7 +59,9 @@ spec:
         - '-c'
         - |
           cat <<EOF >>/tmp/serve.py
-          import BaseHTTPServer, os, re, SimpleHTTPServer, socket, tarfile, tempfile, threading, time, zipfile
+          import BaseHTTPServer, os, re, signal, SimpleHTTPServer, socket, sys, tarfile, tempfile, threading, time, zipfile
+
+          signal.signal(signal.SIGTERM, lambda signum, frame: sys.exit(0))
 
           # Launch multiple listeners as threads
           class Thread(threading.Thread):


### PR DESCRIPTION
It's possible that this process would run as PID 1 in a PID namespace, and [PID 1 has special handling][1]:

> Only signals for which the "init" process has established a signal handler can be sent to the "init" process by other members of the PID namespace.

That's unlikely to be important for termination, because CRI-O will be TERMing the process from outside the pod's PID namespace.  With the coming PID-namespace sharing [2], you could set this container process
up to not be PID 1 in any namespace.

But regardless, gracefully exiting when we're asked to is polite behavior.  In the future, we might want to add something here to delay exiting until we have finished serving any ongoing downloads (or at least give them a fair shot at finishing), but clients can always retry any downloads that fail because our pod was killed, so I'm not worrying about that now.

[1]: http://man7.org/linux/man-pages/man7/pid_namespaces.7.html
[2]: https://kubernetes.io/docs/tasks/configure-pod-container/share-process-namespace/