### PR TITLE
Make status handlers standalone helper funcs

### DIFF
--- a/pkg/console/operator/operator.go
+++ b/pkg/console/operator/operator.go
@@ -42,7 +42,7 @@ import (
 	operatorclientv1 "github.com/openshift/client-go/operator/clientset/versioned/typed/operator/v1"
 
 	// operator
-
+	statushelpers "github.com/openshift/console-operator/pkg/console/status"
 	"github.com/openshift/console-operator/pkg/console/subresource/configmap"
 	"github.com/openshift/console-operator/pkg/console/subresource/deployment"
 	"github.com/openshift/console-operator/pkg/console/subresource/oauthclient"
@@ -212,18 +212,18 @@ func (c *consoleOperator) handleSync(configs configSet) error {
 	case operatorsv1.Unmanaged:
 		klog.V(4).Infoln("console is in an unmanaged state.")
 		if !reflect.DeepEqual(updatedStatus, configs.Operator) {
-			c.SyncStatus(updatedStatus)
+			statushelpers.SyncStatus(c.operatorConfigClient, updatedStatus)
 		}
 		return nil
 	case operatorsv1.Removed:
 		klog.V(4).Infoln("console has been removed.")
 		if !reflect.DeepEqual(updatedStatus, configs.Operator) {
-			c.SyncStatus(updatedStatus)
+			statushelpers.SyncStatus(c.operatorConfigClient, updatedStatus)
 		}
 		return c.removeConsole(updatedStatus)
 	default:
 		if !reflect.DeepEqual(updatedStatus, configs.Operator) {
-			c.SyncStatus(updatedStatus)
+			statushelpers.SyncStatus(c.operatorConfigClient, updatedStatus)
 		}
 		return fmt.Errorf("console is in an unknown state: %v", updatedStatus.Spec.ManagementState)
 	}
@@ -233,7 +233,7 @@ func (c *consoleOperator) handleSync(configs configSet) error {
 	// finally write out the set of conditions currently set if anything has changed
 	// to avoid a hot loop
 	if !reflect.DeepEqual(updatedStatus, configs.Operator) {
-		c.SyncStatus(updatedStatus)
+		statushelpers.SyncStatus(c.operatorConfigClient, updatedStatus)
 	}
 	return err
 }

--- a/pkg/console/status/status_test.go
+++ b/pkg/console/status/status_test.go
@@ -1,4 +1,4 @@
-package operator
+package status
 
 import (
 	"errors"
@@ -58,8 +58,7 @@ func TestHandleDegraded(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			operator := consoleOperator{}
-			operator.HandleDegraded(tt.args.operatorConfig, tt.args.typePrefix, tt.args.errorReason, tt.args.err)
+			HandleDegraded(tt.args.operatorConfig, tt.args.typePrefix, tt.args.errorReason, tt.args.err)
 
 			condition := tt.args.operatorConfig.Status.Conditions[0]
 			// nil the time for easier matching
@@ -117,8 +116,7 @@ func TestHandleProgressing(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			operator := consoleOperator{}
-			operator.HandleProgressing(tt.args.operatorConfig, tt.args.typePrefix, tt.args.errorReason, tt.args.err)
+			HandleProgressing(tt.args.operatorConfig, tt.args.typePrefix, tt.args.errorReason, tt.args.err)
 
 			condition := tt.args.operatorConfig.Status.Conditions[0]
 			// nil the time for easier matching
@@ -216,8 +214,7 @@ func TestHandleProgressingOrDegraded(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			operator := consoleOperator{}
-			operator.HandleProgressingOrDegraded(tt.input.operatorConfig, tt.input.typePrefix, tt.input.errorReason, tt.input.err)
+			HandleProgressingOrDegraded(tt.input.operatorConfig, tt.input.typePrefix, tt.input.errorReason, tt.input.err)
 
 			progressingCondition := operatorv1.OperatorCondition{}
 			degradedCondition := operatorv1.OperatorCondition{}


### PR DESCRIPTION
Make status handlers standalone helper funcs that can be used across controllers

This makes them useful now that we want to break off into separate controllers. See:

- #306 CLIDownloadsController 
- #305 ServiceSyncController 

/assign @jhadvig @spadgett 