### PR TITLE
Improve deployment state errors

### DIFF
--- a/pkg/console/subresource/deployment/deployment.go
+++ b/pkg/console/subresource/deployment/deployment.go
@@ -358,23 +358,39 @@ func livenessProbe() *corev1.Probe {
 // one ready replica
 func IsReady(deployment *appsv1.Deployment) bool {
 	avail := deployment.Status.ReadyReplicas >= 1
-	if avail {
-		klog.V(4).Infof("deployment is available, ready replicas: %v", deployment.Status.ReadyReplicas)
-	} else {
-		klog.V(4).Infof("deployment is not available, ready replicas: %v", deployment.Status.ReadyReplicas)
+	if !avail {
+		klog.V(4).Infof("deployment is not available, expected replicas: %v, ready replicas: %v", deployment.Spec.Replicas, deployment.Status.ReadyReplicas)
 	}
 	return avail
 }
 
 func IsReadyAndUpdated(deployment *appsv1.Deployment) bool {
-	return deployment.Status.Replicas == deployment.Status.ReadyReplicas &&
-		deployment.Status.Replicas == deployment.Status.UpdatedReplicas
+	ready := deployment.Status.Replicas == deployment.Status.ReadyReplicas
+	updated := deployment.Status.Replicas == deployment.Status.UpdatedReplicas
+	if !ready {
+		klog.V(4).Infof("deployment is not ready, expected replicas: %v, ready replicas: %v, total replicas: %v", deployment.Spec.Replicas, deployment.Status.ReadyReplicas, deployment.Status.Replicas)
+	}
+	if !updated {
+		klog.V(4).Infof("deployment is not updated, expected replicas: %v, updated replicas: %v, total replicas: %v", deployment.Spec.Replicas, deployment.Status.UpdatedReplicas, deployment.Status.Replicas)
+	}
+	return ready && updated
 }
 
 func IsAvailableAndUpdated(deployment *appsv1.Deployment) bool {
-	return deployment.Status.AvailableReplicas > 0 &&
-		deployment.Status.ObservedGeneration >= deployment.Generation &&
-		deployment.Status.UpdatedReplicas == deployment.Status.Replicas
+	available := deployment.Status.AvailableReplicas > 0
+	currentGen := deployment.Status.ObservedGeneration >= deployment.Generation
+	updated := deployment.Status.UpdatedReplicas == deployment.Status.Replicas
+	if !available {
+		klog.V(4).Infof("deployment is not available, expected replicas: %v, available replicas: %v, total replicas: %v", deployment.Spec.Replicas, deployment.Status.AvailableReplicas, deployment.Status.Replicas)
+	}
+	if !currentGen {
+		klog.V(4).Infof("deployment is not current, observing generation: %v, generation: %v", deployment.Status.ObservedGeneration, deployment.Generation)
+	}
+	if !updated {
+		klog.V(4).Infof("deployment is not updated, updated replicas: %v, available replicas: %v, total replicas: %v", deployment.Spec.Replicas, deployment.Status.UpdatedReplicas, deployment.Status.Replicas)
+	}
+
+	return available && currentGen && updated
 }
 
 func defaultVolumeConfig() []volumeConfig {


### PR DESCRIPTION
We have gotten some requests for a little more detail in err messages when the deployment is not available/ready/etc.  Stating some `x of y` data should improve this.

Also eliminates logging when in a good state as this is likely just noise.

/assign @jhadvig 