### PR TITLE
Remove redundant service delete

### DIFF
--- a/pkg/console/operator/operator.go
+++ b/pkg/console/operator/operator.go
@@ -49,7 +49,6 @@ import (
 	"github.com/openshift/console-operator/pkg/console/subresource/oauthclient"
 	"github.com/openshift/console-operator/pkg/console/subresource/route"
 	"github.com/openshift/console-operator/pkg/console/subresource/secret"
-	"github.com/openshift/console-operator/pkg/console/subresource/service"
 )
 
 const (
@@ -251,8 +250,6 @@ func (c *consoleOperator) removeConsole() error {
 	klog.V(2).Info("deleting console resources")
 	defer klog.V(2).Info("finished deleting console resources")
 	var errs []error
-	// service
-	errs = append(errs, c.serviceClient.Services(api.TargetNamespace).Delete(service.Stub().Name, &metav1.DeleteOptions{}))
 	// route
 	errs = append(errs, c.routeClient.Routes(api.TargetNamespace).Delete(route.Stub().Name, &metav1.DeleteOptions{}))
 	// configmaps


### PR DESCRIPTION
The `DELETE` of the `service` is handled in the `ServiceSyncController` now.  Remove the redundant attempt to delete the service. 

/assign @jhadvig 