### PR TITLE
Bug 1781475: Avoid console_url metric as empty string [Release-4.2]

### DIFF
--- a/pkg/console/metrics/console_url.go
+++ b/pkg/console/metrics/console_url.go
@@ -1,0 +1,47 @@
+package metrics
+
+import "k8s.io/klog"
+
+func HandleConsoleURL(oldURL, newURL string) {
+	// if neither have been set, there is nothing to update
+	if noHost(oldURL, newURL) {
+		klog.V(4).Infof("metric console_url has no host")
+		return
+	}
+
+	// only a new URL
+	if isNewHost(oldURL, newURL) {
+		klog.V(4).Infof("metric console_url new host: %s %s", oldURL, newURL)
+		singleton.ConsoleURL.WithLabelValues(newURL).Set(1)
+		return
+	}
+
+	// route or ingress update
+	if isHostTransition(oldURL, newURL) {
+		klog.V(4).Infof("metric console_url host transition: %s to %s", oldURL, newURL)
+		singleton.ConsoleURL.WithLabelValues(oldURL).Set(0)
+		singleton.ConsoleURL.WithLabelValues(newURL).Set(1)
+		return
+	}
+
+	// something went wrong and we no longer have a route or ingress with a host
+	if hostDied(oldURL, newURL) {
+		klog.V(4).Infof("metric console_url host lost: %s %s", oldURL, newURL)
+		singleton.ConsoleURL.WithLabelValues(oldURL).Set(0)
+		return
+	}
+	klog.Error("metric console_url unhandled")
+}
+
+func noHost(old, new string) bool {
+	return len(old) == 0 && len(new) == 0
+}
+func isNewHost(old, new string) bool {
+	return len(old) == 0 && len(new) != 0
+}
+func isHostTransition(old, new string) bool {
+	return len(old) != 0 && len(new) != 0
+}
+func hostDied(old, new string) bool {
+	return len(old) != 0 && len(new) == 0
+}

--- a/pkg/console/metrics/register.go
+++ b/pkg/console/metrics/register.go
@@ -1,0 +1,31 @@
+package metrics
+
+import (
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type ConsoleMetrics struct {
+	ConsoleURL *prometheus.GaugeVec
+}
+
+var singleton *ConsoleMetrics
+var once sync.Once
+
+func Register() *ConsoleMetrics {
+	// thread safe
+	once.Do(func() {
+		singleton = &ConsoleMetrics{}
+
+		// metric: console_url{url="https://<url>"} 1
+		singleton.ConsoleURL = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "console_url",
+			Help: "URL of the console exposed on the cluster",
+			// one label
+		}, []string{"url"})
+
+		prometheus.MustRegister(singleton.ConsoleURL)
+	})
+	return singleton
+}


### PR DESCRIPTION
Manual backport of #346 

- #346 includes the updates to use `legacy-registry` due to the global registry issues with Prometheus.  I believe this issue appeared in `kubernetes-1.15`, which is 4.3+.  The files included have been adjusted to use the original global registry.