### PR TITLE
Dockerfile destinations must end in trailing slash when COPY multiple files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ COPY --from=builder /tmp/build/console /usr/bin/console
 COPY manifests /manifests/
 
 # extensions manifests generated from openshift/api types
-COPY vendor/github.com/openshift/api/console/v1/*.yaml /manifests
+COPY vendor/github.com/openshift/api/console/v1/*.yaml /manifests/
 
 LABEL io.k8s.display-name="OpenShift console-operator" \
       io.k8s.description="This is a component of OpenShift Container Platform and manages the lifecycle of the web console." \

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -14,7 +14,7 @@ COPY --from=builder /tmp/build/console /usr/bin/console
 COPY manifests /manifests/
 
 # extensions manifests generated from openshift/api types
-COPY vendor/github.com/openshift/api/console/v1/*.yaml /manifests
+COPY vendor/github.com/openshift/api/console/v1/*.yaml /manifests/
 
 LABEL io.k8s.display-name="OpenShift console-operator" \
       io.k8s.description="This is a component of OpenShift Container Platform and manages the lifecycle of the web console." \


### PR DESCRIPTION
Fixes:

```
Step 9/12 : COPY manifests /manifests/
 ---> e755cdd503bb
Step 10/12 : COPY vendor/github.com/openshift/api/console/v1/*.yaml /manifests
When using COPY with more than one source file, the destination must be a directory and end with a /
pushing image...
```

/assign @jhadvig 