### PR TITLE
Enable multi-arch support in downloads

### DIFF
--- a/manifests/07-downloads-deployment.yaml
+++ b/manifests/07-downloads-deployment.yaml
@@ -89,11 +89,18 @@ spec:
               os.mkdir(arch)
               for operating_system in ['linux', 'mac', 'windows']:
                   os.mkdir(os.path.join(arch, operating_system))
+          for arch in ['arm64', 'ppc64le', 's390x']:
+              os.mkdir(arch)
+              for operating_system in ['linux']:
+                  os.mkdir(os.path.join(arch, operating_system))
 
           for arch, operating_system, path in [
-                  ('amd64', 'linux', '/usr/bin/oc'),
+                  ('amd64', 'linux', '/usr/share/openshift/linux_amd64/oc'),
                   ('amd64', 'mac', '/usr/share/openshift/mac/oc'),
                   ('amd64', 'windows', '/usr/share/openshift/windows/oc.exe'),
+                  ('arm64', 'linux', '/usr/share/openshift/linux_arm64/oc'),
+                  ('ppc64le', 'linux', '/usr/share/openshift/linux_ppc64le/oc'),
+                  ('s390x', 'linux', '/usr/share/openshift/linux_s390x/oc'),
                   ]:
               basename = os.path.basename(path)
               target_path = os.path.join(arch, operating_system, basename)

--- a/pkg/console/controllers/clidownloads/controller.go
+++ b/pkg/console/controllers/clidownloads/controller.go
@@ -162,7 +162,7 @@ func PlatformBasedOCConsoleCLIDownloads(host, cliDownloadsName string) *v1.Conso
 		{"Linux for IBM Power, little endian", "ppc64le/linux", "oc.tar"},
 		{"Linux for IBM Z", "s390x/linux", "oc.tar"},
 		{"Mac", "amd64/mac", "oc.zip"},
-		{"Windows", "amd64/windows", "oc.zip"},
+		{"Windows 64-bit", "amd64/windows", "oc.zip"},
 	}
 
 	links := []v1.CLIDownloadLink{}

--- a/pkg/console/controllers/clidownloads/controller.go
+++ b/pkg/console/controllers/clidownloads/controller.go
@@ -122,7 +122,7 @@ func (c *CLIDownloadsSyncController) sync() error {
 	}
 
 	host := routesub.GetCanonicalHost(consoleRoute)
