### PR TITLE
Skip custom brand e2e test (TEMP)

### DIFF
--- a/test/e2e/brand_customization_test.go
+++ b/test/e2e/brand_customization_test.go
@@ -77,6 +77,9 @@ func cleanupCustomLogoConfigMap(t *testing.T, clientSet *framework.ClientSet, cu
 //  - image with string representation (.svg) is set as a custom-logo
 //  - custom-logo gets unset
 func TestCustomBrand(t *testing.T) {
+
+	t.Skip("Skipping TestCustomBrand() for flakes.")
+
 	// create a configmaps with binary and string image type representation
 	client, operatorConfig := setupCustomBrandTest(t)
 	// cleanup, defer deletion of the configmaps to ensure it happens even if another part of the test fails


### PR DESCRIPTION
The custom brand has historically been our most flakey test.  This PR is a test, if skipping this one reduces flakes, we should look again at fixing it.

/assign @jhadvig 
/cc @spadgett 