### PR TITLE
Missing service informer

### DIFF
--- a/pkg/console/starter/starter.go
+++ b/pkg/console/starter/starter.go
@@ -189,11 +189,12 @@ func RunOperator(ctx *controllercmd.ControllerContext) error {
 	)
 
 	consoleServiceController := service.NewServiceSyncController(
-		// operator config so we can update status
-		operatorConfigClient.OperatorV1().Consoles(),
-		// only needs to interact with the service resource
-		kubeClient.CoreV1(),
-		kubeInformersNamespaced.Core().V1().Services(),
+		// clients
+		operatorConfigClient.OperatorV1().Consoles(), // operator config so we can update status
+		kubeClient.CoreV1(),                          // only needs to interact with the service resource
+		// informers
+		operatorConfigInformers.Operator().V1().Consoles(), // OperatorConfig
+		kubeInformersNamespaced.Core().V1().Services(),     // Services
 		// names
 		api.OpenShiftConsoleNamespace,
 		api.OpenShiftConsoleName,

--- a/test/e2e/framework/console-operator.go
+++ b/test/e2e/framework/console-operator.go
@@ -325,9 +325,9 @@ func operatorIsObservingCurrentGeneration(operatorConfig *operatorsv1.Console) b
 
 // A helper to ensure our operator config reaches a settled state before we
 // begin the next test.
-func WaitForSettledState(t *testing.T, client *ClientSet) (settled bool, err error) {
+func WaitForSettledState(t *testing.T, client *ClientSet, phase string) (settled bool, err error) {
 	t.Helper()
-	fmt.Printf("waiting to reach settled state...\n")
+	t.Logf("waiting for %s to reach settled state...\n", phase)
 	// don't rush it
 	interval := 2 * time.Second
 	// it should never take this long for a test to pass

--- a/test/e2e/framework/utils.go
+++ b/test/e2e/framework/utils.go
@@ -27,7 +27,7 @@ func StandardSetup(t *testing.T) (*ClientSet, *v1.Console) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	WaitForSettledState(t, client)
+	WaitForSettledState(t, client, "setup")
 
 	return client, operatorConfig
 }
@@ -43,7 +43,7 @@ func StandardCleanup(t *testing.T, client *ClientSet) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	WaitForSettledState(t, client)
+	WaitForSettledState(t, client, "cleanup")
 }
 
 func CheckEnvVars(want []corev1.EnvVar, have []corev1.EnvVar, includes bool) []error {

--- a/test/e2e/removed_test.go
+++ b/test/e2e/removed_test.go
@@ -18,7 +18,6 @@ func cleanupRemovedTestCase(t *testing.T, client *framework.ClientSet) {
 // TestRemoved() sets ManagementState:Removed and verifies that all
 // console resources are deleted.
 func TestRemoved(t *testing.T) {
-	t.Skip()
 	client, _ := setupRemovedTestCase(t)
 	defer cleanupRemovedTestCase(t, client)
 

--- a/test/e2e/unmanaged_test.go
+++ b/test/e2e/unmanaged_test.go
@@ -21,7 +21,6 @@ func cleanUpUnmanagedTestCase(t *testing.T, client *framework.ClientSet) {
 // TestUnmanaged() sets ManagementState:Unmanaged then deletes a set of console
 // resources and verifies that the operator does not recreate them.
 func TestUnmanaged(t *testing.T) {
-	t.Skip()
 	client, _ := setupUnmanagedTestCase(t)
 	defer cleanUpUnmanagedTestCase(t, client)
 
@@ -34,7 +33,6 @@ func TestUnmanaged(t *testing.T) {
 }
 
 func TestEditUnmanagedConfigMap(t *testing.T) {
-	t.Skip()
 	client, _ := setupUnmanagedTestCase(t)
 	defer cleanUpUnmanagedTestCase(t, client)
 
@@ -45,7 +43,6 @@ func TestEditUnmanagedConfigMap(t *testing.T) {
 }
 
 func TestEditUnmanagedService(t *testing.T) {
-	t.Skip()
 	client, _ := setupUnmanagedTestCase(t)
 	defer cleanUpUnmanagedTestCase(t, client)
 
@@ -56,7 +53,6 @@ func TestEditUnmanagedService(t *testing.T) {
 }
 
 func TestEditUnmanagedRoute(t *testing.T) {
-	t.Skip()
 	client, _ := setupUnmanagedTestCase(t)
 	defer cleanUpUnmanagedTestCase(t, client)
 

--- a/test/e2e/unmanaged_test.go
+++ b/test/e2e/unmanaged_test.go
@@ -3,14 +3,15 @@ package e2e
 import (
 	"testing"
 
+	operatorsv1 "github.com/openshift/api/operator/v1"
 	"github.com/openshift/console-operator/pkg/api"
 	"github.com/openshift/console-operator/test/e2e/framework"
 )
 
-func setupUnmanagedTestCase(t *testing.T) *framework.ClientSet {
-	client := framework.MustNewClientset(t, nil)
+func setupUnmanagedTestCase(t *testing.T) (*framework.ClientSet, *operatorsv1.Console) {
+	client, operatorConfig := framework.StandardSetup(t)
 	framework.MustUnmanageConsole(t, client)
-	return client
+	return client, operatorConfig
 }
 
 func cleanUpUnmanagedTestCase(t *testing.T, client *framework.ClientSet) {
@@ -21,7 +22,7 @@ func cleanUpUnmanagedTestCase(t *testing.T, client *framework.ClientSet) {
 // resources and verifies that the operator does not recreate them.
 func TestUnmanaged(t *testing.T) {
 	t.Skip()
-	client := setupUnmanagedTestCase(t)
+	client, _ := setupUnmanagedTestCase(t)
 	defer cleanUpUnmanagedTestCase(t, client)
 
 	framework.DeleteAll(t, client)
@@ -34,7 +35,7 @@ func TestUnmanaged(t *testing.T) {
 
 func TestEditUnmanagedConfigMap(t *testing.T) {
 	t.Skip()
-	client := setupUnmanagedTestCase(t)
+	client, _ := setupUnmanagedTestCase(t)
 	defer cleanUpUnmanagedTestCase(t, client)
 
 	err := patchAndCheckConfigMap(t, client, false)
@@ -45,7 +46,7 @@ func TestEditUnmanagedConfigMap(t *testing.T) {
 
 func TestEditUnmanagedService(t *testing.T) {
 	t.Skip()
-	client := setupUnmanagedTestCase(t)
+	client, _ := setupUnmanagedTestCase(t)
 	defer cleanUpUnmanagedTestCase(t, client)
 
 	err := patchAndCheckService(t, client, false)
@@ -56,7 +57,7 @@ func TestEditUnmanagedService(t *testing.T) {
 
 func TestEditUnmanagedRoute(t *testing.T) {
 	t.Skip()
-	client := setupUnmanagedTestCase(t)
+	client, _ := setupUnmanagedTestCase(t)
 	defer cleanUpUnmanagedTestCase(t, client)
 
 	err := patchAndCheckRoute(t, client, false)
@@ -66,7 +67,7 @@ func TestEditUnmanagedRoute(t *testing.T) {
 }
 
 func TestEditUnmanagedConsoleCLIDownloads(t *testing.T) {
-	client := setupUnmanagedTestCase(t)
+	client, _ := setupUnmanagedTestCase(t)
 	defer cleanUpUnmanagedTestCase(t, client)
 
 	err := patchAndCheckConsoleCLIDownloads(t, client, false, api.OCCLIDownloadsCustomResourceName)


### PR DESCRIPTION
The issue of the failing Unmanaged e2e tests was that the new ServiceController haven't picked up changes in the consoleoperator config, eg: change from `Unmanaged` to `Managed` state.
Due to this the `console` service has not been recreated and the console pods could not start since cause of that the `console-serving-cert` secret was missing.

Also adding the `StandardSetup` call from https://github.com/openshift/console-operator/pull/329, which this PR shoud replace.

Also removing the skipping of the failing tests, which should replace https://github.com/openshift/console-operator/pull/336 since there is no point to have two PR for that.

/assign @benjaminapetersen 