### PR TITLE
Temporarily return extension CRDs from cluster-config-operator to our Manifests dir

### DIFF
--- a/manifests/00-crd-consoleclidownloads.yaml
+++ b/manifests/00-crd-consoleclidownloads.yaml
@@ -1,0 +1,85 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: consoleclidownloads.console.openshift.io
+  annotations:
+    displayName: ConsoleCLIDownload
+    description: Extension for configuring openshift web console command line interface
+      (CLI) downloads.
+spec:
+  scope: Cluster
+  group: console.openshift.io
+  versions:
+    - name: v1
+      served: true
+      storage: true
+  names:
+    plural: consoleclidownloads
+    singular: consoleclidownload
+    kind: ConsoleCLIDownload
+    listKind: ConsoleCLIDownloadList
+  additionalPrinterColumns:
+    - name: Display name
+      type: string
+      JSONPath: .spec.displayName
+    - name: Age
+      type: string
+      JSONPath: .metadata.creationTimestamp
+    - name: Description
+      type: string
+      JSONPath: .spec.description
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: ConsoleCLIDownload is an extension for configuring openshift web
+        console command line interface (CLI) downloads.
+      type: object
+      required:
+        - spec
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          description: Standard object's metadata.
+          type: object
+        spec:
+          description: ConsoleCLIDownloadSpec is the desired cli download configuration.
+          type: object
+          required:
+            - description
+            - displayName
+            - links
+          properties:
+            description:
+              description: description is the description of the CLI download (can
+                include markdown).
+              type: string
+            displayName:
+              description: displayName is the display name of the CLI download.
+              type: string
+            links:
+              description: links is a list of objects that provide CLI download link
+                details.
+              type: array
+              items:
+                type: object
+                required:
+                  - href
+                properties:
+                  href:
+                    description: href is the absolute secure URL for the link (must
+                      use https)
+                    type: string
+                    pattern: ^https://([\w-]+.)+[\w-]+(/[\w- ./?%&=])?$
+                  text:
+                    description: text is the display text for the link
+                    type: string

--- a/manifests/00-crd-consoleexternalloglinks.yaml
+++ b/manifests/00-crd-consoleexternalloglinks.yaml
@@ -1,0 +1,89 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: consoleexternalloglinks.console.openshift.io
+  annotations:
+    displayName: ConsoleExternalLogLinks
+    description: ConsoleExternalLogLink is an extension for customizing OpenShift
+      web console log links.
+spec:
+  scope: Cluster
+  group: console.openshift.io
+  versions:
+    - name: v1
+      served: true
+      storage: true
+  names:
+    plural: consoleexternalloglinks
+    singular: consoleexternalloglink
+    kind: ConsoleExternalLogLink
+    listKind: ConsoleExternalLogLinkList
+  additionalPrinterColumns:
+    - name: Text
+      type: string
+      JSONPath: .spec.text
+    - name: HrefTemplate
+      type: string
+      JSONPath: .spec.hrefTemplate
+    - name: Age
+      type: date
+      JSONPath: .metadata.creationTimestamp
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: ConsoleExternalLogLink is an extension for customizing OpenShift
+        web console log links.
+      type: object
+      required:
+        - spec
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          description: Standard object's metadata.
+          type: object
+        spec:
+          description: ConsoleExternalLogLinkSpec is the desired log link configuration.
+            The log link will appear on the logs tab of the pod details page.
+          type: object
+          required:
+            - hrefTemplate
+            - text
+          properties:
+            hrefTemplate:
+              description: "hrefTemplate is an absolute secure URL (must use https)
+                for the log link including variables to be replaced. Variables are
+                specified in the URL with the format ${variableName}, for instance,
+                ${containerName} and will be replaced with the corresponding values
+                from the resource. Resource is a pod. Supported variables are:
+                - ${resourceName} - name of the resource which containes the logs
+                - ${resourceUID} - UID of the resource which contains the logs
+                  - e.g. `11111111-2222-3333-4444-555555555555`
+                - ${containerName} - name of the resource's container that contains the logs
+                - ${resourceNamespace} - namespace of the resource that contains the logs
+                - ${resourceNamespaceUID} - namespace UID of the resource that contains the logs
+                - ${podLabels} - JSON representation of labels matching the pod with the logs
+                  - e.g. `{\"key1\":\"value1\",\"key2\":\"value2\"}`
+                e.g., https://example.com/logs?resourceName=${resourceName}&containerName=${containerName}&resourceNamespace=${resourceNamespace}&podLabels=${podLabels}"
+              type: string
+              pattern: ^https://
+            namespaceFilter:
+              description: namespaceFilter is a regular expression used to restrict
+                a log link to a matching set of namespaces (e.g., `^openshift-`).
+                The string is converted into a regular expression using the JavaScript
+                RegExp constructor. If not specified, links will be displayed for
+                all the namespaces.
+              type: string
+            text:
+              description: text is the display text for the link
+              type: string
+

