### PR TITLE
Add e2e test for oc downloads links

### DIFF
--- a/test/e2e/downloads_test.go
+++ b/test/e2e/downloads_test.go
@@ -1,0 +1,50 @@
+package e2e
+
+import (
+	"net/http"
+	"testing"
+
+	operatorsv1 "github.com/openshift/api/operator/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openshift/console-operator/pkg/api"
+	"github.com/openshift/console-operator/pkg/console/controllers/clidownloads"
+	routesub "github.com/openshift/console-operator/pkg/console/subresource/route"
+	"github.com/openshift/console-operator/test/e2e/framework"
+)
+
+func setupDownloadsTestCase(t *testing.T) (*framework.ClientSet, *operatorsv1.Console) {
+	return framework.StandardSetup(t)
+}
+
+func cleanupDownloadsTestCase(t *testing.T, client *framework.ClientSet) {
+	framework.StandardCleanup(t, client)
+}
+
+func TestDownloadsEndpoint(t *testing.T) {
+	client, _ := setupDownloadsTestCase(t)
+	defer cleanupDownloadsTestCase(t, client)
+
+	route, err := client.Routes.Routes(api.OpenShiftConsoleNamespace).Get(api.OpenShiftConsoleName, v1.GetOptions{})
+	if err != nil {
+		t.Fatalf("could not get route: %s", err)
+	}
+	host := routesub.GetCanonicalHost(route)
+
+	ocDownloads := clidownloads.PlatformBasedOCConsoleCLIDownloads(host, "amd64", api.OCCLIDownloadsCustomResourceName)
+
+	for _, link := range ocDownloads.Spec.Links {
+		req := getRequest(t, link.Href)
+		client := getInsecureClient()
+		resp, err := client.Do(req)
+
+		if err != nil {
+			t.Fatalf("http error getting %s at %s: %s", link.Text, link.Href, err)
+		}
+		if !httpOK(resp) {
+			t.Fatalf("http error for %s at %s: %d %s", link.Text, link.Href, resp.StatusCode, http.StatusText(resp.StatusCode))
+		}
+		resp.Body.Close()
+		t.Logf("%s %s\n", link.Text, resp.Status)
+	}
+}

--- a/test/e2e/metrics_test.go
+++ b/test/e2e/metrics_test.go
@@ -107,21 +107,6 @@ func metricsRequest(t *testing.T, routeForMetrics string) string {
 	return string(bytes)
 }
 
-func httpOK(resp *http.Response) bool {
-	if resp.StatusCode >= 200 && resp.StatusCode <= 299 {
-		return true
-	}
-	return false
-}
-
-func getRequest(t *testing.T, metricsURL string) *http.Request {
-	req, err := http.NewRequest("GET", metricsURL, nil)
-	if err != nil {
-		fmt.Printf("%s\n", err)
-	}
-	return req
-}
-
 // kubeadmin is an oauth account. it will not work. to run tests instead do:
 // oc login -u system:admin
 // so that the config read gives correct data back.

--- a/test/e2e/removed_test.go
+++ b/test/e2e/removed_test.go
@@ -17,6 +17,8 @@ func cleanupRemovedTestCase(t *testing.T, client *framework.ClientSet) {
 
 // TestRemoved() sets ManagementState:Removed and verifies that all
 // console resources are deleted.
+// NOTE: this does not apply to the Downloads resources.  The Downloads
+// resources are managed by CVO and thus always exist.
 func TestRemoved(t *testing.T) {
 	client, _ := setupRemovedTestCase(t)
 	defer cleanupRemovedTestCase(t, client)

--- a/test/e2e/util_http.go
+++ b/test/e2e/util_http.go
@@ -1,0 +1,58 @@
+package e2e
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/openshift/console-operator/test/e2e/framework"
+)
+
+// a request with a route & the bearer token
+// this only works if test are run as a token user (example: kube:admin)
+func getRequestWithToken(t *testing.T, url, bearer string) *http.Request {
+	req := getRequest(t, url)
+	req.Header.Add("Authorization", bearer)
+	return req
+}
+
+func getRequest(t *testing.T, url string) *http.Request {
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		fmt.Printf("%s\n", err)
+	}
+	return req
+}
+
+func getInsecureClient() *http.Client {
+	// ignore self signed certs for testing purposes
+	return &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true,
+			},
+		},
+	}
+}
+
+// gets us a token from the kubeconfig file
+func getBearerToken(t *testing.T) string {
+	tokenProvider, err := framework.GetConfig()
+	if err != nil {
+		t.Fatalf("error, can't get config: %s", err)
+	}
+
+	// use this for
+	// tokenProvider.TLSClientConfig
+
+	// build the request header with a token from the kubeconfig
+	return fmt.Sprintf("Bearer %s", tokenProvider.BearerToken)
+}
+
+func httpOK(resp *http.Response) bool {
+	if resp.StatusCode >= 200 && resp.StatusCode <= 299 {
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
```bash
go test -run TestDownloadsEndpoint -count 1
checking for console-operator availability
found operator deployment
link for Download oc for Linux 200 OK (https://console-openshift-console.apps.bpetersen.devcluster.openshift.com/amd64/linux/oc.tar)
link for Download oc for Mac 200 OK (https://console-openshift-console.apps.bpetersen.devcluster.openshift.com/amd64/mac/oc.zip)
link for Download oc for Windows 200 OK (https://console-openshift-console.apps.bpetersen.devcluster.openshift.com/amd64/windows/oc.zip)
PASS
ok  	github.com/openshift/console-operator/test/e2e	5.274s
```

/assign @spadgett 