### PR TITLE
Bug 1764704: Sync router-ca to the console namespace

### DIFF
--- a/hack/test-unit.sh
+++ b/hack/test-unit.sh
@@ -10,6 +10,7 @@ PACKAGES_TO_TEST=(
     "github.com/openshift/console-operator/pkg/console/operator"
     "github.com/openshift/console-operator/pkg/console/starter"
     "github.com/openshift/console-operator/pkg/console/subresource/configmap"
+    "github.com/openshift/console-operator/pkg/console/subresource/consoleserver"
     "github.com/openshift/console-operator/pkg/console/subresource/deployment"
     "github.com/openshift/console-operator/pkg/console/subresource/oauthclient"
     "github.com/openshift/console-operator/pkg/console/subresource/route"

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -15,6 +15,7 @@ const (
 	OpenShiftConsoleConfigMapName       = "console-config"
 	OpenShiftConsolePublicConfigMapName = "console-public"
 	ServiceCAConfigMapName              = "service-ca"
+	RouterCAConfigMapName               = "router-ca"
 	OpenShiftConsoleDeploymentName      = OpenShiftConsoleName
 	OpenShiftConsoleServiceName         = OpenShiftConsoleName
 	OpenShiftConsoleRouteName           = OpenShiftConsoleName

--- a/pkg/console/controllers/resourcesyncdestination/controller.go
+++ b/pkg/console/controllers/resourcesyncdestination/controller.go
@@ -1,0 +1,138 @@
+package resourcesyncdestination
+
+import (
+	"fmt"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	coreinformersv1 "k8s.io/client-go/informers/core/v1"
+	coreclientv1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog"
+
+	operatorsv1 "github.com/openshift/api/operator/v1"
+	operatorclientv1 "github.com/openshift/client-go/operator/clientset/versioned/typed/operator/v1"
+	operatorinformersv1 "github.com/openshift/client-go/operator/informers/externalversions/operator/v1"
+	"github.com/openshift/console-operator/pkg/api"
+	"github.com/openshift/library-go/pkg/operator/events"
+)
+
+const (
+	controllerWorkQueueKey = "resource-sync-destination-work-queue-key"
+	controllerName         = "ConsoleResourceSyncDestinationController"
+)
+
+type ResourceSyncDestinationController struct {
+	operatorConfigClient operatorclientv1.ConsoleInterface
+	configMapClient      coreclientv1.ConfigMapsGetter
+	// events
+	cachesToSync []cache.InformerSynced
+	queue        workqueue.RateLimitingInterface
+	recorder     events.Recorder
+}
+
+func NewResourceSyncDestinationController(
+	// operatorconfig
+	operatorConfigClient operatorclientv1.ConsoleInterface,
+	operatorConfigInformer operatorinformersv1.ConsoleInformer,
+	// configmap
+	corev1Client coreclientv1.CoreV1Interface,
+	configMapInformer coreinformersv1.ConfigMapInformer,
+	// events
+	recorder events.Recorder,
+) *ResourceSyncDestinationController {
+	corev1Client.ConfigMaps(api.OpenShiftConsoleNamespace)
+
+	ctrl := &ResourceSyncDestinationController{
+		operatorConfigClient: operatorConfigClient,
+		configMapClient:      corev1Client,
+		// events
+		recorder:     recorder,
+		cachesToSync: nil,
+		queue:        workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), controllerName),
+	}
+
+	configMapInformer.Informer().AddEventHandler(ctrl.newEventHandler())
+	operatorConfigInformer.Informer().AddEventHandler(ctrl.newEventHandler())
+	ctrl.cachesToSync = append(ctrl.cachesToSync,
+		operatorConfigInformer.Informer().HasSynced,
+		configMapInformer.Informer().HasSynced,
+	)
+
+	return ctrl
+}
+
+func (c *ResourceSyncDestinationController) sync() error {
+	operatorConfig, err := c.operatorConfigClient.Get(api.ConfigResourceName, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	switch operatorConfig.Spec.ManagementState {
+	case operatorsv1.Managed:
+		klog.V(4).Infoln("console is in a managed state: syncing router-ca configmap")
+	case operatorsv1.Unmanaged:
+		klog.V(4).Infoln("console is in an unmanaged state: skipping router-ca configmap sync")
+		return nil
+	case operatorsv1.Removed:
+		klog.V(4).Infoln("console is in an removed state: removing synced router-ca configmap")
+		return c.removeRouterCAConfigMap()
+	default:
+		return fmt.Errorf("unknown state: %v", operatorConfig.Spec.ManagementState)
+	}
+
+	return err
+}
+
+func (c *ResourceSyncDestinationController) removeRouterCAConfigMap() error {
+	klog.V(2).Info("deleting router-ca configmap")
+	defer klog.V(2).Info("finished deleting router-ca configmap")
+	return c.configMapClient.ConfigMaps(api.OpenShiftConsoleNamespace).Delete(api.RouterCAConfigMapName, &metav1.DeleteOptions{})
+}
+
+func (c *ResourceSyncDestinationController) Run(workers int, stopCh <-chan struct{}) {
+	defer runtime.HandleCrash()
+	defer c.queue.ShutDown()
+	klog.Infof("starting %v", controllerName)
+	defer klog.Infof("shutting down %v", controllerName)
+	if !cache.WaitForCacheSync(stopCh, c.cachesToSync...) {
+		klog.Infoln("caches did not sync")
+		runtime.HandleError(fmt.Errorf("caches did not sync"))
+		return
+	}
+	// only start one worker
+	go wait.Until(c.runWorker, time.Second, stopCh)
+	<-stopCh
+}
+
+func (c *ResourceSyncDestinationController) runWorker() {
+	for c.processNextWorkItem() {
+	}
+}
+
+func (c *ResourceSyncDestinationController) processNextWorkItem() bool {
+	processKey, quit := c.queue.Get()
+	if quit {
+		return false
+	}
+	defer c.queue.Done(processKey)
+	err := c.sync()
+	if err == nil {
+		c.queue.Forget(processKey)
+		return true
+	}
+	runtime.HandleError(fmt.Errorf("%v failed with : %v", processKey, err))
+	c.queue.AddRateLimited(processKey)
+	return true
+}
+
+func (c *ResourceSyncDestinationController) newEventHandler() cache.ResourceEventHandler {
+	return cache.ResourceEventHandlerFuncs{
+		AddFunc:    func(obj interface{}) { c.queue.Add(controllerWorkQueueKey) },
+		UpdateFunc: func(old, new interface{}) { c.queue.Add(controllerWorkQueueKey) },
+		DeleteFunc: func(obj interface{}) { c.queue.Add(controllerWorkQueueKey) },
+	}
+}

--- a/pkg/console/operator/sync_v400.go
+++ b/pkg/console/operator/sync_v400.go
@@ -95,6 +95,9 @@ func (co *consoleOperator) sync_v400(updatedOperatorConfig *operatorv1.Console, 
 	// The sync loop may not settle, we are unable to honor it in current state.
 	status.HandleProgressingOrDegraded(updatedOperatorConfig, "CustomLogoSync", customLogoErrReason, customLogoError)
 
+	routerCAConfigMap, routerCAErrReason, routerCAError := co.ValidateRouterCAConfigMap()
+	status.HandleProgressingOrDegraded(updatedOperatorConfig, "RouterCAValidation", routerCAErrReason, routerCAError)
+
 	sec, secChanged, secErr := co.SyncSecret(set.Operator)
 	toUpdate = toUpdate || secChanged
 	status.HandleProgressingOrDegraded(updatedOperatorConfig, "OAuthClientSecretSync", "FailedApply", secErr)
@@ -109,7 +112,7 @@ func (co *consoleOperator) sync_v400(updatedOperatorConfig *operatorv1.Console, 
 		return oauthErr
 	}
 
-	actualDeployment, depChanged, depErrReason, depErr := co.SyncDeployment(set.Operator, cm, serviceCAConfigMap, trustedCAConfigMap, sec, rt, set.Proxy, customLogoCanMount)
+	actualDeployment, depChanged, depErrReason, depErr := co.SyncDeployment(set.Operator, cm, serviceCAConfigMap, routerCAConfigMap, trustedCAConfigMap, sec, rt, set.Proxy, customLogoCanMount)
 	toUpdate = toUpdate || depChanged
 	status.HandleProgressingOrDegraded(updatedOperatorConfig, "DeploymentSync", depErrReason, depErr)
 	if depErr != nil {
@@ -231,13 +234,14 @@ func (co *consoleOperator) SyncDeployment(
 	operatorConfig *operatorv1.Console,
 	cm *corev1.ConfigMap,
 	serviceCAConfigMap *corev1.ConfigMap,
+	routerCAConfigMap *corev1.ConfigMap,
 	trustedCAConfigMap *corev1.ConfigMap,
 	sec *corev1.Secret,
 	rt *routev1.Route,
 	proxyConfig *configv1.Proxy,
 	canMountCustomLogo bool) (consoleDeployment *appsv1.Deployment, changed bool, reason string, err error) {
 
-	requiredDeployment := deploymentsub.DefaultDeployment(operatorConfig, cm, serviceCAConfigMap, trustedCAConfigMap, sec, rt, proxyConfig, canMountCustomLogo)
+	requiredDeployment := deploymentsub.DefaultDeployment(operatorConfig, cm, serviceCAConfigMap, routerCAConfigMap, trustedCAConfigMap, sec, rt, proxyConfig, canMountCustomLogo)
 	expectedGeneration := getDeploymentGeneration(co)
 	genChanged := operatorConfig.ObjectMeta.Generation != operatorConfig.Status.ObservedGeneration
 
@@ -307,7 +311,18 @@ func (co *consoleOperator) SyncConfigMap(
 		return nil, false, "FailedManagedConfig", mcErr
 	}
 
-	defaultConfigmap, _, err := configmapsub.DefaultConfigMap(operatorConfig, consoleConfig, managedConfig, infrastructureConfig, consoleRoute)
+	useDefaultCAFile := true
+	// We are syncing the `router-ca` configmap from `openshift-config-managed` to `openshift-console`.
+	// `router-ca` is only published in `openshift-config-managed` if an operator-generated default certificate is used.
+	// It will not exist if all ingresscontrollers user admin-provided default certificates.
+	// If the `router-ca` configmap in `openshift-console` exist we should mount that to the console container,
+	// otherwise default to `/var/run/secrets/kubernetes.io/serviceaccount/ca.crt`
+	_, rcaErr := co.configMapClient.ConfigMaps(api.OpenShiftConsoleNamespace).Get(api.RouterCAConfigMapName, metav1.GetOptions{})
+	if rcaErr != nil && apierrors.IsNotFound(rcaErr) {
+		useDefaultCAFile = false
+	}
+
+	defaultConfigmap, _, err := configmapsub.DefaultConfigMap(operatorConfig, consoleConfig, managedConfig, infrastructureConfig, consoleRoute, useDefaultCAFile)
 	if err != nil {
 		return nil, false, "FailedConsoleConfigBuilder", err
 	}
@@ -428,6 +443,20 @@ func (c *consoleOperator) SyncCustomLogoConfigMap(operatorConfig *operatorsv1.Co
 		}
 	}
 	return okToMount, reason, err
+}
+
+func (c *consoleOperator) ValidateRouterCAConfigMap() (routerCA *corev1.ConfigMap, reason string, err error) {
+	routerCAConfigMap, err := c.configMapClient.ConfigMaps(api.OpenShiftConsoleNamespace).Get(api.RouterCAConfigMapName, metav1.GetOptions{})
+	if err != nil {
+		klog.V(4).Infoln("router-ca configmap not found")
+		return nil, "FailedGet", fmt.Errorf("router-ca configmap not found")
+	}
+
+	_, caBundle := routerCAConfigMap.Data["ca-bundle.crt"]
+	if !caBundle {
+		return nil, "MissingRouterCABundle", fmt.Errorf("router-ca configmap is missing ca-bundle.crt data")
+	}
+	return routerCAConfigMap, "", nil
 }
 
 // on each pass of the operator sync loop, we need to check the

--- a/pkg/console/subresource/configmap/configmap.go
+++ b/pkg/console/subresource/configmap/configmap.go
@@ -39,13 +39,15 @@ func DefaultConfigMap(
 	consoleConfig *configv1.Console,
 	managedConfig *corev1.ConfigMap,
 	infrastructureConfig *configv1.Infrastructure,
-	rt *routev1.Route) (consoleConfigmap *corev1.ConfigMap, unsupportedOverridesHaveMerged bool, err error) {
+	rt *routev1.Route,
+	useDefaultCAFile bool) (consoleConfigmap *corev1.ConfigMap, unsupportedOverridesHaveMerged bool, err error) {
 
 	defaultBuilder := &consoleserver.ConsoleServerCLIConfigBuilder{}
 	defaultConfig, err := defaultBuilder.Host(rt.Spec.Host).
 		LogoutURL(defaultLogoutURL).
 		Brand(DEFAULT_BRAND).
 		DocURL(DEFAULT_DOC_URL).
+		RouterCA(useDefaultCAFile).
 		APIServerURL(getApiUrl(infrastructureConfig)).
 		ConfigYAML()
 
@@ -55,6 +57,7 @@ func DefaultConfigMap(
 		LogoutURL(consoleConfig.Spec.Authentication.LogoutRedirect).
 		Brand(operatorConfig.Spec.Customization.Brand).
 		DocURL(operatorConfig.Spec.Customization.DocumentationBaseURL).
+		RouterCA(useDefaultCAFile).
 		APIServerURL(getApiUrl(infrastructureConfig)).
 		CustomLogoFile(operatorConfig.Spec.Customization.CustomLogoFile.Key).
 		CustomProductName(operatorConfig.Spec.Customization.CustomProductName).

--- a/pkg/console/subresource/configmap/configmap_test.go
+++ b/pkg/console/subresource/configmap/configmap_test.go
@@ -33,6 +33,7 @@ func TestDefaultConfigMap(t *testing.T) {
 		managedConfig        *corev1.ConfigMap
 		infrastructureConfig *configv1.Infrastructure
 		rt                   *routev1.Route
+		useDefaultCAFile     bool
 	}
 	tests := []struct {
 		name string
@@ -55,6 +56,7 @@ func TestDefaultConfigMap(t *testing.T) {
 						Host: host,
 					},
 				},
+				useDefaultCAFile: true,
 			},
 			want: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
@@ -69,6 +71,52 @@ auth:
   clientID: console
   clientSecretFile: /var/oauth-config/clientSecret
   oauthEndpointCAFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+clusterInfo:
+  consoleBaseAddress: https://` + host + `
+  masterPublicURL: ` + mockAPIServer + `
+customization:
+  branding: ` + DEFAULT_BRAND + `
+  documentationBaseURL: ` + DEFAULT_DOC_URL + `
+servingInfo:
+  bindAddress: https://0.0.0.0:8443
+  certFile: /var/serving-cert/tls.crt
+  keyFile: /var/serving-cert/tls.key
+providers: {}
+`,
+				},
+			},
+		},
+		{
+			name: "Test configmap with router-ca",
+			args: args{
+				operatorConfig: &operatorv1.Console{},
+				consoleConfig:  &configv1.Console{},
+				managedConfig:  &corev1.ConfigMap{},
+				infrastructureConfig: &configv1.Infrastructure{
+					Status: configv1.InfrastructureStatus{
+						APIServerURL: mockAPIServer,
+					},
+				},
+				rt: &routev1.Route{
+					Spec: routev1.RouteSpec{
+						Host: host,
+					},
+				},
+				useDefaultCAFile: false,
+			},
+			want: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        api.OpenShiftConsoleConfigMapName,
+					Namespace:   api.OpenShiftConsoleNamespace,
+					Labels:      map[string]string{"app": api.OpenShiftConsoleName},
+					Annotations: map[string]string{},
+				},
+				Data: map[string]string{configKey: `kind: ConsoleConfig
+apiVersion: console.openshift.io/v1
+auth:
+  clientID: console
+  clientSecretFile: /var/oauth-config/clientSecret
+  oauthEndpointCAFile: /var/router-ca/ca-bundle.crt
 clusterInfo:
   consoleBaseAddress: https://` + host + `
   masterPublicURL: ` + mockAPIServer + `
@@ -108,6 +156,7 @@ customization:
 						Host: host,
 					},
 				},
+				useDefaultCAFile: true,
 			},
 			want: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