--- a/manifests/00-crd-consolelinks.yaml
+++ b/manifests/00-crd-consolelinks.yaml
@@ -1,0 +1,112 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: consolelinks.console.openshift.io
+  annotations:
+    displayName: ConsoleLinks
+    description: Extension for customizing OpenShift web console links
+spec:
+  scope: Cluster
+  group: console.openshift.io
+  versions:
+    - name: v1
+      served: true
+      storage: true
+  names:
+    plural: consolelinks
+    singular: consolelink
+    kind: ConsoleLink
+    listKind: ConsoleLinkList
+  additionalPrinterColumns:
+    - name: Text
+      type: string
+      JSONPath: .spec.text
+    - name: URL
+      type: string
+      JSONPath: .spec.href
+    - name: Menu
+      type: string
+      JSONPath: .spec.menu
+    - name: Age
+      type: date
+      JSONPath: .metadata.creationTimestamp
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: ConsoleLink is an extension for customizing OpenShift web console
+        links.
+      type: object
+      required:
+        - spec
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          description: Standard object's metadata.
+          type: object
+        spec:
+          description: ConsoleLinkSpec is the desired console link configuration.
+          type: object
+          required:
+            - href
+            - location
+            - text
+          properties:
+            applicationMenu:
+              description: applicationMenu holds information about section and icon
+                used for the link in the application menu, and it is applicable only
+                when location is set to ApplicationMenu.
+              type: object
+              required:
+                - section
+              properties:
+                imageURL:
+                  description: imageUrl is the URL for the icon used in front of the
+                    link in the application menu. The URL must be an HTTPS URL or
+                    a Data URI. The image should be square and will be shown at 24x24
+                    pixels.
+                  type: string
+                section:
+                  description: section is the section of the application menu in which
+                    the link should appear. This can be any text that will appear
+                    as a subheading in the application menu dropdown. A new section
+                    will be created if the text does not match text of an existing
+                    section.
+                  type: string
+            href:
+              description: href is the absolute secure URL for the link (must use
+                https)
+              type: string
+              pattern: ^https://([\w-]+.)+[\w-]+(/[\w- ./?%&=])?$
+            location:
+              description: location determines which location in the console the link
+                will be appended to (ApplicationMenu, HelpMenu, UserMenu, NamespaceDashboard).
+              type: string
+              pattern: ^(ApplicationMenu|HelpMenu|UserMenu|NamespaceDashboard)$
+            namespaceDashboard:
+              description: namespaceDashboard holds information about namespaces in
+                which the dashboard link should appear, and it is applicable only
+                when location is set to NamespaceDashboard. If not specified, the
+                link will appear in all namespaces.
+              type: object
+              required:
+                - namespaces
+              properties:
+                namespaces:
+                  description: namespaces is an array of namespace names in which
+                    the dashboard link should appear.
+                  type: array
+                  items:
+                    type: string
+            text:
+              description: text is the display text for the link
+              type: string

