### PR TITLE
pkg/console/controllers/clidownloads/controller: Arch qualifiers for Mac/Windows

### DIFF
--- a/pkg/console/controllers/clidownloads/controller.go
+++ b/pkg/console/controllers/clidownloads/controller.go
@@ -161,8 +161,8 @@ func PlatformBasedOCConsoleCLIDownloads(host, cliDownloadsName string) *v1.Conso
 		{"Linux for ARM 64", "arm64/linux", "oc.tar"},
 		{"Linux for IBM Power, little endian", "ppc64le/linux", "oc.tar"},
 		{"Linux for IBM Z", "s390x/linux", "oc.tar"},
-		{"Mac", "amd64/mac", "oc.zip"},
-		{"Windows 64-bit", "amd64/windows", "oc.zip"},
+		{"Mac for x86_64", "amd64/mac", "oc.zip"},
+		{"Windows for x86_64", "amd64/windows", "oc.zip"},
 	}
 
 	links := []v1.CLIDownloadLink{}

--- a/pkg/console/controllers/clidownloads/controller_test.go
+++ b/pkg/console/controllers/clidownloads/controller_test.go
@@ -129,11 +129,11 @@ The oc binary offers the same capabilities as the kubectl binary, but it is furt
 						},
 						{
 							Href: "https://www.example.com/amd64/mac/oc.zip",
-							Text: "Download oc for Mac",
+							Text: "Download oc for Mac for x86_64",
 						},
 						{
 							Href: "https://www.example.com/amd64/windows/oc.zip",
-							Text: "Download oc for Windows 64-bit",
+							Text: "Download oc for Windows for x86_64",
 						},
 					},
 				},


### PR DESCRIPTION
Folks could presumably be running these OSes on other architectures.  For example, [the GOOS/GOARCH docs][1] provide for darwin on 386, amd64, arm, and arm64 and windows on 386 and amd64 (although [Windows runs on ARM64][2] and possibly other architectures as well).

I'm sticking with `x86_64` for consistency with the Linux entry from 865d84d7bb (#343).  Previous discussion starting [here][3].  CC @yselkowitz.

[1]: https://golang.org/doc/install/source#environment
[2]: https://docs.microsoft.com/en-us/windows/arm/
[3]: https://github.com/openshift/console-operator/pull/343#discussion_r347735631