### PR TITLE
Add status handling for RouteHealth

### DIFF
--- a/manifests/07-operator.yaml
+++ b/manifests/07-operator.yaml
@@ -40,9 +40,7 @@ spec:
         ports:
         - containerPort: 60000
           name: metrics
-        command:
-        - console
-        - operator
+        command: ["/bin/bash", "-ec"]
         args:
         - |
           if [ -s /var/run/configmaps/trusted-ca-bundle/ca-bundle.crt ]; then

--- a/manifests/07-operator.yaml
+++ b/manifests/07-operator.yaml
@@ -3,6 +3,10 @@ kind: Deployment
 metadata:
   name: console-operator
   namespace: openshift-console-operator
+  labels:
+    name: console-operator
+  annotations:
+    config.openshift.io/inject-proxy: operator
 spec:
   replicas: 1
   selector:
@@ -40,14 +44,24 @@ spec:
         - console
         - operator
         args:
-        - "-v=2"
-        - "--config=/var/run/configmaps/config/controller-config.yaml"
+        - |
+          if [ -s /var/run/configmaps/trusted-ca-bundle/ca-bundle.crt ]; then
+              echo "Copying system trust bundle"
+              cp -f /var/run/configmaps/trusted-ca-bundle/ca-bundle.crt /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
+          fi
+          exec console-operator operator --config=/var/run/configmaps/config/controller-config.yaml --v=2 --terminate-on-files=/var/run/configmaps/trusted-ca-bundle/ca-bundle.crt
+        # args:
+        # - "-v=2"
+        # - "--config=/var/run/configmaps/config/controller-config.yaml"
         imagePullPolicy: IfNotPresent
         volumeMounts:
         - mountPath: /var/run/configmaps/config
           name: config
         - mountPath: /var/run/secrets/serving-cert
           name: serving-cert
+        - mountPath: /var/run/configmaps/trusted-ca-bundle
+          name: trusted-ca-bundle
+          readOnly: true
         env:
         - name: IMAGE
           value: registry.svc.ci.openshift.org/openshift:console
@@ -70,4 +84,8 @@ spec:
       - name: serving-cert
         secret:
           secretName: serving-cert
+          optional: true
+      - name: trusted-ca-bundle
+        configMap:
+          name: trusted-ca-bundle
           optional: true

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -31,3 +31,8 @@ const (
 	OCCLIDownloadsCustomResourceName    = "oc-cli-downloads"
 	ODOCLIDownloadsCustomResourceName   = "odo-cli-downloads"
 )
+
+const (
+	RouterCAFilePath        = "/var/router-ca/ca-bundle.crt"
+	OAuthEndpointCAFilePath = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+)

--- a/pkg/console/operator/health_deployment.go
+++ b/pkg/console/operator/health_deployment.go
@@ -1,0 +1,41 @@
+package operator
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	deploymentv1 "k8s.io/api/apps/v1"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+
+	"github.com/openshift/console-operator/pkg/console/status"
+	deploymentsub "github.com/openshift/console-operator/pkg/console/subresource/deployment"
+)
+
+func (co *consoleOperator) CheckDeploymentHealth(opConfig *operatorv1.Console, deployment *deploymentv1.Deployment, toUpdate bool) {
+	status.HandleAvailable(func() (conf *operatorv1.Console, prefix string, reason string, err error) {
+		prefix = "Deployment"
+		if !deploymentsub.IsReady(deployment) {
+			return opConfig, prefix, "InsufficientReplicas", errors.New(fmt.Sprintf("%v pods available for console deployment", deployment.Status.ReadyReplicas))
+		}
+		if !deploymentsub.IsReadyAndUpdated(deployment) {
+			return opConfig, prefix, "FailedUpdate", errors.New(fmt.Sprintf("%v replicas ready at version %s", deployment.Status.ReadyReplicas, os.Getenv("RELEASE_VERSION")))
+		}
+		return opConfig, prefix, "", nil
+	}())
+
+	status.HandleProgressing(opConfig, "SyncLoopRefresh", "InProgress", func() error {
+		if toUpdate {
+			return errors.New("Changes made during sync updates, additional sync expected.")
+		}
+		version := os.Getenv("RELEASE_VERSION")
+		if !deploymentsub.IsAvailableAndUpdated(deployment) {
+			return errors.New(fmt.Sprintf("Working toward version %s", version))
+		}
+		if co.versionGetter.GetVersions()["operator"] != version {
+			co.versionGetter.SetVersion("operator", version)
+		}
+		return nil
+	}())
+}

