### PR TITLE
Bug 1794548: IPv6 support to console operator & console [openshift-4.3.z]

### DIFF
--- a/manifests/05-config.yaml
+++ b/manifests/05-config.yaml
@@ -9,3 +9,5 @@ data:
     kind: GenericOperatorConfig
     leaderElection:
       namespace: openshift-console-operator
+    servingInfo:
+      bindNetwork: "tcp"

--- a/manifests/07-downloads-deployment.yaml
+++ b/manifests/07-downloads-deployment.yaml
@@ -113,8 +113,11 @@ spec:
                   zip.write(path, basename)
 
           # Create socket
-          addr = ('', 8080)
-          sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+          # IPv6 should handle IPv4 passively so long as it is not bound to a
+          # specific address or set to IPv6_ONLY
+          # https://stackoverflow.com/questions/25817848/python-3-does-http-server-support-ipv6
+          addr = ('::', 8080)
+          sock = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
           sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
           sock.bind(addr)
           sock.listen(5)

--- a/pkg/console/subresource/configmap/configmap_test.go
+++ b/pkg/console/subresource/configmap/configmap_test.go
@@ -76,7 +76,7 @@ customization:
   branding: ` + DEFAULT_BRAND + `
   documentationBaseURL: ` + DEFAULT_DOC_URL + `
 servingInfo:
-  bindAddress: https://0.0.0.0:8443
+  bindAddress: https://[::]:8443
   certFile: /var/serving-cert/tls.crt
   keyFile: /var/serving-cert/tls.key
 providers: {}
@@ -129,7 +129,7 @@ customization:
   branding: online 
   documentationBaseURL: https://docs.okd.io/4.3/
 servingInfo:
-  bindAddress: https://0.0.0.0:8443
+  bindAddress: https://[::]:8443
   certFile: /var/serving-cert/tls.crt
   keyFile: /var/serving-cert/tls.key
 providers: {}
@@ -191,7 +191,7 @@ customization:
   branding: ` + string(operatorv1.BrandDedicated) + `
   documentationBaseURL: ` + mockOperatorDocURL + `
 servingInfo:
-  bindAddress: https://0.0.0.0:8443
+  bindAddress: https://[::]:8443
   certFile: /var/serving-cert/tls.crt
   keyFile: /var/serving-cert/tls.key
 providers: {}
@@ -260,7 +260,7 @@ customization:
   customLogoFile: /var/logo/logo.svg
   customProductName: custom-product-name
 servingInfo:
-  bindAddress: https://0.0.0.0:8443
+  bindAddress: https://[::]:8443
   certFile: /var/serving-cert/tls.crt
   keyFile: /var/serving-cert/tls.key
 providers: {}
@@ -327,7 +327,7 @@ customization:
   branding: ` + string(operatorv1.BrandDedicated) + `
   documentationBaseURL: ` + mockOperatorDocURL + `
 servingInfo:
-  bindAddress: https://0.0.0.0:8443
+  bindAddress: https://[::]:8443
   certFile: /var/serving-cert/tls.crt
   keyFile: /var/serving-cert/tls.key
 providers: 

