### PR TITLE
Bug 1794546: Console-1933: IPv6 support (simpler alternative)

### DIFF
--- a/manifests/05-config.yaml
+++ b/manifests/05-config.yaml
@@ -9,3 +9,5 @@ data:
     kind: GenericOperatorConfig
     leaderElection:
       namespace: openshift-console-operator
+    servingInfo:
+      bindNetwork: "tcp"

--- a/manifests/07-downloads-deployment.yaml
+++ b/manifests/07-downloads-deployment.yaml
@@ -113,8 +113,11 @@ spec:
                   zip.write(path, basename)
 
           # Create socket
-          addr = ('', 8080)
-          sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+          # IPv6 should handle IPv4 passively so long as it is not bound to a
+          # specific address or set to IPv6_ONLY
+          # https://stackoverflow.com/questions/25817848/python-3-does-http-server-support-ipv6
+          addr = ('::', 8080)
+          sock = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
           sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
           sock.bind(addr)
           sock.listen(5)

--- a/pkg/console/subresource/configmap/configmap_test.go
+++ b/pkg/console/subresource/configmap/configmap_test.go
@@ -78,7 +78,7 @@ customization:
   branding: ` + DEFAULT_BRAND + `
   documentationBaseURL: ` + DEFAULT_DOC_URL + `
 servingInfo:
-  bindAddress: https://0.0.0.0:8443
+  bindAddress: https://[::]:8443
   certFile: /var/serving-cert/tls.crt
   keyFile: /var/serving-cert/tls.key
 providers: {}
@@ -124,7 +124,7 @@ customization:
   branding: ` + DEFAULT_BRAND + `
   documentationBaseURL: ` + DEFAULT_DOC_URL + `
 servingInfo:
-  bindAddress: https://0.0.0.0:8443
+  bindAddress: https://[::]:8443
   certFile: /var/serving-cert/tls.crt
   keyFile: /var/serving-cert/tls.key
 providers: {}
@@ -178,7 +178,7 @@ customization:
   branding: online 
   documentationBaseURL: https://docs.okd.io/4.4/
 servingInfo:
-  bindAddress: https://0.0.0.0:8443
+  bindAddress: https://[::]:8443
   certFile: /var/serving-cert/tls.crt
   keyFile: /var/serving-cert/tls.key
 providers: {}
@@ -241,7 +241,7 @@ customization:
   branding: ` + string(operatorv1.BrandDedicated) + `
   documentationBaseURL: ` + mockOperatorDocURL + `
 servingInfo:
-  bindAddress: https://0.0.0.0:8443
+  bindAddress: https://[::]:8443
   certFile: /var/serving-cert/tls.crt
   keyFile: /var/serving-cert/tls.key
 providers: {}
@@ -311,7 +311,7 @@ customization:
   customLogoFile: /var/logo/logo.svg
   customProductName: custom-product-name
 servingInfo:
-  bindAddress: https://0.0.0.0:8443
+  bindAddress: https://[::]:8443
   certFile: /var/serving-cert/tls.crt
   keyFile: /var/serving-cert/tls.key
 providers: {}
@@ -379,7 +379,7 @@ customization:
   branding: ` + string(operatorv1.BrandDedicated) + `
   documentationBaseURL: ` + mockOperatorDocURL + `
 servingInfo:
-  bindAddress: https://0.0.0.0:8443
+  bindAddress: https://[::]:8443
   certFile: /var/serving-cert/tls.crt
   keyFile: /var/serving-cert/tls.key
 providers: 

