### PR TITLE
RBAC for console backend to request openshift-config-managed configmaps

### DIFF
--- a/manifests/03-rbac-role-ns-openshift-config-managed.yaml
+++ b/manifests/03-rbac-role-ns-openshift-config-managed.yaml
@@ -35,3 +35,16 @@ rules:
   - console-public
   verbs:
   - get
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: console-configmap-reader
+  namespace: openshift-config-managed
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get

--- a/manifests/04-rbac-rolebinding.yaml
+++ b/manifests/04-rbac-rolebinding.yaml
@@ -80,4 +80,17 @@ subjects:
   - kind: ServiceAccount
     name: console-operator
     namespace: openshift-console-operator
-
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: console-configmap-reader
+  namespace: openshift-config-managed
+roleRef:
+  kind: Role
+  name: console-configmap-reader
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: console
+    namespace: openshift-console

--- a/manifests/06-sa.yaml
+++ b/manifests/06-sa.yaml
@@ -3,3 +3,9 @@ kind: ServiceAccount
 metadata:
   name: console-operator
   namespace: openshift-console-operator
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: console
+  namespace: openshift-console

--- a/pkg/console/subresource/deployment/deployment.go
+++ b/pkg/console/subresource/deployment/deployment.go
@@ -106,6 +106,7 @@ func DefaultDeployment(operatorConfig *operatorv1.Console, cm *corev1.ConfigMap,
 					Annotations: annotations,
 				},
 				Spec: corev1.PodSpec{
+					ServiceAccountName: "console",
 					// we want to deploy on master nodes
 					NodeSelector: map[string]string{
 						// empty string is correct

--- a/pkg/console/subresource/deployment/deployment_test.go
+++ b/pkg/console/subresource/deployment/deployment_test.go
@@ -196,6 +196,7 @@ func TestDefaultDeployment(t *testing.T) {
 						Annotations: consoleDeploymentTemplateAnnotations,
 					},
 						Spec: corev1.PodSpec{
+							ServiceAccountName: "console",
 							// we want to deploy on master nodes
 							NodeSelector: map[string]string{
 								// empty string is correct
@@ -261,6 +262,7 @@ func TestDefaultDeployment(t *testing.T) {
 						Annotations: consoleDeploymentTemplateAnnotations,
 					},
 						Spec: corev1.PodSpec{
+							ServiceAccountName: "console",
 							// we want to deploy on master nodes
 							NodeSelector: map[string]string{
 								// empty string is correct


### PR DESCRIPTION
Adding:
 - `Role` for GETting ConfigMaps from the `openshift-config-managed` namespace. Haven't found any existing Role on the cluster that would be suitable.
 - `ServiceAccount` for the console, since there are only default ServiceAccounts in the `openshift-console` namespace
 - `RoleBinding` - for binding the added `Role` and `ServiceAccount`

Story: https://issues.redhat.com/browse/CONSOLE-1993

/assign @benjaminapetersen 