--- a/pkg/console/operator/health_route.go
+++ b/pkg/console/operator/health_route.go
@@ -63,6 +63,11 @@ func (co *consoleOperator) CheckRouteHealth(opConfig *operatorv1.Console, rt *ro
 }
 
 func (co *consoleOperator) getCA() (*x509.CertPool, error) {
+	// TODO: should I update to this? start with the SystemCertPool?
+	//rootCAs, _ := x509.SystemCertPool()
+	//if rootCAs == nil {
+	//	rootCAs = x509.NewCertPool()
+	//}
 	caCertPool := x509.NewCertPool()
 
 	routerCA, rcaErr := co.configMapClient.ConfigMaps(api.OpenShiftConsoleNamespace).Get(api.RouterCAConfigMapName, metav1.GetOptions{})
@@ -93,6 +98,7 @@ func (co *consoleOperator) getCA() (*x509.CertPool, error) {
 func clientWithCA(caPool *x509.CertPool) *http.Client {
 	return &http.Client{
 		Timeout: 5 * time.Second,
+		// TODO: do I need http.DefaultTransport.(*http.Transport)?
 		Transport: &http.Transport{
 			TLSClientConfig: &tls.Config{
 				RootCAs: caPool,

--- a/pkg/console/operator/health_route.go
+++ b/pkg/console/operator/health_route.go
@@ -1,0 +1,102 @@
+package operator
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+	routev1 "github.com/openshift/api/route/v1"
+
+	"github.com/openshift/console-operator/pkg/api"
+	"github.com/openshift/console-operator/pkg/console/status"
+	routesub "github.com/openshift/console-operator/pkg/console/subresource/route"
+)
+
+const (
+	routerCABundleKey = "ca-bundle.crt"
+)
+
+func (co *consoleOperator) CheckRouteHealth(opConfig *operatorv1.Console, rt *routev1.Route) {
+	status.HandleDegraded(func() (conf *operatorv1.Console, prefix string, reason string, err error) {
+		prefix = "RouteHealth"
+
+		caPool, err := co.getCA()
+		if err != nil {
+			return opConfig, prefix, "FailedLoadCA", fmt.Errorf("failed to read CA to check route health: %v", err)
+		}
+		client := clientWithCA(caPool)
+
+		// TODO: deal with an environment with a MitM proxy?
+		url := "https://" + rt.Spec.Host + "/health"
+		req, err := http.NewRequest(http.MethodGet, url, nil)
+		if err != nil {
+			return opConfig, prefix, "FailedRequest", fmt.Errorf("failed to build request to route (%s): %v", url, err)
+		}
+		resp, err := client.Do(req)
+		if err != nil {
+			return opConfig, prefix, "FailedGet", fmt.Errorf("failed to GET route (%s): %v", url, err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			return opConfig, prefix, "StatusError", fmt.Errorf("route not yet available, %s returns '%s'", url, resp.Status)
+
+		}
+		return opConfig, prefix, "", nil
+	}())
+
+	status.HandleAvailable(opConfig, "Route", "FailedAdmittedIngress", func() error {
+		if !routesub.IsAdmitted(rt) {
+			return errors.New("console route is not admitted")
+		}
+		return nil
+	}())
+}
+
+func (co *consoleOperator) getCA() (*x509.CertPool, error) {
+	caCertPool := x509.NewCertPool()
+
+	routerCA, rcaErr := co.configMapClient.ConfigMaps(api.OpenShiftConsoleNamespace).Get(api.RouterCAConfigMapName, metav1.GetOptions{})
+
+	if rcaErr != nil && apierrors.IsNotFound(rcaErr) {
+		//  using CA ca-bundle.crt from configmap router-ca from openshift-config-managed
+		klog.V(4).Infof("using CA [%s] from configmap %s from %s ", routerCABundleKey, api.RouterCAConfigMapName, api.OpenShiftConsoleNamespace)
+		var textCABundle string
+		textCABundle = routerCA.Data[routerCABundleKey]
+		caCertPool.AppendCertsFromPEM([]byte(textCABundle))
+		return caCertPool, nil
+	}
+	// this error is unexpected
+	if rcaErr != nil {
+		klog.Infof("failed to GET configmap %s in %s (synced from %s)", api.RouterCAConfigMapName, api.OpenShiftConsoleNamespace, api.OpenShiftConfigManagedNamespace)
+	}
+	// fallback to our local ca in from our serviceaccount
+	// if we hit this path, are we likely to get self signed certs errors?
+	serviceAccountCAbytes, err := ioutil.ReadFile(api.OAuthEndpointCAFilePath)
+	if err != nil {
+		return nil, errors.New(fmt.Sprintf("failure to read service account ca file: %v\n", err))
+	}
+	klog.V(4).Infof("using CA on disk from %s", api.OAuthEndpointCAFilePath)
+	caCertPool.AppendCertsFromPEM(serviceAccountCAbytes)
+	return caCertPool, nil
+}
+
+func clientWithCA(caPool *x509.CertPool) *http.Client {
+	return &http.Client{
+		Timeout: 5 * time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				RootCAs: caPool,
+			},
+		},
+	}
+}

--- a/pkg/console/operator/operator.go
+++ b/pkg/console/operator/operator.go
@@ -3,6 +3,7 @@ package operator
 import (
 	// standard lib
 	"fmt"
+	"io/ioutil"
 	"reflect"
 	"time"
 
@@ -75,6 +76,8 @@ type consoleOperator struct {
 	// recorder
 	recorder       events.Recorder
 	resourceSyncer resourcesynccontroller.ResourceSyncer
+
+	systemCABundle []byte
 }
 
 func NewConsoleOperator(
@@ -127,6 +130,13 @@ func NewConsoleOperator(
 		recorder:       recorder,
 		resourceSyncer: resourceSyncer,
 	}
+
+	// mounted via operator.yaml manifest
+	systemCABytes, err := ioutil.ReadFile("/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem")
+	if err != nil {
+		klog.Warningf("Unable to read system CA from /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem: %v", err)
+	}
+	c.systemCABundle = systemCABytes
 
 	secretsInformer := coreV1.Secrets()
 	configMapInformer := coreV1.ConfigMaps()

--- a/pkg/console/subresource/consoleserver/config_builder.go
+++ b/pkg/console/subresource/consoleserver/config_builder.go
@@ -9,9 +9,7 @@ import (
 )
 
 const (
-	clientSecretFilePath    = "/var/oauth-config/clientSecret"
-	routerCAFilePath        = "/var/router-ca/ca-bundle.crt"
-	oauthEndpointCAFilePath = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+	clientSecretFilePath = "/var/oauth-config/clientSecret"
 	// serving info
 	certFilePath = "/var/serving-cert/tls.crt"
 	keyFilePath  = "/var/serving-cert/tls.key"
@@ -78,10 +76,10 @@ func (b *ConsoleServerCLIConfigBuilder) StatusPageID(id string) *ConsoleServerCL
 
 func (b *ConsoleServerCLIConfigBuilder) RouterCA(useDefaultRouterCA bool) *ConsoleServerCLIConfigBuilder {
 	if useDefaultRouterCA {
-		b.CAFile = oauthEndpointCAFilePath
+		b.CAFile = api.OAuthEndpointCAFilePath
 		return b
 	}
-	b.CAFile = routerCAFilePath
+	b.CAFile = api.RouterCAFilePath
 	return b
 }
 
@@ -133,7 +131,7 @@ func (b *ConsoleServerCLIConfigBuilder) authServer() Auth {
 	// we need this fallback due to the way our unit test are structured,
 	// where the ConsoleServerCLIConfigBuilder object is being instantiated empty
 	if b.CAFile == "" {
-		b.CAFile = oauthEndpointCAFilePath
+		b.CAFile = api.OAuthEndpointCAFilePath
 	}
 	conf := Auth{
 		ClientID:            api.OpenShiftConsoleName,

--- a/pkg/console/subresource/consoleserver/config_builder_test.go
+++ b/pkg/console/subresource/consoleserver/config_builder_test.go
@@ -38,7 +38,7 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 				Auth: Auth{
 					ClientID:            api.OpenShiftConsoleName,
 					ClientSecretFile:    clientSecretFilePath,
-					OAuthEndpointCAFile: oauthEndpointCAFilePath,
+					OAuthEndpointCAFile: OAuthEndpointCAFilePath,
 				},
 				Customization: Customization{},
 				Providers:     Providers{},
@@ -96,7 +96,7 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 				Auth: Auth{
 					ClientID:            api.OpenShiftConsoleName,
 					ClientSecretFile:    clientSecretFilePath,
-					OAuthEndpointCAFile: oauthEndpointCAFilePath,
+					OAuthEndpointCAFile: OAuthEndpointCAFilePath,
 				},
 				Customization: Customization{},
 				Providers: Providers{
@@ -130,7 +130,7 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 				Auth: Auth{
 					ClientID:            api.OpenShiftConsoleName,
 					ClientSecretFile:    clientSecretFilePath,
-					OAuthEndpointCAFile: oauthEndpointCAFilePath,
+					OAuthEndpointCAFile: OAuthEndpointCAFilePath,
 					LogoutRedirect:      "https://foobar.com/logout",
 				},
 				Customization: Customization{

--- a/test/e2e/metrics_test.go
+++ b/test/e2e/metrics_test.go
@@ -155,6 +155,10 @@ func getClientWithCertAuth(t *testing.T) *http.Client {
 	// that are missing from the system trust roots
 	rootCAs.AppendCertsFromPEM(config.CAData)
 
+	// TODO: could get router-ca ConfigMap we sync'd from openshift-config-managed
+	// and append the cert from there.  Perhaps would eliminate need for
+	// InsecureSkipVerify: true
+
 	return &http.Client{
 		Transport: &http.Transport{
 			TLSClientConfig: &tls.Config{


### PR DESCRIPTION
Most of the "Console isn't happy" questions we get stem from the console route being unhealthy at this point.  This adds a `RouteHealthDegraded` condition, with several checks to see if the route is in a good place.

It is similar to the check done by the authentication operator, which seems to have made debugging much easier:
https://github.com/openshift/cluster-authentication-operator/blob/e7d5e3d45f5188e9c0631e93552e5b7ac48a06e4/pkg/operator2/operator.go#L445

/assign @spadgett @jhadvig 
