### PR TITLE
[WIP] Console-1933 IPv6 support

### DIFF
--- a/manifests/03-rbac-role-cluster.yaml
+++ b/manifests/03-rbac-role-cluster.yaml
@@ -18,6 +18,7 @@ rules:
   - config.openshift.io
   resources:
   - infrastructures
+  - networks
   verbs:
   - get
   - list

--- a/manifests/05-config.yaml
+++ b/manifests/05-config.yaml
@@ -9,3 +9,5 @@ data:
     kind: GenericOperatorConfig
     leaderElection:
       namespace: openshift-console-operator
+    servingInfo:
+      bindNetwork: "tcp"

--- a/manifests/07-operator.yaml
+++ b/manifests/07-operator.yaml
@@ -51,6 +51,8 @@ spec:
         env:
         - name: IMAGE
           value: registry.svc.ci.openshift.org/openshift:console
+        - name: DOWNLOADS_IMAGE
+          value: registry.svc.ci.openshift.org/openshift:cli-artifacts
         - name: RELEASE_VERSION
           value: "0.0.1-snapshot"
         - name: OPERATOR_NAME

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -19,7 +19,9 @@ const (
 	OpenShiftConsoleDeploymentName      = OpenShiftConsoleName
 	OpenShiftConsoleServiceName         = OpenShiftConsoleName
 	OpenShiftConsoleRouteName           = OpenShiftConsoleName
-	OpenShiftConsoleDownloadsRouteName  = "downloads"
+	OpenShiftDownloadsName              = "downloads"
+	OpenShiftDownloadsRouteName         = OpenShiftDownloadsName
+	OpenShiftDownloadsServerName        = "downloads-server"
 	OAuthClientName                     = OpenShiftConsoleName
 	OpenShiftConfigManagedNamespace     = "openshift-config-managed"
 	OpenShiftConfigNamespace            = "openshift-config"

--- a/pkg/console/config/network.go
+++ b/pkg/console/config/network.go
@@ -1,0 +1,43 @@
+package config
+
+import (
+	"net"
+
+	configv1 "github.com/openshift/api/config/v1"
+)
+
+type IPMode string
+
+const (
+	IPv4Mode   IPMode = "v4"
+	IPv6Mode   IPMode = "v6"
+	IPv4v6Mode IPMode = "v4v6"
+)
+
+// borrowing existing logic from cluster-ingress-operator
+// - https://github.com/openshift/cluster-ingress-operator/blob/master/pkg/operator/controller/ingress/deployment.go#L412
+func NetworkSupported(networkConfig *configv1.Network) (IPv4IPv6mode IPMode, usingIPv4 bool, usingIPv6 bool) {
+	usingIPv4 = false
+	usingIPv6 = false
+	mode := IPv4Mode
+
+	for _, clusterNetworkEntry := range networkConfig.Status.ClusterNetwork {
+		addr, _, err := net.ParseCIDR(clusterNetworkEntry.CIDR)
+		if err != nil {
+			continue
+		}
+		if addr.To4() != nil {
+			usingIPv4 = true
+		} else {
+			usingIPv6 = true
+		}
+	}
+
+	if usingIPv6 {
+		mode = IPv4v6Mode
+		if !usingIPv4 {
+			mode = IPv6Mode
+		}
+	}
+	return mode, usingIPv4, usingIPv6
+}

--- a/pkg/console/controllers/clidownloads/controller.go
+++ b/pkg/console/controllers/clidownloads/controller.go
@@ -116,7 +116,7 @@ func (c *CLIDownloadsSyncController) sync() error {
 		return fmt.Errorf("console is in an unknown state: %v", updatedOperatorConfig.Spec.ManagementState)
 	}
 
-	consoleRoute, err := c.routeClient.Routes(api.TargetNamespace).Get(api.OpenShiftConsoleDownloadsRouteName, metav1.GetOptions{})
+	consoleRoute, err := c.routeClient.Routes(api.TargetNamespace).Get(api.OpenShiftDownloadsRouteName, metav1.GetOptions{})
 	if err != nil {
 		return err
 	}

--- a/pkg/console/operator/operator.go
+++ b/pkg/console/operator/operator.go
@@ -139,6 +139,8 @@ func NewConsoleOperator(
 	configNameFilter := operator.FilterByNames(api.ConfigResourceName)
 	targetNameFilter := operator.FilterByNames(api.OpenShiftConsoleName)
 
+	deploymentsFilter := operator.FilterByNames(api.OpenShiftConsoleName, api.OpenShiftDownloadsName)
+
 	return operator.New(controllerName, c,
 		// configs
 		operator.WithInformer(configV1Informers.Consoles(), configNameFilter),
@@ -147,7 +149,7 @@ func NewConsoleOperator(
 		operator.WithInformer(configV1Informers.Proxies(), configNameFilter),
 		operator.WithInformer(configV1Informers.Networks(), configNameFilter),
 		// console resources
-		operator.WithInformer(deployments, targetNameFilter),
+		operator.WithInformer(deployments, deploymentsFilter),
 		operator.WithInformer(routes, targetNameFilter),
 		operator.WithInformer(serviceInformer, targetNameFilter),
 		operator.WithInformer(oauthClients, targetNameFilter),

--- a/pkg/console/subresource/configmap/configmap.go
+++ b/pkg/console/subresource/configmap/configmap.go
@@ -10,7 +10,9 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	routev1 "github.com/openshift/api/route/v1"
+
 	"github.com/openshift/console-operator/pkg/api"
+	"github.com/openshift/console-operator/pkg/console/config"
 	"github.com/openshift/console-operator/pkg/console/subresource/consoleserver"
 	"github.com/openshift/console-operator/pkg/console/subresource/util"
 )
@@ -40,7 +42,8 @@ func DefaultConfigMap(
 	managedConfig *corev1.ConfigMap,
 	infrastructureConfig *configv1.Infrastructure,
 	rt *routev1.Route,
-	useDefaultCAFile bool) (consoleConfigmap *corev1.ConfigMap, unsupportedOverridesHaveMerged bool, err error) {
+	useDefaultCAFile bool,
+	ipVMode config.IPMode) (consoleConfigmap *corev1.ConfigMap, unsupportedOverridesHaveMerged bool, err error) {
 
 	defaultBuilder := &consoleserver.ConsoleServerCLIConfigBuilder{}
 	defaultConfig, err := defaultBuilder.Host(rt.Spec.Host).

--- a/pkg/console/subresource/configmap/configmap.go
+++ b/pkg/console/subresource/configmap/configmap.go
@@ -52,6 +52,7 @@ func DefaultConfigMap(
 		DocURL(DEFAULT_DOC_URL).
 		DefaultIngressCert(useDefaultCAFile).
 		APIServerURL(getApiUrl(infrastructureConfig)).
+		IPMode(ipVMode).
 		ConfigYAML()
 
 	extractedManagedConfig := extractYAML(managedConfig)

--- a/pkg/console/subresource/deployment/deployment.go
+++ b/pkg/console/subresource/deployment/deployment.go
@@ -82,7 +82,6 @@ func DefaultDeployment(operatorConfig *operatorv1.Console, cm *corev1.ConfigMap,
 	meta.Annotations = annotations
 	replicas := int32(ConsoleReplicas)
 	gracePeriod := int64(30)
-	tolerationSeconds := int64(120)
 	volumeConfig := defaultVolumeConfig()
 	caBundle, caBundleExists := trustedCAConfigMap.Data["ca-bundle.crt"]
 	if caBundleExists && caBundle != "" {

--- a/pkg/console/subresource/deployment/deployment.go
+++ b/pkg/console/subresource/deployment/deployment.go
@@ -127,25 +127,7 @@ func DefaultDeployment(operatorConfig *operatorv1.Console, cm *corev1.ConfigMap,
 						},
 					},
 					// toleration is a taint override. we can and should be scheduled on a master node.
-					Tolerations: []corev1.Toleration{
-						{
-							Key:      "node-role.kubernetes.io/master",
-							Operator: corev1.TolerationOpExists,
-							Effect:   corev1.TaintEffectNoSchedule,
-						},
-						{
-							Key:               "node.kubernetes.io/unreachable",
-							Operator:          corev1.TolerationOpExists,
-							Effect:            corev1.TaintEffectNoExecute,
-							TolerationSeconds: &tolerationSeconds,
-						},
-						{
-							Key:               "node.kubernetes.io/not-reachable",
-							Operator:          corev1.TolerationOpExists,
-							Effect:            corev1.TaintEffectNoExecute,
-							TolerationSeconds: &tolerationSeconds,
-						},
-					},
+					Tolerations:                   tolerations(),
 					PriorityClassName:             "system-cluster-critical",
 					RestartPolicy:                 corev1.RestartPolicyAlways,
 					SchedulerName:                 corev1.DefaultSchedulerName,

--- a/pkg/console/subresource/deployment/downloads.go
+++ b/pkg/console/subresource/deployment/downloads.go
@@ -27,7 +27,7 @@ func DownloadsDeployment(ipVMode config.IPMode) *appsv1.Deployment {
 	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      api.OpenShiftDownloadsName,
-			Namespace: api.OpenShiftConsoleName,
+			Namespace: api.OpenShiftConsoleNamespace,
 			Labels:    labels,
 		},
 		Spec: appsv1.DeploymentSpec{

--- a/pkg/console/subresource/deployment/downloads.go
+++ b/pkg/console/subresource/deployment/downloads.go
@@ -78,7 +78,7 @@ func downloadsContainer(ipVMode config.IPMode) corev1.Container {
 				corev1.ResourceMemory: resource.MustParse("50Mi"),
 			},
 		},
-		Args: downloadsArgs(ipVMode config.IPMode),
+		Args: downloadsArgs(ipVMode),
 	}
 }
 

--- a/pkg/console/subresource/deployment/downloads.go
+++ b/pkg/console/subresource/deployment/downloads.go
@@ -1,0 +1,204 @@
+package deployment
+
+import (
+	"fmt"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"github.com/openshift/console-operator/pkg/api"
+	"github.com/openshift/console-operator/pkg/console/config"
+)
+
+func DownloadsDeployment(ipVMode config.IPMode) *appsv1.Deployment {
+
+	replicas := int32(ConsoleReplicas)
+
+	labels := map[string]string{
+		"app":       "console",
+		"component": "downloads",
+	}
+
+	gracePeriod := int64(1)
+
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      api.OpenShiftDownloadsName,
+			Namespace: api.OpenShiftConsoleName,
+			Labels:    labels,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: labels,
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   api.OpenShiftDownloadsName,
+					Labels: labels,
+				},
+				Spec: corev1.PodSpec{
+					NodeSelector: nodeSelector(),
+					Tolerations:  tolerations(),
+					Containers: []corev1.Container{
+						downloadsContainer(ipVMode),
+					},
+					TerminationGracePeriodSeconds: &gracePeriod,
+				},
+			},
+		},
+	}
+	return deployment
+}
+
+func nodeSelector() map[string]string {
+	return map[string]string{
+		"kubernetes.io/os": "linux",
+	}
+}
+
+func downloadsContainer(ipVMode config.IPMode) corev1.Container {
+	return corev1.Container{
+		Name:                     api.OpenShiftDownloadsServerName,
+		TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+		Image:                    downloadsImage(),
+		ImagePullPolicy:          corev1.PullIfNotPresent,
+		Ports:                    downloadsPorts(),
+		LivenessProbe:            downloadsLiveness(),
+		ReadinessProbe:           downloadsReadiness(),
+		Command: []string{
+			"/bin/sh",
+		},
+		Resources: corev1.ResourceRequirements{
+			Requests: map[corev1.ResourceName]resource.Quantity{
+				corev1.ResourceCPU:    resource.MustParse("10m"),
+				corev1.ResourceMemory: resource.MustParse("50Mi"),
+			},
+		},
+		Args: downloadsArgs(ipVMode config.IPMode),
+	}
+}
+
+// TODO: does this already in manifests/image-references
+// do we need to do anything here?  read it from command line
+// like console deployment IMAGE=<image>?
+func downloadsImage() string {
+	return "registry.svc.ci.openshift.org/openshift:cli-artifacts"
+}
+
+func downloadsPorts() []corev1.ContainerPort {
+	return []corev1.ContainerPort{{
+		Name:          "http",
+		Protocol:      corev1.ProtocolTCP,
+		ContainerPort: 8080,
+	}}
+}
+
+func downloadsLiveness() *corev1.Probe {
+	return &corev1.Probe{
+		Handler: corev1.Handler{
+			HTTPGet: &corev1.HTTPGetAction{
+				Path:   "/",
+				Port:   intstr.FromInt(8080),
+				Scheme: corev1.URISchemeHTTP,
+			},
+		},
+	}
+}
+
+func downloadsReadiness() *corev1.Probe {
+	probe := downloadsLiveness()
+	probe.FailureThreshold = 3
+	return probe
+}
+
+func downloadsArgs(ipVMode config.IPMode) []string {
+	return []string{
+		"-c",
+		downloadsInlineScript(ipVMode),
+	}
+}
+
+func downloadsInlineScript(ipVMode config.IPMode) string {
+	// defaults to IPv4
+	addressFamily := "AF_INET"
+
+	// if we get a IPv4v6 value, we will have to panic as we don't know how to support both yet
+	if ipVMode == config.IPv4v6Mode {
+		panic(fmt.Sprintf("mode not supported: %v", ipVMode))
+	}
+
+	if ipVMode == config.IPv6Mode {
+		addressFamily = "AF_INET6"
+	}
+
+	return `|
+          cat <<EOF >>/tmp/serve.py
+          import BaseHTTPServer, os, re, signal, SimpleHTTPServer, socket, sys, tarfile, tempfile, threading, time, zipfile
+
+          signal.signal(signal.SIGTERM, lambda signum, frame: sys.exit(0))
+
+          # Launch multiple listeners as threads
+          class Thread(threading.Thread):
+              def __init__(self, i, socket):
+                  threading.Thread.__init__(self)
+                  self.i = i
+                  self.socket = socket
+                  self.daemon = True
+                  self.start()
+
+              def run(self):
+                  httpd = BaseHTTPServer.HTTPServer(addr, SimpleHTTPServer.SimpleHTTPRequestHandler, False)
+
+                  # Prevent the HTTP server from re-binding every handler.
+                  # https://stackoverflow.com/questions/46210672/
+                  httpd.socket = self.socket
+                  httpd.server_bind = self.server_close = lambda self: None
+
+                  httpd.serve_forever()
+
+          temp_dir = tempfile.mkdtemp()
+          print('serving from {}'.format(temp_dir))
+          os.chdir(temp_dir)
+          for arch in ['amd64']:
+              os.mkdir(arch)
+              for operating_system in ['linux', 'mac', 'windows']:
+                  os.mkdir(os.path.join(arch, operating_system))
+          for arch in ['arm64', 'ppc64le', 's390x']:
+              os.mkdir(arch)
+              for operating_system in ['linux']:
+                  os.mkdir(os.path.join(arch, operating_system))
+
+          for arch, operating_system, path in [
+                  ('amd64', 'linux', '/usr/share/openshift/linux_amd64/oc'),
+                  ('amd64', 'mac', '/usr/share/openshift/mac/oc'),
+                  ('amd64', 'windows', '/usr/share/openshift/windows/oc.exe'),
+                  ('arm64', 'linux', '/usr/share/openshift/linux_arm64/oc'),
+                  ('ppc64le', 'linux', '/usr/share/openshift/linux_ppc64le/oc'),
+                  ('s390x', 'linux', '/usr/share/openshift/linux_s390x/oc'),
+                  ]:
+              basename = os.path.basename(path)
+              target_path = os.path.join(arch, operating_system, basename)
+              os.symlink(path, target_path)
+              base_root, _ = os.path.splitext(basename)
+              archive_path_root = os.path.join(arch, operating_system, base_root)
+              with tarfile.open('{}.tar'.format(archive_path_root), 'w') as tar:
+                  tar.add(path, basename)
+              with zipfile.ZipFile('{}.zip'.format(archive_path_root), 'w') as zip:
+                  zip.write(path, basename)
+
+          # Create socket
+          addr = ('', 8080)
+          sock = socket.socket(socket.` + addressFamily + `, socket.SOCK_STREAM)
+          sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+          sock.bind(addr)
+          sock.listen(5)
+
+          [Thread(i, socket=sock) for i in range(100)]
+          time.sleep(9e9)
+          EOF
+          exec python2 /tmp/serve.py  # the cli image only has Python 2.7`
+}

