### PR TITLE
Expose /metrics endpoint for monitoring

### DIFF
--- a/manifests/0000_90_console-operator_01_prometheusrbac.yaml
+++ b/manifests/0000_90_console-operator_01_prometheusrbac.yaml
@@ -1,0 +1,32 @@
+# Role for accessing metrics exposed by the console-operator
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: prometheus-k8s
+  namespace: openshift-console-operator
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - services
+      - endpoints
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+---
+# Grant cluster-monitoring access to console-operator metrics
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: prometheus-k8s
+  namespace: openshift-console-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: prometheus-k8s
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-k8s
+    namespace: openshift-monitoring

--- a/manifests/0000_90_console-operator_02_servicemonitor.yaml
+++ b/manifests/0000_90_console-operator_02_servicemonitor.yaml
@@ -1,0 +1,21 @@
+# Configure cluster-monitoring for console-operator
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: console-operator
+  namespace: openshift-console-operator
+spec:
+  endpoints:
+    - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      interval: 30s
+      path: /metrics
+      port: https
+      scheme: https
+      tlsConfig:
+        caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+        serverName: metrics.openshift-console-operator.svc
+  jobLabel: component
+  selector:
+    matchLabels:
+      name: console-operator
+

--- a/manifests/02-namespace.yaml
+++ b/manifests/02-namespace.yaml
@@ -11,3 +11,5 @@ metadata:
   name: openshift-console-operator
   annotations:
     openshift.io/node-selector: ""
+  labels:
+    openshift.io/cluster-monitoring: "true"

--- a/manifests/04-rbac-rolebinding.yaml
+++ b/manifests/04-rbac-rolebinding.yaml
@@ -25,19 +25,6 @@ subjects:
 - kind: ServiceAccount
   name: console-operator
 ---
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: console-operator
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: console-operator
-subjects:
-- kind: ServiceAccount
-  name: console-operator
-  namespace: openshift-console-operator
----
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -65,3 +52,32 @@ subjects:
   - kind: Group
     name: system:authenticated
     apiGroup: rbac.authorization.k8s.io
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: console-operator
+  namespace: openshift-config
+roleRef:
+  kind: Role
+  name: console-operator
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: console-operator
+    namespace: openshift-console-operator
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: console-operator
+  namespace: kube-system
+roleRef:
+  kind: Role
+  name: extension-apiserver-authentication-reader
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: console-operator
+    namespace: openshift-console-operator
+

--- a/manifests/05-config.yaml
+++ b/manifests/05-config.yaml
@@ -9,7 +9,3 @@ data:
     kind: GenericOperatorConfig
     leaderElection:
       namespace: openshift-console-operator
-    authentication:
-      disabled: true
-    authorization:
-      disabled: true

--- a/manifests/05-service.yaml
+++ b/manifests/05-service.yaml
@@ -1,0 +1,20 @@
+# Expose operator metrics
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.alpha.openshift.io/serving-cert-secret-name: serving-cert
+  labels:
+    name: console-operator
+  name: metrics
+  namespace: openshift-console-operator
+spec:
+  ports:
+    - name: https
+      port: 443
+      protocol: TCP
+      targetPort: 8443
+  selector:
+    name: console-operator
+  sessionAffinity: None
+  type: ClusterIP

--- a/manifests/07-operator.yaml
+++ b/manifests/07-operator.yaml
@@ -46,6 +46,8 @@ spec:
         volumeMounts:
         - mountPath: /var/run/configmaps/config
           name: config
+        - mountPath: /var/run/secrets/serving-cert
+          name: serving-cert
         env:
         - name: IMAGE
           value: docker.io/openshift/origin-console:latest
@@ -65,3 +67,7 @@ spec:
       - name: config
         configMap:
           name: console-operator-config
+      - name: serving-cert
+        secret:
+          secretName: serving-cert
+          optional: true


### PR DESCRIPTION
This is a `cherry-pick` (with resolutions) of #270 which exposes metrics, specifically `console_url`  in 4.2.

- Add manifest for ServiceMonitor object
- Authorize prometheus to scrape metrics from console & console-operator
  - NOTE: console disabled until we support the /metrics endpoint
- RBAC
  - reenable delegated auth
  - add rolebinding to kube-system for
extension-apiserver-authentication-reader for console-operatoro
  - add clusterrole system:auth-delegator to console-operator
  - allows authentication (tokenreview) and authorization
(subjectaccessreview)
  - required as the /metrics endpoint is protected
- mount serving-cert in operator deployment
- add labels to namespaces to tell openshift monitoring to begin
monitoring