### PR TITLE
Revert "Skip Unmanaged and Removed TCs"

### DIFF
--- a/test/e2e/removed_test.go
+++ b/test/e2e/removed_test.go
@@ -18,7 +18,6 @@ func cleanupRemovedTestCase(t *testing.T, client *framework.ClientSet) {
 // TestRemoved() sets ManagementState:Removed and verifies that all
 // console resources are deleted.
 func TestRemoved(t *testing.T) {
-	t.Skip()
 	client, _ := setupRemovedTestCase(t)
 	defer cleanupRemovedTestCase(t, client)
 

--- a/test/e2e/unmanaged_test.go
+++ b/test/e2e/unmanaged_test.go
@@ -20,7 +20,6 @@ func cleanUpUnmanagedTestCase(t *testing.T, client *framework.ClientSet) {
 // TestUnmanaged() sets ManagementState:Unmanaged then deletes a set of console
 // resources and verifies that the operator does not recreate them.
 func TestUnmanaged(t *testing.T) {
-	t.Skip()
 	client := setupUnmanagedTestCase(t)
 	defer cleanUpUnmanagedTestCase(t, client)
 
@@ -33,7 +32,6 @@ func TestUnmanaged(t *testing.T) {
 }
 
 func TestEditUnmanagedConfigMap(t *testing.T) {
-	t.Skip()
 	client := setupUnmanagedTestCase(t)
 	defer cleanUpUnmanagedTestCase(t, client)
 
@@ -44,7 +42,6 @@ func TestEditUnmanagedConfigMap(t *testing.T) {
 }
 
 func TestEditUnmanagedService(t *testing.T) {
-	t.Skip()
 	client := setupUnmanagedTestCase(t)
 	defer cleanUpUnmanagedTestCase(t, client)
 
@@ -55,7 +52,6 @@ func TestEditUnmanagedService(t *testing.T) {
 }
 
 func TestEditUnmanagedRoute(t *testing.T) {
-	t.Skip()
 	client := setupUnmanagedTestCase(t)
 	defer cleanUpUnmanagedTestCase(t, client)
 


### PR DESCRIPTION
Reverts openshift/console-operator#333

We want to turn our tests back on sooner than later.  Opening this up while we dig into the flake.

@jhadvig 