--- a/pkg/console/subresource/consoleserver/config_builder.go
+++ b/pkg/console/subresource/consoleserver/config_builder.go
@@ -98,7 +98,7 @@ func (b *ConsoleServerCLIConfigBuilder) ConfigYAML() (consoleConfigYAML []byte, 
 
 func (b *ConsoleServerCLIConfigBuilder) servingInfo() ServingInfo {
 	return ServingInfo{
-		BindAddress: "https://0.0.0.0:8443",
+		BindAddress: "https://[::]:8443",
 		CertFile:    certFilePath,
 		KeyFile:     keyFilePath,
 	}

--- a/pkg/console/subresource/consoleserver/config_builder_test.go
+++ b/pkg/console/subresource/consoleserver/config_builder_test.go
@@ -28,7 +28,7 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 				Kind:       "ConsoleConfig",
 				APIVersion: "console.openshift.io/v1",
 				ServingInfo: ServingInfo{
-					BindAddress: "https://0.0.0.0:8443",
+					BindAddress: "https://[::]:8443",
 					CertFile:    certFilePath,
 					KeyFile:     keyFilePath,
 				},
@@ -57,7 +57,7 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 				Kind:       "ConsoleConfig",
 				APIVersion: "console.openshift.io/v1",
 				ServingInfo: ServingInfo{
-					BindAddress: "https://0.0.0.0:8443",
+					BindAddress: "https://[::]:8443",
 					CertFile:    certFilePath,
 					KeyFile:     keyFilePath,
 				},
@@ -85,7 +85,7 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 				Kind:       "ConsoleConfig",
 				APIVersion: "console.openshift.io/v1",
 				ServingInfo: ServingInfo{
-					BindAddress: "https://0.0.0.0:8443",
+					BindAddress: "https://[::]:8443",
 					CertFile:    certFilePath,
 					KeyFile:     keyFilePath,
 				},
@@ -118,7 +118,7 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 				Kind:       "ConsoleConfig",
 				APIVersion: "console.openshift.io/v1",
 				ServingInfo: ServingInfo{
-					BindAddress: "https://0.0.0.0:8443",
+					BindAddress: "https://[::]:8443",
 					CertFile:    certFilePath,
 					KeyFile:     keyFilePath,
 				},
@@ -172,7 +172,7 @@ func TestConsoleServerCLIConfigBuilderYAML(t *testing.T) {
 			output: `apiVersion: console.openshift.io/v1
 kind: ConsoleConfig
 servingInfo:
-  bindAddress: https://0.0.0.0:8443
+  bindAddress: https://[::]:8443
   certFile: /var/serving-cert/tls.crt
   keyFile: /var/serving-cert/tls.key
 clusterInfo: {}
@@ -197,7 +197,7 @@ providers: {}
 			output: `apiVersion: console.openshift.io/v1
 kind: ConsoleConfig
 servingInfo:
-  bindAddress: https://0.0.0.0:8443
+  bindAddress: https://[::]:8443
   certFile: /var/serving-cert/tls.crt
   keyFile: /var/serving-cert/tls.key
 clusterInfo:
@@ -221,7 +221,7 @@ providers: {}
 			output: `apiVersion: console.openshift.io/v1
 kind: ConsoleConfig
 servingInfo:
-  bindAddress: https://0.0.0.0:8443
+  bindAddress: https://[::]:8443
   certFile: /var/serving-cert/tls.crt
   keyFile: /var/serving-cert/tls.key
 clusterInfo: {}
@@ -249,7 +249,7 @@ providers:
 			output: `apiVersion: console.openshift.io/v1
 kind: ConsoleConfig
 servingInfo:
-  bindAddress: https://0.0.0.0:8443
+  bindAddress: https://[::]:8443
   certFile: /var/serving-cert/tls.crt
   keyFile: /var/serving-cert/tls.key
 clusterInfo:

--- a/pkg/console/subresource/consoleserver/config_merger_test.go
+++ b/pkg/console/subresource/consoleserver/config_merger_test.go
@@ -55,7 +55,7 @@ kind: ConsoleConfig
 providers:
   statuspageID: status-12345
 servingInfo:
-  bindAddress: https://0.0.0.0:8443
+  bindAddress: https://[::]:8443
   certFile: /var/serving-cert/tls.crt
   keyFile: /var/serving-cert/tls.key
 `,


### PR DESCRIPTION
Backport of #375 

Manual cherry pick to eliminate the extra unit test for the `default-ingress-cert` as that does not exist in 4.3.

https://bugzilla.redhat.com/show_bug.cgi?id=1794548

/assign @russellb
/cc @spadgett @jhadvig

