### PR TITLE
remove trailing slash for odo href

### DIFF
--- a/pkg/console/controllers/clidownloads/controller.go
+++ b/pkg/console/controllers/clidownloads/controller.go
@@ -201,7 +201,7 @@ odo abstracts away complex Kubernetes and OpenShift concepts, thus allowing deve
 			DisplayName: "odo - Developer-focused CLI for OpenShift",
 			Links: []v1.Link{
 				{
-					Href: "https://mirror.openshift.com/pub/openshift-v4/clients/odo/latest/",
+					Href: "https://mirror.openshift.com/pub/openshift-v4/clients/odo/latest",
 					Text: "Download odo",
 				},
 			},


### PR DESCRIPTION
Regexp that we have on the `spec.links.href` [field](https://github.com/openshift/console-operator/blob/master/manifests/00-crd-consoleclidownloads.yaml#L82) refuses trailing slashes on the `href` field. For that cause the `odo` CR wont be created.

/assign @benjaminapetersen 