### PR TITLE
Add liveness and readiness probes to console operator

### DIFF
--- a/manifests/07-operator.yaml
+++ b/manifests/07-operator.yaml
@@ -63,6 +63,16 @@ spec:
           requests:
             memory: "100Mi"
             cpu: "10m"
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8443
+            scheme: HTTPS
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8443
+            scheme: HTTPS
       volumes:
       - name: config
         configMap:


### PR DESCRIPTION
We have several endpoints we can hit on the operator:

```
{
  "paths": [
    "/apis",
    "/healthz",
    "/healthz/log",
    "/healthz/ping",
    "/livez",
    "/livez/log",
    "/livez/ping",
    "/metrics",
    "/readyz",
    "/readyz/log",
    "/readyz/ping",
    "/readyz/shutdown"
  ]
}
```
So adding both `/healthz` and `/readyz` probes.  Initial prob config is basically the same as that of the `console` `deployment` otherwise.

/assign @spadgett  @jhadvig 


To manually test these endpoints, do something like `oc create -f` on:

```yaml
apiVersion: route.openshift.io/v1
kind: Route
metadata:
  name: console-operator-route-for-testing
  namespace: openshift-console-operator
spec:
  port:
    targetPort: https
  tls:
    insecureEdgeTerminationPolicy: Redirect
    termination: passthrough
  to:
    # this is fine, the service name is a misnomer, its generic to the operator but initial intent was only metrics
    kind: Service
    name: metrics
    weight: 100
  wildcardPolicy: None
```

then:

```bash
# health
curl --insecure -H "Authorization: Bearer $(oc whoami --show-token)" $(oc get route console-operator-route-for-testing --template 'https://{{.spec.host}}/healthz')
# ready
curl --insecure -H "Authorization: Bearer $(oc whoami --show-token)" $(oc get route metrics-route-for-testingconsole-operator-route-for-testing --template 'https://{{.spec.host}}/readyz')
```