--- a/manifests/00-crd-consolenotifications.yaml
+++ b/manifests/00-crd-consolenotifications.yaml
@@ -1,0 +1,89 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: consolenotifications.console.openshift.io
+  annotations:
+    displayName: ConsoleNotification
+    description: Extension for configuring openshift web console notifications.
+spec:
+  scope: Cluster
+  group: console.openshift.io
+  versions:
+    - name: v1
+      served: true
+      storage: true
+  names:
+    plural: consolenotifications
+    singular: consolenotification
+    kind: ConsoleNotification
+    listKind: ConsoleNotificationList
+  additionalPrinterColumns:
+    - name: Text
+      type: string
+      JSONPath: .spec.text
+    - name: Location
+      type: string
+      JSONPath: .spec.location
+    - name: Age
+      type: date
+      JSONPath: .metadata.creationTimestamp
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: ConsoleNotification is the extension for configuring openshift
+        web console notifications.
+      type: object
+      required:
+        - spec
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          description: Standard object's metadata.
+          type: object
+        spec:
+          description: ConsoleNotificationSpec is the desired console notification
+            configuration.
+          type: object
+          required:
+            - text
+          properties:
+            backgroundColor:
+              description: backgroundColor is the color of the background for the
+                notification as CSS data type color.
+              type: string
+            color:
+              description: color is the color of the text for the notification as
+                CSS data type color.
+              type: string
+            link:
+              description: link is an object that holds notification link details.
+              type: object
+              required:
+                - href
+                - text
+              properties:
+                href:
+                  description: href is the absolute secure URL for the link (must
+                    use https)
+                  type: string
+                  pattern: ^https://([\w-]+.)+[\w-]+(/[\w- ./?%&=])?$
+                text:
+                  description: text is the display text for the link
+                  type: string
+            location:
+              description: location is the location of the notification in the console.
+              type: string
+              pattern: ^(BannerTop|BannerBottom|BannerTopBottom)$
+            text:
+              description: text is the visible text of the notification.
+              type: string

--- a/manifests/00-crd-consoleyamlsamples.yaml
+++ b/manifests/00-crd-consoleyamlsamples.yaml
@@ -1,0 +1,86 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: consoleyamlsamples.console.openshift.io
+  annotations:
+    displayName: ConsoleYAMLSample
+    description: Extension for configuring openshift web console YAML samples.
+spec:
+  scope: Cluster
+  group: console.openshift.io
+  versions:
+    - name: v1
+      served: true
+      storage: true
+  names:
+    plural: consoleyamlsamples
+    singular: consoleyamlsample
+    kind: ConsoleYAMLSample
+    listKind: ConsoleYAMLSampleList
+  additionalPrinterColumns:
+    - name: Title
+      type: string
+      JSONPath: .spec.title
+    - name: Age
+      type: string
+      JSONPath: .metadata.creationTimestamp
+    - name: Description
+      type: string
+      JSONPath: .spec.description
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: ConsoleYAMLSample is an extension for customizing OpenShift web
+        console YAML samples.
+      type: object
+      required:
+        - metadata
+        - spec
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          description: Standard object's metadata.
+          type: object
+        spec:
+          description: ConsoleYAMLSampleSpec is the desired YAML sample configuration.
+            Samples will appear with their descriptions in a samples sidebar when
+            creating a resources in the web console.
+          type: object
+          required:
+            - description
+            - title
+            - yaml
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            description:
+              description: description of the YAML sample.
+              type: string
+              pattern: ^(.|\s)*\S(.|\s)*$
+            kind:
+              description: 'Kind is a string value representing the REST resource
+                this object represents. Servers may infer this from the endpoint the
+                client submits requests to. Cannot be updated. In CamelCase. More
+                info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            title:
+              description: title of the YAML sample.
+              type: string
+              pattern: ^(.|\s)*\S(.|\s)*$
+            yaml:
+              description: yaml is the YAML sample to display.
+              type: string
+              pattern: ^(.|\s)*\S(.|\s)*$


### PR DESCRIPTION
They shall return to us!
To make @deads2k happy 😄 
/cc @spadgett @jhadvig 

TODO as follow-up:
- [x] revert https://github.com/openshift/cluster-config-operator/pull/95 once this PR has merged. 
- [x] investigate mechanism to generate these from `openshift/api` type definitions to avoid drift 
- [ ] Reopen #316 and import the CRDs instead.