@@ -170,6 +219,7 @@ customization:
 						Host: host,
 					},
 				},
+				useDefaultCAFile: true,
 			},
 			want: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
@@ -237,6 +287,7 @@ customization:
 						Host: host,
 					},
 				},
+				useDefaultCAFile: true,
 			},
 			want: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
@@ -306,6 +357,7 @@ customization:
 						Host: host,
 					},
 				},
+				useDefaultCAFile: true,
 			},
 			want: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
@@ -339,7 +391,7 @@ providers:
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cm, _, _ := DefaultConfigMap(tt.args.operatorConfig, tt.args.consoleConfig, tt.args.managedConfig, tt.args.infrastructureConfig, tt.args.rt)
+			cm, _, _ := DefaultConfigMap(tt.args.operatorConfig, tt.args.consoleConfig, tt.args.managedConfig, tt.args.infrastructureConfig, tt.args.rt, tt.args.useDefaultCAFile)
 
 			// marshall the exampleYaml to map[string]interface{} so we can use it in diff below
 			var exampleConfig map[string]interface{}

--- a/pkg/console/subresource/consoleserver/config_builder.go
+++ b/pkg/console/subresource/consoleserver/config_builder.go
@@ -10,6 +10,7 @@ import (
 
 const (
 	clientSecretFilePath    = "/var/oauth-config/clientSecret"
+	routerCAFilePath        = "/var/router-ca/ca-bundle.crt"
 	oauthEndpointCAFilePath = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
 	// serving info
 	certFilePath = "/var/serving-cert/tls.crt"
@@ -36,6 +37,7 @@ type ConsoleServerCLIConfigBuilder struct {
 	statusPageID      string
 	customProductName string
 	customLogoFile    string
+	CAFile            string
 }
 
 func (b *ConsoleServerCLIConfigBuilder) Host(host string) *ConsoleServerCLIConfigBuilder {
@@ -71,6 +73,15 @@ func (b *ConsoleServerCLIConfigBuilder) CustomLogoFile(customLogoFile string) *C
 
 func (b *ConsoleServerCLIConfigBuilder) StatusPageID(id string) *ConsoleServerCLIConfigBuilder {
 	b.statusPageID = id
+	return b
+}
+
+func (b *ConsoleServerCLIConfigBuilder) RouterCA(useDefaultRouterCA bool) *ConsoleServerCLIConfigBuilder {
+	if useDefaultRouterCA {
+		b.CAFile = oauthEndpointCAFilePath
+		return b
+	}
+	b.CAFile = routerCAFilePath
 	return b
 }
 
@@ -119,10 +130,15 @@ func (b *ConsoleServerCLIConfigBuilder) clusterInfo() ClusterInfo {
 }
 
 func (b *ConsoleServerCLIConfigBuilder) authServer() Auth {
+	// we need this fallback due to the way our unit test are structured,
+	// where the ConsoleServerCLIConfigBuilder object is being instantiated empty
+	if b.CAFile == "" {
+		b.CAFile = oauthEndpointCAFilePath
+	}
 	conf := Auth{
 		ClientID:            api.OpenShiftConsoleName,
 		ClientSecretFile:    clientSecretFilePath,
-		OAuthEndpointCAFile: oauthEndpointCAFilePath,
+		OAuthEndpointCAFile: b.CAFile,
 	}
 	if len(b.logoutRedirectURL) > 0 {
 		conf.LogoutRedirect = b.logoutRedirectURL

--- a/pkg/console/subresource/consoleserver/config_builder_test.go
+++ b/pkg/console/subresource/consoleserver/config_builder_test.go
@@ -51,6 +51,7 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 					APIServerURL("https://foobar.com/api").
 					Host("https://foobar.com/host").
 					LogoutURL("https://foobar.com/logout").
+					RouterCA(false).
 					Config()
 			},
 			output: Config{
@@ -69,7 +70,7 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 				Auth: Auth{
 					ClientID:            api.OpenShiftConsoleName,
 					ClientSecretFile:    clientSecretFilePath,
-					OAuthEndpointCAFile: oauthEndpointCAFilePath,
+					OAuthEndpointCAFile: routerCAFilePath,
 					LogoutRedirect:      "https://foobar.com/logout",
 				},
 				Customization: Customization{},
@@ -192,6 +193,7 @@ providers: {}
 					APIServerURL("https://foobar.com/api").
 					Host("https://foobar.com/host").
 					LogoutURL("https://foobar.com/logout").
+					RouterCA(false).
 					ConfigYAML()
 			},
 			output: `apiVersion: console.openshift.io/v1
@@ -206,7 +208,7 @@ clusterInfo:
 auth:
   clientID: console
   clientSecretFile: /var/oauth-config/clientSecret
-  oauthEndpointCAFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+  oauthEndpointCAFile: /var/router-ca/ca-bundle.crt
   logoutRedirect: https://foobar.com/logout
 customization: {}
 providers: {}
@@ -243,7 +245,8 @@ providers:
 					Brand(v1.BrandOKD).
 					DocURL("https://foobar.com/docs").
 					APIServerURL("https://foobar.com/api").
-					StatusPageID("status-12345")
+					StatusPageID("status-12345").
+					RouterCA(true)
 				return b.ConfigYAML()
 			},
 			output: `apiVersion: console.openshift.io/v1

--- a/pkg/console/subresource/deployment/deployment.go
+++ b/pkg/console/subresource/deployment/deployment.go
@@ -34,6 +34,7 @@ const (
 	configMapResourceVersionAnnotation          = "console.openshift.io/console-config-version"
 	proxyConfigResourceVersionAnnotation        = "console.openshift.io/proxy-config-version"
 	serviceCAConfigMapResourceVersionAnnotation = "console.openshift.io/service-ca-config-version"
+	routerCAConfigMapResourceVersionAnnotation  = "console.openshift.io/router-ca-config-version"
 	trustedCAConfigMapResourceVersionAnnotation = "console.openshift.io/trusted-ca-config-version"
 	secretResourceVersionAnnotation             = "console.openshift.io/oauth-secret-version"
 	consoleImageAnnotation                      = "console.openshift.io/image"
@@ -44,6 +45,7 @@ var (
 		configMapResourceVersionAnnotation,
 		proxyConfigResourceVersionAnnotation,
 		serviceCAConfigMapResourceVersionAnnotation,
+		routerCAConfigMapResourceVersionAnnotation,
 		trustedCAConfigMapResourceVersionAnnotation,
 		secretResourceVersionAnnotation,
 		consoleImageAnnotation,
@@ -61,13 +63,14 @@ type volumeConfig struct {
 	mappedKeys  map[string]string
 }
 
-func DefaultDeployment(operatorConfig *operatorv1.Console, cm *corev1.ConfigMap, serviceCAConfigMap *corev1.ConfigMap, trustedCAConfigMap *corev1.ConfigMap, sec *corev1.Secret, rt *routev1.Route, proxyConfig *configv1.Proxy, canMountCustomLogo bool) *appsv1.Deployment {
+func DefaultDeployment(operatorConfig *operatorv1.Console, cm *corev1.ConfigMap, serviceCAConfigMap *corev1.ConfigMap, routerCAConfigMap *corev1.ConfigMap, trustedCAConfigMap *corev1.ConfigMap, sec *corev1.Secret, rt *routev1.Route, proxyConfig *configv1.Proxy, canMountCustomLogo bool) *appsv1.Deployment {
 	labels := util.LabelsForConsole()
 	meta := util.SharedMeta()
 	meta.Labels = labels
 	annotations := map[string]string{
 		configMapResourceVersionAnnotation:          cm.GetResourceVersion(),
 		serviceCAConfigMapResourceVersionAnnotation: serviceCAConfigMap.GetResourceVersion(),
+		routerCAConfigMapResourceVersionAnnotation:  routerCAConfigMap.GetResourceVersion(),
 		trustedCAConfigMapResourceVersionAnnotation: trustedCAConfigMap.GetResourceVersion(),
 		proxyConfigResourceVersionAnnotation:        proxyConfig.GetResourceVersion(),
 		secretResourceVersionAnnotation:             sec.GetResourceVersion(),
@@ -401,6 +404,12 @@ func defaultVolumeConfig() []volumeConfig {
 			name:        api.ServiceCAConfigMapName,
 			readOnly:    true,
 			path:        "/var/service-ca",
+			isConfigMap: true,
+		},
+		{
+			name:        api.RouterCAConfigMapName,
+			readOnly:    true,
+			path:        "/var/router-ca",
 			isConfigMap: true,
 		},
 	}


### PR DESCRIPTION
Syncing the `router-ca` from `openshift-config-managed` namespace to `openshift-console` namespace and pasing to the `console` deployment.

Will update the unit tests after the first round of review to avoid unnecessary rewrites.

/assign @benjaminapetersen 