### PR TITLE
Bug 1773808: Enable multi-arch support in downloads [4.2]

### DIFF
--- a/manifests/07-downloads-deployment.yaml
+++ b/manifests/07-downloads-deployment.yaml
@@ -87,11 +87,18 @@ spec:
               os.mkdir(arch)
               for operating_system in ['linux', 'mac', 'windows']:
                   os.mkdir(os.path.join(arch, operating_system))
+          for arch in ['arm64', 'ppc64le', 's390x']:
+              os.mkdir(arch)
+              for operating_system in ['linux']:
+                  os.mkdir(os.path.join(arch, operating_system))
 
           for arch, operating_system, path in [
-                  ('amd64', 'linux', '/usr/bin/oc'),
+                  ('amd64', 'linux', '/usr/share/openshift/linux_amd64/oc'),
                   ('amd64', 'mac', '/usr/share/openshift/mac/oc'),
                   ('amd64', 'windows', '/usr/share/openshift/windows/oc.exe'),
+                  ('arm64', 'linux', '/usr/share/openshift/linux_arm64/oc'),
+                  ('ppc64le', 'linux', '/usr/share/openshift/linux_ppc64le/oc'),
+                  ('s390x', 'linux', '/usr/share/openshift/linux_s390x/oc'),
                   ]:
               basename = os.path.basename(path)
               target_path = os.path.join(arch, operating_system, basename)


### PR DESCRIPTION
In order for console-operator deployment to succeed, cli-artifacts needs to be available on all arches for downloads-openshift-console. However, in that case, /usr/bin/oc (inherited from cli) is a native binary, and we want to provide all primary Linux architectures to match those on mirror.openshift.com, regardless of cluster architecture.

This depends on https://github.com/openshift/oc/pull/168 to provide the new binaries in cli-artifacts for 4.2.

This is a cherry-pick of the first commit from https://github.com/openshift/console-operator/pull/343.  The other commits from that PR are relevant only to new code in 4.3+.