-	ocConsoleCLIDownloads := PlatformBasedOCConsoleCLIDownloads(host, "amd64", api.OCCLIDownloadsCustomResourceName)
+	ocConsoleCLIDownloads := PlatformBasedOCConsoleCLIDownloads(host, api.OCCLIDownloadsCustomResourceName)
 	_, ocCLIDownloadsErrReason, ocCLIDownloadsErr := ApplyCLIDownloads(c.consoleCliDownloadsClient, ocConsoleCLIDownloads)
 	status.HandleDegraded(updatedOperatorConfig, "OCDownloadsSync", ocCLIDownloadsErrReason, ocCLIDownloadsErr)
 	if ocCLIDownloadsErr != nil {
@@ -150,16 +150,19 @@ func GetPlatformURL(baseURL, platform, archiveType string) string {
 	return fmt.Sprintf("%s/%s/%s", baseURL, platform, archiveType)
 }
 
-func PlatformBasedOCConsoleCLIDownloads(host, arch, cliDownloadsName string) *v1.ConsoleCLIDownload {
-	baseURL := fmt.Sprintf("%s/%s", util.HTTPS(host), arch)
+func PlatformBasedOCConsoleCLIDownloads(host, cliDownloadsName string) *v1.ConsoleCLIDownload {
+	baseURL := fmt.Sprintf("%s", util.HTTPS(host))
 	platforms := []struct {
 		label    string
 		key      string
 		archType string
 	}{
-		{"Linux", "linux", "oc.tar"},
-		{"Mac", "mac", "oc.zip"},
-		{"Windows", "windows", "oc.zip"},
+		{"Linux for x86_64", "amd64/linux", "oc.tar"},
+		{"Linux for ARM 64", "arm64/linux", "oc.tar"},
+		{"Linux for IBM Power, little endian", "ppc64le/linux", "oc.tar"},
+		{"Linux for IBM Z", "s390x/linux", "oc.tar"},
+		{"Mac", "amd64/mac", "oc.zip"},
+		{"Windows", "amd64/windows", "oc.zip"},
 	}
 
 	links := []v1.CLIDownloadLink{}

--- a/pkg/console/controllers/clidownloads/controller_test.go
+++ b/pkg/console/controllers/clidownloads/controller_test.go
@@ -20,13 +20,40 @@ func TestGetPlatformURL(t *testing.T) {
 		want string
 	}{
 		{
-			name: "Test assembling linux specific URL",
+			name: "Test assembling linux amd64 specific URL",
 			args: args{
 				baseURL:     "https://www.example.com/amd64",
 				platform:    "linux",
 				archiveType: "oc.tar",
 			},
 			want: "https://www.example.com/amd64/linux/oc.tar",
+		},
+		{
+			name: "Test assembling linux arm64 specific URL",
+			args: args{
+				baseURL:     "https://www.example.com/arm64",
+				platform:    "linux",
+				archiveType: "oc.tar",
+			},
+			want: "https://www.example.com/arm64/linux/oc.tar",
+		},
+		{
+			name: "Test assembling linux ppc64le specific URL",
+			args: args{
+				baseURL:     "https://www.example.com/ppc64le",
+				platform:    "linux",
+				archiveType: "oc.tar",
+			},
+			want: "https://www.example.com/ppc64le/linux/oc.tar",
+		},
+		{
+			name: "Test assembling linux s390x specific URL",
+			args: args{
+				baseURL:     "https://www.example.com/s390x",
+				platform:    "linux",
+				archiveType: "oc.tar",
+			},
+			want: "https://www.example.com/s390x/linux/oc.tar",
 		},
 		{
 			name: "Test assembling mac specific URL",
@@ -71,12 +98,11 @@ func TestPlatformBasedOCConsoleCLIDownloads(t *testing.T) {
 			name: "Test assembling platform specific URL",
 			args: args{
 				host:             "www.example.com",
-				arch:             "amd64",
-				cliDownloadsName: "oc-cli-downloads",
+				cliDownloadsName: "amd64/oc-cli-downloads",
 			},
 			want: &v1.ConsoleCLIDownload{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "oc-cli-downloads",
+					Name: "amd64/oc-cli-downloads",
 				},
 				Spec: v1.ConsoleCLIDownloadSpec{
 					Description: `With the OpenShift command line interface, you can create applications and manage OpenShift projects from a terminal.
@@ -87,7 +113,19 @@ The oc binary offers the same capabilities as the kubectl binary, but it is furt
 					Links: []v1.CLIDownloadLink{
 						{
 							Href: "https://www.example.com/amd64/linux/oc.tar",
-							Text: "Download oc for Linux",
+							Text: "Download oc for Linux for x86_64",
+						},
+						{
+							Href: "https://www.example.com/arm64/linux/oc.tar",
+							Text: "Download oc for Linux for ARM 64",
+						},
+						{
+							Href: "https://www.example.com/ppc64le/linux/oc.tar",
+							Text: "Download oc for Linux for IBM Power, little endian",
+						},
+						{
+							Href: "https://www.example.com/s390x/linux/oc.tar",
+							Text: "Download oc for Linux for IBM Z",
 						},
 						{
 							Href: "https://www.example.com/amd64/mac/oc.zip",
@@ -104,7 +142,7 @@ The oc binary offers the same capabilities as the kubectl binary, but it is furt
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if diff := deep.Equal(PlatformBasedOCConsoleCLIDownloads(tt.args.host, tt.args.arch, tt.args.cliDownloadsName), tt.want); diff != nil {
+			if diff := deep.Equal(PlatformBasedOCConsoleCLIDownloads(tt.args.host, tt.args.cliDownloadsName), tt.want); diff != nil {
 				t.Error(diff)
 			}
 		})

--- a/pkg/console/controllers/clidownloads/controller_test.go
+++ b/pkg/console/controllers/clidownloads/controller_test.go
@@ -65,7 +65,7 @@ func TestGetPlatformURL(t *testing.T) {
 			want: "https://www.example.com/amd64/mac/oc.zip",
 		},
 		{
-			name: "Test assembling windows specific URL",
+			name: "Test assembling windows 64-bit specific URL",
 			args: args{
 				baseURL:     "https://www.example.com/amd64",
 				platform:    "windows",
@@ -133,7 +133,7 @@ The oc binary offers the same capabilities as the kubectl binary, but it is furt
 						},
 						{
 							Href: "https://www.example.com/amd64/windows/oc.zip",
-							Text: "Download oc for Windows",
+							Text: "Download oc for Windows 64-bit",
 						},
 					},
 				},

--- a/test/e2e/downloads_test.go
+++ b/test/e2e/downloads_test.go
@@ -31,7 +31,7 @@ func TestDownloadsEndpoint(t *testing.T) {
 	}
 	host := routesub.GetCanonicalHost(route)
 
-	ocDownloads := clidownloads.PlatformBasedOCConsoleCLIDownloads(host, "amd64", api.OCCLIDownloadsCustomResourceName)
+	ocDownloads := clidownloads.PlatformBasedOCConsoleCLIDownloads(host, api.OCCLIDownloadsCustomResourceName)
 
 	for _, link := range ocDownloads.Spec.Links {
 		req := getRequest(t, link.Href)


### PR DESCRIPTION
In order for console-operator deployment to succeed, cli-artifacts needs to be available on all arches for downloads-openshift-console. However, in that case, /usr/bin/oc (inherited from cli) is a native binary, and we want to provide all primary Linux architectures to match those on mirror.openshift.com, regardless of cluster architecture.

This depends on https://github.com/openshift/oc/pull/153 to provide the new binaries in cli-artifacts.

Because this affects cluster deployment, we are looking to get this into 4.2 and later branches (we can provide separate PRs for stable branches as needed).