### PR TITLE
Add e2e test for oc and odo ConsoleCLIDownloads CRs

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -27,4 +27,6 @@ const (
 	TrustedCABundleKey                  = "ca-bundle.crt"
 	TrustedCABundleMountDir             = "/etc/pki/ca-trust/extracted/pem"
 	TrustedCABundleMountFile            = "tls-ca-bundle.pem"
+	OCCLIDownloadsCustomResourceName    = "oc-cli-downloads"
+	ODOCLIDownloadsCustomResourceName   = "odo-cli-downloads"
 )

--- a/pkg/console/controllers/clidownloads/controller.go
+++ b/pkg/console/controllers/clidownloads/controller.go
@@ -44,9 +44,6 @@ import (
 const (
 	controllerWorkQueueKey = "clidownloads-sync-work-queue-key"
 	controllerName         = "ConsoleCLIDownloadsSyncController"
-
-	ocCLIDownloadsCustomResourceName  = "oc-cli-downloads"
-	odoCLIDownloadsCustomResourceName = "odo-cli-downloads"
 )
 
 type CLIDownloadsSyncController struct {
@@ -125,7 +122,7 @@ func (c *CLIDownloadsSyncController) sync() error {
 	}
 
 	host := routesub.GetCanonicalHost(consoleRoute)
-	ocConsoleCLIDownloads := PlatformBasedOCConsoleCLIDownloads(host, "amd64", ocCLIDownloadsCustomResourceName)
+	ocConsoleCLIDownloads := PlatformBasedOCConsoleCLIDownloads(host, "amd64", api.OCCLIDownloadsCustomResourceName)
 	_, ocCLIDownloadsErrReason, ocCLIDownloadsErr := ApplyCLIDownloads(c.consoleCliDownloadsClient, ocConsoleCLIDownloads)
 	status.HandleDegraded(updatedOperatorConfig, "OCDownloadsSync", ocCLIDownloadsErrReason, ocCLIDownloadsErr)
 	if ocCLIDownloadsErr != nil {
@@ -144,8 +141,8 @@ func (c *CLIDownloadsSyncController) sync() error {
 func (c *CLIDownloadsSyncController) removeCLIDownloads() error {
 	defer klog.V(4).Info("finished deleting ConsoleCliDownloads custom resources")
 	var errs []error
-	errs = append(errs, c.consoleCliDownloadsClient.Delete(ocCLIDownloadsCustomResourceName, &metav1.DeleteOptions{}))
-	errs = append(errs, c.consoleCliDownloadsClient.Delete(odoCLIDownloadsCustomResourceName, &metav1.DeleteOptions{}))
+	errs = append(errs, c.consoleCliDownloadsClient.Delete(api.OCCLIDownloadsCustomResourceName, &metav1.DeleteOptions{}))
+	errs = append(errs, c.consoleCliDownloadsClient.Delete(api.ODOCLIDownloadsCustomResourceName, &metav1.DeleteOptions{}))
 	return utilerrors.FilterOut(utilerrors.NewAggregate(errs), errors.IsNotFound)
 }
 
@@ -191,7 +188,7 @@ The oc binary offers the same capabilities as the kubectl binary, but it is furt
 func ODOConsoleCLIDownloads() *v1.ConsoleCLIDownload {
 	return &v1.ConsoleCLIDownload{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: odoCLIDownloadsCustomResourceName,
+			Name: api.ODOCLIDownloadsCustomResourceName,
 		},
 		Spec: v1.ConsoleCLIDownloadSpec{
 			Description: `OpenShift Do (odo) is a fast, iterative, and straightforward CLI tool for developers who write, build, and deploy applications on OpenShift.

--- a/test/e2e/framework/clientset.go
+++ b/test/e2e/framework/clientset.go
@@ -9,6 +9,7 @@ import (
 	restclient "k8s.io/client-go/rest"
 
 	configv1 "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
+	consoleclientv1 "github.com/openshift/client-go/console/clientset/versioned/typed/console/v1"
 	operatorclientv1 "github.com/openshift/client-go/operator/clientset/versioned/typed/operator/v1"
 	clientroutev1 "github.com/openshift/client-go/route/clientset/versioned/typed/route/v1"
 )
@@ -16,13 +17,14 @@ import (
 // ClientSet is a set of Kubernetes clients.
 type ClientSet struct {
 	// embedded
-	Core            clientcorev1.CoreV1Interface
-	Apps            clientappsv1.AppsV1Interface
-	Routes          clientroutev1.RouteV1Interface
-	Operator        operatorclientv1.ConsolesGetter
-	Console         configv1.ConsolesGetter
-	ClusterOperator configv1.ClusterOperatorsGetter
-	Proxy           configv1.ProxiesGetter
+	Core                clientcorev1.CoreV1Interface
+	Apps                clientappsv1.AppsV1Interface
+	Routes              clientroutev1.RouteV1Interface
+	ConsoleCliDownloads consoleclientv1.ConsoleCLIDownloadInterface
+	Operator            operatorclientv1.ConsolesGetter
+	Console             configv1.ConsolesGetter
+	ClusterOperator     configv1.ClusterOperatorsGetter
+	Proxy               configv1.ProxiesGetter
 }
 
 // NewClientset creates a set of Kubernetes clients. The default kubeconfig is
@@ -62,6 +64,12 @@ func NewClientset(kubeconfig *restclient.Config) (*ClientSet, error) {
 	clientset.Console = configClient
 	clientset.Proxy = configClient
 	clientset.ClusterOperator = configClient
+
+	consoleClient, err := consoleclientv1.NewForConfig(kubeconfig)
+	if err != nil {
+		return nil, err
+	}
+	clientset.ConsoleCliDownloads = consoleClient.ConsoleCLIDownloads()
 
 	return clientset, nil
 }

--- a/test/e2e/framework/console-operator.go
+++ b/test/e2e/framework/console-operator.go
@@ -164,6 +164,7 @@ func removeConsole(t *testing.T, client *ClientSet) error {
 
 	return nil
 }
+
 func MustManageConsole(t *testing.T, client *ClientSet) error {
 	t.Helper()
 	if err := manageConsole(t, client); err != nil {

--- a/test/e2e/managed_test.go
+++ b/test/e2e/managed_test.go
@@ -5,6 +5,7 @@ import (
 
 	operatorsv1 "github.com/openshift/api/operator/v1"
 
+	"github.com/openshift/console-operator/pkg/api"
 	"github.com/openshift/console-operator/test/e2e/framework"
 )
 
@@ -55,6 +56,21 @@ func TestEditManagedRoute(t *testing.T) {
 	defer cleanupManagedTestCase(t, client)
 
 	err := patchAndCheckRoute(t, client, true)
+	if err != nil {
+		t.Fatalf("error: %s", err)
+	}
+}
+
+func TestEditManagedConsoleCLIDownloads(t *testing.T) {
+	client, _ := setupManagedTestCase(t)
+	defer cleanupManagedTestCase(t, client)
+
+	err := patchAndCheckConsoleCLIDownloads(t, client, true, api.OCCLIDownloadsCustomResourceName)
+	if err != nil {
+		t.Fatalf("error: %s", err)
+	}
+
+	err = patchAndCheckConsoleCLIDownloads(t, client, true, api.ODOCLIDownloadsCustomResourceName)
 	if err != nil {
 		t.Fatalf("error: %s", err)
 	}

--- a/test/e2e/unmanaged_test.go
+++ b/test/e2e/unmanaged_test.go
@@ -3,6 +3,7 @@ package e2e
 import (
 	"testing"
 
+	"github.com/openshift/console-operator/pkg/api"
 	"github.com/openshift/console-operator/test/e2e/framework"
 )
 
@@ -55,6 +56,21 @@ func TestEditUnmanagedRoute(t *testing.T) {
 	defer cleanUpUnmanagedTestCase(t, client)
 
 	err := patchAndCheckRoute(t, client, false)
+	if err != nil {
+		t.Fatalf("error: %s", err)
+	}
+}
+
+func TestEditUnmanagedConsoleCLIDownloads(t *testing.T) {
+	client, _ := setupManagedTestCase(t)
+	defer cleanupManagedTestCase(t, client)
+
+	err := patchAndCheckConsoleCLIDownloads(t, client, false, api.OCCLIDownloadsCustomResourceName)
+	if err != nil {
+		t.Fatalf("error: %s", err)
+	}
+
+	err = patchAndCheckConsoleCLIDownloads(t, client, false, api.ODOCLIDownloadsCustomResourceName)
 	if err != nil {
 		t.Fatalf("error: %s", err)
 	}

--- a/test/e2e/unmanaged_test.go
+++ b/test/e2e/unmanaged_test.go
@@ -62,8 +62,8 @@ func TestEditUnmanagedRoute(t *testing.T) {
 }
 
 func TestEditUnmanagedConsoleCLIDownloads(t *testing.T) {
-	client, _ := setupManagedTestCase(t)
-	defer cleanupManagedTestCase(t, client)
+	client := setupUnmanagedTestCase(t)
+	defer cleanUpUnmanagedTestCase(t, client)
 
 	err := patchAndCheckConsoleCLIDownloads(t, client, false, api.OCCLIDownloadsCustomResourceName)
 	if err != nil {


### PR DESCRIPTION
Adding the TCs to the Managed, Unmanaged and Removed test suites, since the testing scenario is pretty much the same as other resources.

Due to the wrong regexp on the ConsoleCLIDownloads CRD the added e2e will fail until it will be fixed.

/hold

/assign @benjaminapetersen 