--- a/pkg/console/subresource/deployment/downloads.go
+++ b/pkg/console/subresource/deployment/downloads.go
@@ -2,6 +2,7 @@ package deployment
 
 import (
 	"fmt"
+	"os"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -86,7 +87,8 @@ func downloadsContainer(ipVMode config.IPMode) corev1.Container {
 // do we need to do anything here?  read it from command line
 // like console deployment IMAGE=<image>?
 func downloadsImage() string {
-	return "registry.svc.ci.openshift.org/openshift:cli-artifacts"
+	// return "registry.svc.ci.openshift.org/openshift:cli-artifacts"
+	return os.Getenv("DOWNLOADS_IMAGE")
 }
 
 func downloadsPorts() []corev1.ContainerPort {
@@ -117,7 +119,6 @@ func downloadsReadiness() *corev1.Probe {
 
 func downloadsArgs(ipVMode config.IPMode) []string {
 	return []string{
-		"-c",
 		downloadsInlineScript(ipVMode),
 	}
 }
@@ -135,9 +136,11 @@ func downloadsInlineScript(ipVMode config.IPMode) string {
 		addressFamily = "AF_INET6"
 	}
 
-	return `|
+	// Unfortunately formatting here is not maintained when this is deployed
+	// Python depends on formatting.  Not sure that this will run correctly.
+	return `-c |
           cat <<EOF >>/tmp/serve.py
-          import BaseHTTPServer, os, re, signal, SimpleHTTPServer, socket, sys, tarfile, tempfile, threading, time, zipfile
+          import BaseHTTPServer, os, re, signal, SimpleHTTPServer, socket, sys, tarfile, tempfile, threading, time, zipfile	
 
           signal.signal(signal.SIGTERM, lambda signum, frame: sys.exit(0))
 

--- a/pkg/console/subresource/deployment/util.go
+++ b/pkg/console/subresource/deployment/util.go
@@ -1,0 +1,25 @@
+package deployment
+
+import corev1 "k8s.io/api/core/v1"
+
+func tolerations() []corev1.Toleration {
+	return []corev1.Toleration{
+		{
+			Key:      "node-role.kubernetes.io/master",
+			Operator: corev1.TolerationOpExists,
+			Effect:   corev1.TaintEffectNoSchedule,
+		},
+		{
+			Key:               "node.kubernetes.io/unreachable",
+			Operator:          corev1.TolerationOpExists,
+			Effect:            corev1.TaintEffectNoExecute,
+			TolerationSeconds: &tolerationSeconds,
+		},
+		{
+			Key:               "node.kubernetes.io/not-reachable",
+			Operator:          corev1.TolerationOpExists,
+			Effect:            corev1.TaintEffectNoExecute,
+			TolerationSeconds: &tolerationSeconds,
+		},
+	}
+}


### PR DESCRIPTION
Ensures that the console can support either IPv4 or IPv6 (but not yet both).

RE [doc changes needed](https://docs.google.com/document/d/1zznvkK87y7UvOJZqs2DM4oWzx94P8Lg6YUb43whil3g/edit#heading=h.wp47a79o7bw0)

/assign @russellb 
/cc @spadgett @jhadvig 

- [x] Operator config `bindNetwork: "tcp"`
   - Per https://github.com/openshift-kni/console-operator/commit/31b4d3910f2d476d3351d14f0999a75c46195914
- [x] Console config handles IPv4 or IPv6 based on `network.config.openshift.io`
   - Per https://github.com/openshift-kni/console-operator/commit/01865a640a24ee0bd719306c7a5b08802667e84d
- [ ] Downloads Deployment handles IPv4 or IPv6
   - Per https://github.com/openshift-kni/console-operator/commit/f395cb1a571fc867046750bc57a490e1d5264f24
- [ ] tests