### PR TITLE
Bug 1784582: Added Helm CLI download links

### DIFF
--- a/manifests/07-downloads-helm.yaml
+++ b/manifests/07-downloads-helm.yaml
@@ -1,0 +1,13 @@
+apiVersion: console.openshift.io/v1
+kind: ConsoleCLIDownload
+metadata:
+  name: helm-download-links
+spec:
+  description: |
+    Helm 3 is a package manager for Kubernetes applications which enables defining,
+    installing, and upgrading applications packaged as Helm Charts.
+    Helm 3 is a [Technology Preview](https://access.redhat.com/support/offerings/techpreview) feature on OpenShift 4.
+  displayName: helm - Helm 3 CLI
+  links:
+    - href: 'https://mirror.openshift.com/pub/openshift-v4/clients/helm/latest'
+      text: Download helm


### PR DESCRIPTION
This PR adds to OpenShift Console the additional Helm CLI download link(s).