### PR TITLE
Reorganize args to NewConsoleOperator func

### DIFF
--- a/pkg/console/operator/operator.go
+++ b/pkg/console/operator/operator.go
@@ -76,25 +76,28 @@ type consoleOperator struct {
 }
 
 func NewConsoleOperator(
-	// informers
-	operatorConfigInformer operatorinformerv1.ConsoleInformer,
-	configInformer configinformer.SharedInformerFactory,
-
-	coreV1 corev1.Interface,
-	managedCoreV1 corev1.Interface,
-	deployments appsinformersv1.DeploymentInformer,
-	routes routesinformersv1.RouteInformer,
-	oauthClients oauthinformersv1.OAuthClientInformer,
-
-	// clients
-	operatorConfigClient operatorclientv1.OperatorV1Interface,
+	// top level config
 	configClient configclientv1.ConfigV1Interface,
+	configInformer configinformer.SharedInformerFactory,
+	// operator
+	operatorConfigClient operatorclientv1.OperatorV1Interface,
+	operatorConfigInformer operatorinformerv1.ConsoleInformer,
+	// core resources
 	corev1Client coreclientv1.CoreV1Interface,
+	coreV1 corev1.Interface,
+	// deployments
 	deploymentClient appsv1.DeploymentsGetter,
+	deployments appsinformersv1.DeploymentInformer,
+	// routes
 	routev1Client routeclientv1.RoutesGetter,
+	routes routesinformersv1.RouteInformer,
+	// oauth
 	oauthv1Client oauthclientv1.OAuthClientsGetter,
+	oauthClients oauthinformersv1.OAuthClientInformer,
+	// openshift managed
+	managedCoreV1 corev1.Interface,
+	// event handling
 	versionGetter status.VersionGetter,
-	// recorder
 	recorder events.Recorder,
 	resourceSyncer resourcesynccontroller.ResourceSyncer,
 ) operator.Runner {

--- a/pkg/console/starter/starter.go
+++ b/pkg/console/starter/starter.go
@@ -131,22 +131,28 @@ func RunOperator(ctx *controllercmd.ControllerContext) error {
 
 	// TODO: rearrange these into informer,client pairs, NOT separated.
 	consoleOperator := operator.NewConsoleOperator(
-		// informers
-		operatorConfigInformers.Operator().V1().Consoles(), // OperatorConfig
-		configInformers,                                   // ConsoleConfig
-		kubeInformersNamespaced.Core().V1(),               // Secrets, ConfigMaps, Service
-		kubeInformersManagedNamespaced.Core().V1(),        // Managed ConfigMaps
-		kubeInformersNamespaced.Apps().V1().Deployments(), // Deployments
-		routesInformersNamespaced.Route().V1().Routes(),   // Route
-		oauthInformers.Oauth().V1().OAuthClients(),        // OAuth clients
-		// clients
-		operatorConfigClient.OperatorV1(),
+		// top level config
 		configClient.ConfigV1(),
+		configInformers,
+		// operator
+		operatorConfigClient.OperatorV1(),
+		operatorConfigInformers.Operator().V1().Consoles(), // OperatorConfig
 
-		kubeClient.CoreV1(), // Secrets, ConfigMaps, Service
+		// core resources
+		kubeClient.CoreV1(),                 // Secrets, ConfigMaps, Service
+		kubeInformersNamespaced.Core().V1(), // Secrets, ConfigMaps, Service
+		// deployments
 		kubeClient.AppsV1(),
+		kubeInformersNamespaced.Apps().V1().Deployments(), // Deployments
+		// routes
 		routesClient.RouteV1(),
+		routesInformersNamespaced.Route().V1().Routes(), // Route
+		// oauth
 		oauthClient.OauthV1(),
+		oauthInformers.Oauth().V1().OAuthClients(), // OAuth clients
+		// openshift managed
+		kubeInformersManagedNamespaced.Core().V1(), // Managed ConfigMaps
+		// event handling
 		versionGetter,
 		recorder,
 		resourceSyncer,


### PR DESCRIPTION
Reorganize args to NewConsoleOperator() to fit client/informer sets together.

This will make it easier to extract out components into separate controllers. 

/assign @jhadvig 