--- a/pkg/console/subresource/consoleserver/config_builder.go
+++ b/pkg/console/subresource/consoleserver/config_builder.go
@@ -109,7 +109,7 @@ func (b *ConsoleServerCLIConfigBuilder) ConfigYAML() (consoleConfigYAML []byte, 
 
 func (b *ConsoleServerCLIConfigBuilder) servingInfo() ServingInfo {
 	return ServingInfo{
-		BindAddress: "https://0.0.0.0:8443",
+		BindAddress: "https://[::]:8443",
 		CertFile:    certFilePath,
 		KeyFile:     keyFilePath,
 	}

--- a/pkg/console/subresource/consoleserver/config_builder_test.go
+++ b/pkg/console/subresource/consoleserver/config_builder_test.go
@@ -28,7 +28,7 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 				Kind:       "ConsoleConfig",
 				APIVersion: "console.openshift.io/v1",
 				ServingInfo: ServingInfo{
-					BindAddress: "https://0.0.0.0:8443",
+					BindAddress: "https://[::]:8443",
 					CertFile:    certFilePath,
 					KeyFile:     keyFilePath,
 				},
@@ -58,7 +58,7 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 				Kind:       "ConsoleConfig",
 				APIVersion: "console.openshift.io/v1",
 				ServingInfo: ServingInfo{
-					BindAddress: "https://0.0.0.0:8443",
+					BindAddress: "https://[::]:8443",
 					CertFile:    certFilePath,
 					KeyFile:     keyFilePath,
 				},
@@ -86,7 +86,7 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 				Kind:       "ConsoleConfig",
 				APIVersion: "console.openshift.io/v1",
 				ServingInfo: ServingInfo{
-					BindAddress: "https://0.0.0.0:8443",
+					BindAddress: "https://[::]:8443",
 					CertFile:    certFilePath,
 					KeyFile:     keyFilePath,
 				},
@@ -119,7 +119,7 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 				Kind:       "ConsoleConfig",
 				APIVersion: "console.openshift.io/v1",
 				ServingInfo: ServingInfo{
-					BindAddress: "https://0.0.0.0:8443",
+					BindAddress: "https://[::]:8443",
 					CertFile:    certFilePath,
 					KeyFile:     keyFilePath,
 				},
@@ -173,7 +173,7 @@ func TestConsoleServerCLIConfigBuilderYAML(t *testing.T) {
 			output: `apiVersion: console.openshift.io/v1
 kind: ConsoleConfig
 servingInfo:
-  bindAddress: https://0.0.0.0:8443
+  bindAddress: https://[::]:8443
   certFile: /var/serving-cert/tls.crt
   keyFile: /var/serving-cert/tls.key
 clusterInfo: {}
@@ -199,7 +199,7 @@ providers: {}
 			output: `apiVersion: console.openshift.io/v1
 kind: ConsoleConfig
 servingInfo:
-  bindAddress: https://0.0.0.0:8443
+  bindAddress: https://[::]:8443
   certFile: /var/serving-cert/tls.crt
   keyFile: /var/serving-cert/tls.key
 clusterInfo:
@@ -223,7 +223,7 @@ providers: {}
 			output: `apiVersion: console.openshift.io/v1
 kind: ConsoleConfig
 servingInfo:
-  bindAddress: https://0.0.0.0:8443
+  bindAddress: https://[::]:8443
   certFile: /var/serving-cert/tls.crt
   keyFile: /var/serving-cert/tls.key
 clusterInfo: {}
@@ -252,7 +252,7 @@ providers:
 			output: `apiVersion: console.openshift.io/v1
 kind: ConsoleConfig
 servingInfo:
-  bindAddress: https://0.0.0.0:8443
+  bindAddress: https://[::]:8443
   certFile: /var/serving-cert/tls.crt
   keyFile: /var/serving-cert/tls.key
 clusterInfo:

--- a/pkg/console/subresource/consoleserver/config_merger_test.go
+++ b/pkg/console/subresource/consoleserver/config_merger_test.go
@@ -55,7 +55,7 @@ kind: ConsoleConfig
 providers:
   statuspageID: status-12345
 servingInfo:
-  bindAddress: https://0.0.0.0:8443
+  bindAddress: https://[::]:8443
   certFile: /var/serving-cert/tls.crt
   keyFile: /var/serving-cert/tls.key
 `,


### PR DESCRIPTION
Simpler/preferred change over #374 

RE [doc changes needed](https://docs.google.com/document/d/1zznvkK87y7UvOJZqs2DM4oWzx94P8Lg6YUb43whil3g/edit#heading=h.wp47a79o7bw0)

/assign @russellb 
/cc @spadgett @jhadvig 

- [x] Operator config `bindNetwork: "tcp"`
   - Per https://github.com/openshift-kni/console-operator/commit/31b4d3910f2d476d3351d14f0999a75c46195914
- [x] Console config handles IPv4 or IPv6 based on `network.config.openshift.io`
   - Per https://github.com/openshift-kni/console-operator/commit/01865a640a24ee0bd719306c7a5b08802667e84d
- [x] Downloads Deployment handles IPv4 or IPv6
   - Per https://github.com/openshift-kni/console-operator/commit/f395cb1a571fc867046750bc57a490e1d5264f24
- [x] tests updated
   - all unit tests updated to verify the expected output
- [ ] IPv6 test?
   - All current tests should continue to pass on IPv4
   - Unclear how to test an IPv6 cluster at this time


