### PR TITLE
Bug 1777486: Add sharing-config configmap from openshift-monitoring to the console-config

### DIFF
--- a/alt-07-operator.yaml
+++ b/alt-07-operator.yaml
@@ -1,0 +1,83 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: console-operator
+  namespace: openshift-console-operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: console-operator
+  template:
+    metadata:
+      labels:
+        name: console-operator
+    spec:
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: "NoSchedule"
+      - key: "node.kubernetes.io/unreachable"
+        operator: "Exists"
+        effect: "NoExecute"
+        tolerationSeconds: 120
+      - key: "node.kubernetes.io/not-ready"
+        operator: "Exists"
+        effect: "NoExecute"
+        tolerationSeconds: 120
+      priorityClassName: system-cluster-critical
+      serviceAccountName: console-operator
+      containers:
+      - name: console-operator
+        terminationMessagePolicy: FallbackToLogsOnError
+        image: docker.io/jhadvig/console-operator:latest
+        ports:
+        - containerPort: 60000
+          name: metrics
+        command:
+        - console
+        - operator
+        args:
+        - "-v=2"
+        - "--config=/var/run/configmaps/config/controller-config.yaml"
+        imagePullPolicy: Always
+        volumeMounts:
+        - mountPath: /var/run/configmaps/config
+          name: config
+        - mountPath: /var/run/secrets/serving-cert
+          name: serving-cert
+        env:
+        - name: IMAGE
+          value: registry.svc.ci.openshift.org/ocp/4.4-2020-02-11-035631@sha256:668cd22560b41876d5e633418f3b378e5c14eb26837f6aa62d4edf17a1db22e5
+        - name: RELEASE_VERSION
+          value: "0.0.1-snapshot"
+        - name: OPERATOR_NAME
+          value: "console-operator"
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        resources:
+          requests:
+            memory: "100Mi"
+            cpu: "10m"
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8443
+            scheme: HTTPS
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8443
+            scheme: HTTPS
+      volumes:
+      - name: config
+        configMap:
+          name: console-operator-config
+      - name: serving-cert
+        secret:
+          secretName: serving-cert
+          optional: true

--- a/manifests/03-rbac-role-ns-openshift-monitoring.yaml
+++ b/manifests/03-rbac-role-ns-openshift-monitoring.yaml
@@ -1,0 +1,14 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: monitoring-configmap-reader
+  namespace: openshift-monitoring
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  resourceNames:
+  - sharing-config
+  verbs:
+  - get

--- a/manifests/04-rbac-rolebinding.yaml
+++ b/manifests/04-rbac-rolebinding.yaml
@@ -94,3 +94,17 @@ subjects:
   - kind: ServiceAccount
     name: console
     namespace: openshift-console
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: console-operator
+  namespace: openshift-monitoring
+roleRef:
+  kind: Role
+  name: monitoring-configmap-reader
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: console-operator
+    namespace: openshift-console-operator

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -23,6 +23,9 @@ const (
 	OAuthClientName                     = OpenShiftConsoleName
 	OpenShiftConfigManagedNamespace     = "openshift-config-managed"
 	OpenShiftConfigNamespace            = "openshift-config"
+	OpenShiftMonitoringNamespace        = "openshift-monitoring"
+	OpenShiftLoggingNamespace           = "openshift-logging"
+	SharingConfigMapName                = "sharing-config"
 	OpenShiftCustomLogoConfigMapName    = "custom-logo"
 	TrustedCAConfigMapName              = "trusted-ca-bundle"
 	TrustedCABundleKey                  = "ca-bundle.crt"

--- a/pkg/console/operator/sync_v400.go
+++ b/pkg/console/operator/sync_v400.go
@@ -289,7 +289,7 @@ func (co *consoleOperator) SyncConfigMap(
 
 	managedConfig, mcErr := co.configMapClient.ConfigMaps(api.OpenShiftConfigManagedNamespace).Get(api.OpenShiftConsoleConfigMapName, metav1.GetOptions{})
 	if mcErr != nil && !apierrors.IsNotFound(mcErr) {
-		return nil, false, "FailedManagedConfig", mcErr
+		return nil, false, "FailedGetManagedConfig", mcErr
 	}
 
 	useDefaultCAFile := true
@@ -303,7 +303,17 @@ func (co *consoleOperator) SyncConfigMap(
 		useDefaultCAFile = false
 	}
 
-	defaultConfigmap, _, err := configmapsub.DefaultConfigMap(operatorConfig, consoleConfig, managedConfig, infrastructureConfig, consoleRoute, useDefaultCAFile)
+	monitoringSharingConfig, mscErr := co.configMapClient.ConfigMaps(api.OpenShiftMonitoringNamespace).Get(api.SharingConfigMapName, metav1.GetOptions{})
+	if mscErr != nil && !apierrors.IsNotFound(mscErr) {
+		return nil, false, "FailedGetMonitoringSharingConfig", mscErr
+	}
+
+	loggingSharingConfig, lscErr := co.configMapClient.ConfigMaps(api.OpenShiftLoggingNamespace).Get(api.SharingConfigMapName, metav1.GetOptions{})
+	if lscErr != nil && !apierrors.IsNotFound(lscErr) {
+		return nil, false, "FailedGetLoggingSharingConfig", lscErr
+	}
+
+	defaultConfigmap, _, err := configmapsub.DefaultConfigMap(operatorConfig, consoleConfig, managedConfig, monitoringSharingConfig, loggingSharingConfig, infrastructureConfig, consoleRoute, useDefaultCAFile)
 	if err != nil {
 		return nil, false, "FailedConsoleConfigBuilder", err
 	}

--- a/pkg/console/subresource/configmap/configmap.go
+++ b/pkg/console/subresource/configmap/configmap.go
@@ -38,6 +38,8 @@ func DefaultConfigMap(
 	operatorConfig *operatorv1.Console,
 	consoleConfig *configv1.Console,
 	managedConfig *corev1.ConfigMap,
+	monitoringSharingConfig *corev1.ConfigMap,
+	loggingSharingConfig *corev1.ConfigMap,
 	infrastructureConfig *configv1.Infrastructure,
 	rt *routev1.Route,
 	useDefaultCAFile bool) (consoleConfigmap *corev1.ConfigMap, unsupportedOverridesHaveMerged bool, err error) {
@@ -49,6 +51,8 @@ func DefaultConfigMap(
 		DocURL(DEFAULT_DOC_URL).
 		DefaultIngressCert(useDefaultCAFile).
 		APIServerURL(getApiUrl(infrastructureConfig)).
+		MonitoringURLs(monitoringSharingConfig).
+		LoggingURLs(loggingSharingConfig).
 		ConfigYAML()
 
 	extractedManagedConfig := extractYAML(managedConfig)
@@ -59,6 +63,8 @@ func DefaultConfigMap(
 		DocURL(operatorConfig.Spec.Customization.DocumentationBaseURL).
 		DefaultIngressCert(useDefaultCAFile).
 		APIServerURL(getApiUrl(infrastructureConfig)).
+		MonitoringURLs(monitoringSharingConfig).
+		LoggingURLs(loggingSharingConfig).
 		CustomLogoFile(operatorConfig.Spec.Customization.CustomLogoFile.Key).
 		CustomProductName(operatorConfig.Spec.Customization.CustomProductName).
 		StatusPageID(statusPageId(operatorConfig)).

--- a/pkg/console/subresource/configmap/configmap_test.go
+++ b/pkg/console/subresource/configmap/configmap_test.go
@@ -28,12 +28,14 @@ const (
 // To manually run these tests: go test -v ./pkg/console/subresource/configmap/...
 func TestDefaultConfigMap(t *testing.T) {
 	type args struct {
-		operatorConfig       *operatorv1.Console
-		consoleConfig        *configv1.Console
-		managedConfig        *corev1.ConfigMap
-		infrastructureConfig *configv1.Infrastructure
-		rt                   *routev1.Route
-		useDefaultCAFile     bool
+		operatorConfig          *operatorv1.Console
+		consoleConfig           *configv1.Console
+		managedConfig           *corev1.ConfigMap
+		monitoringSharingConfig *corev1.ConfigMap
+		loggingSharingConfig    *corev1.ConfigMap
+		infrastructureConfig    *configv1.Infrastructure
+		rt                      *routev1.Route
+		useDefaultCAFile        bool
 	}
 	tests := []struct {
 		name string
@@ -43,9 +45,11 @@ func TestDefaultConfigMap(t *testing.T) {
 		{
 			name: "Test default configmap, no customization",
 			args: args{
-				operatorConfig: &operatorv1.Console{},
-				consoleConfig:  &configv1.Console{},
-				managedConfig:  &corev1.ConfigMap{},
+				operatorConfig:          &operatorv1.Console{},
+				consoleConfig:           &configv1.Console{},
+				managedConfig:           &corev1.ConfigMap{},
+				monitoringSharingConfig: &corev1.ConfigMap{},
+				loggingSharingConfig:    &corev1.ConfigMap{},
 				infrastructureConfig: &configv1.Infrastructure{
 					Status: configv1.InfrastructureStatus{
 						APIServerURL: mockAPIServer,
@@ -89,9 +93,11 @@ providers: {}
 		{
 			name: "Test configmap with default-ingress-cert",
 			args: args{
-				operatorConfig: &operatorv1.Console{},
-				consoleConfig:  &configv1.Console{},
-				managedConfig:  &corev1.ConfigMap{},
+				operatorConfig:          &operatorv1.Console{},
+				consoleConfig:           &configv1.Console{},
+				managedConfig:           &corev1.ConfigMap{},
+				monitoringSharingConfig: &corev1.ConfigMap{},
+				loggingSharingConfig:    &corev1.ConfigMap{},
 				infrastructureConfig: &configv1.Infrastructure{
 					Status: configv1.InfrastructureStatus{
 						APIServerURL: mockAPIServer,
@@ -146,6 +152,8 @@ customization:
 `,
 					},
 				},
+				monitoringSharingConfig: &corev1.ConfigMap{},
+				loggingSharingConfig:    &corev1.ConfigMap{},
 				infrastructureConfig: &configv1.Infrastructure{
 					Status: configv1.InfrastructureStatus{
 						APIServerURL: mockAPIServer,
@@ -209,6 +217,8 @@ customization:
 `,
 					},
 				},
+				monitoringSharingConfig: &corev1.ConfigMap{},
+				loggingSharingConfig:    &corev1.ConfigMap{},
 				infrastructureConfig: &configv1.Infrastructure{
 					Status: configv1.InfrastructureStatus{
 						APIServerURL: mockAPIServer,
@@ -277,6 +287,8 @@ customization:
 `,
 					},
 				},
+				monitoringSharingConfig: &corev1.ConfigMap{},
+				loggingSharingConfig:    &corev1.ConfigMap{},
 				infrastructureConfig: &configv1.Infrastructure{
 					Status: configv1.InfrastructureStatus{
 						APIServerURL: mockAPIServer,
@@ -347,6 +359,8 @@ customization:
 `,
 					},
 				},
+				monitoringSharingConfig: &corev1.ConfigMap{},
+				loggingSharingConfig:    &corev1.ConfigMap{},
 				infrastructureConfig: &configv1.Infrastructure{
 					Status: configv1.InfrastructureStatus{
 						APIServerURL: mockAPIServer,
@@ -388,10 +402,82 @@ providers:
 				},
 			},
 		},
+		{
+			name: "Test operator config with monitoring and logging URLs",
+			args: args{
+				operatorConfig: &operatorv1.Console{},
+				consoleConfig:  &configv1.Console{},
+				managedConfig:  &corev1.ConfigMap{},
+				monitoringSharingConfig: &corev1.ConfigMap{
+					Data: map[string]string{
+						"alertmanagerURL": "https://alertmanager.url.com",
+						"grafanaURL":      "https://grafana.url.com",
+						"prometheusURL":   "https://prometheus.url.com",
+					},
+				},
+				loggingSharingConfig: &corev1.ConfigMap{
+					Data: map[string]string{
+						"kibanaAppURL": "https://kibanaApp.url.com",
+					},
+				},
+				infrastructureConfig: &configv1.Infrastructure{
+					Status: configv1.InfrastructureStatus{
+						APIServerURL: mockAPIServer,
+					},
+				},
+				rt: &routev1.Route{
+					Spec: routev1.RouteSpec{
+						Host: host,
+					},
+				},
+				useDefaultCAFile: true,
+			},
+			want: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        api.OpenShiftConsoleConfigMapName,
+					Namespace:   api.OpenShiftConsoleNamespace,
+					Labels:      map[string]string{"app": api.OpenShiftConsoleName},
+					Annotations: map[string]string{},
+				},
+				Data: map[string]string{configKey: `kind: ConsoleConfig
+apiVersion: console.openshift.io/v1
+auth:
+  clientID: console
+  clientSecretFile: /var/oauth-config/clientSecret
+  oauthEndpointCAFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+clusterInfo:
+  consoleBaseAddress: https://` + host + `
+  masterPublicURL: ` + mockAPIServer + `
+  monitoringURLs:
+    alertmanagerURL: https://alertmanager.url.com
+    grafanaURL: https://grafana.url.com
+    prometheusURL: https://prometheus.url.com
+  loggingURLs:
+    kibanaAppURL: https://kibanaApp.url.com
+customization:
+  branding: ` + DEFAULT_BRAND + `
+  documentationBaseURL: ` + DEFAULT_DOC_URL + `
+servingInfo:
+  bindAddress: https://[::]:8443
+  certFile: /var/serving-cert/tls.crt
+  keyFile: /var/serving-cert/tls.key
+providers: {}
+`,
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cm, _, _ := DefaultConfigMap(tt.args.operatorConfig, tt.args.consoleConfig, tt.args.managedConfig, tt.args.infrastructureConfig, tt.args.rt, tt.args.useDefaultCAFile)
+			cm, _, _ := DefaultConfigMap(
+				tt.args.operatorConfig,
+				tt.args.consoleConfig,
+				tt.args.managedConfig,
+				tt.args.monitoringSharingConfig,
+				tt.args.loggingSharingConfig,
+				tt.args.infrastructureConfig,
+				tt.args.rt, tt.args.useDefaultCAFile,
+			)
 
 			// marshall the exampleYaml to map[string]interface{} so we can use it in diff below
 			var exampleConfig map[string]interface{}

--- a/pkg/console/subresource/consoleserver/config_builder.go
+++ b/pkg/console/subresource/consoleserver/config_builder.go
@@ -1,6 +1,8 @@
 package consoleserver
 
 import (
+	corev1 "k8s.io/api/core/v1"
+
 	operatorv1 "github.com/openshift/api/operator/v1"
 	"github.com/openshift/console-operator/pkg/api"
 	"github.com/openshift/console-operator/pkg/console/subresource/util"
@@ -38,6 +40,8 @@ type ConsoleServerCLIConfigBuilder struct {
 	customProductName string
 	customLogoFile    string
 	CAFile            string
+	monitoringURLs    map[string]string
+	loggingURLs       map[string]string
 }
 
 func (b *ConsoleServerCLIConfigBuilder) Host(host string) *ConsoleServerCLIConfigBuilder {
@@ -84,6 +88,18 @@ func (b *ConsoleServerCLIConfigBuilder) DefaultIngressCert(useDefaultDefaultIngr
 	b.CAFile = defaultIngressCertFilePath
 	return b
 }
+func (b *ConsoleServerCLIConfigBuilder) MonitoringURLs(monitoringConfig *corev1.ConfigMap) *ConsoleServerCLIConfigBuilder {
+	if monitoringConfig != nil {
+		b.monitoringURLs = monitoringConfig.Data
+	}
+	return b
+}
+func (b *ConsoleServerCLIConfigBuilder) LoggingURLs(loggingConfig *corev1.ConfigMap) *ConsoleServerCLIConfigBuilder {
+	if loggingConfig != nil {
+		b.loggingURLs = loggingConfig.Data
+	}
+	return b
+}
 
 func (b *ConsoleServerCLIConfigBuilder) Config() Config {
 	return Config{
@@ -125,6 +141,12 @@ func (b *ConsoleServerCLIConfigBuilder) clusterInfo() ClusterInfo {
 	}
 	if len(b.host) > 0 {
 		conf.ConsoleBaseAddress = util.HTTPS(b.host)
+	}
+	if len(b.monitoringURLs) > 0 {
+		conf.MonitoringURLs = b.monitoringURLs
+	}
+	if len(b.loggingURLs) > 0 {
+		conf.LoggingURLs = b.loggingURLs
 	}
 	return conf
 }

--- a/pkg/console/subresource/consoleserver/config_builder_test.go
+++ b/pkg/console/subresource/consoleserver/config_builder_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	v1 "github.com/openshift/api/operator/v1"
+	corev1 "k8s.io/api/core/v1"
 
 	"github.com/openshift/console-operator/pkg/api"
 
@@ -51,6 +52,18 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 					APIServerURL("https://foobar.com/api").
 					Host("https://foobar.com/host").
 					LogoutURL("https://foobar.com/logout").
+					MonitoringURLs(&corev1.ConfigMap{
+						Data: map[string]string{
+							"alertmanagerURL": "https://alertmanager.url.com",
+							"grafanaURL":      "https://grafana.url.com",
+							"prometheusURL":   "https://prometheus.url.com",
+						},
+					}).
+					LoggingURLs(&corev1.ConfigMap{
+						Data: map[string]string{
+							"kibanaAppURL": "https://kibanaApp.url.com",
+						},
+					}).
 					DefaultIngressCert(false).
 					Config()
 			},
@@ -66,6 +79,14 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 					ConsoleBasePath:    "",
 					ConsoleBaseAddress: "https://foobar.com/host",
 					MasterPublicURL:    "https://foobar.com/api",
+					MonitoringURLs: map[string]string{
+						"alertmanagerURL": "https://alertmanager.url.com",
+						"grafanaURL":      "https://grafana.url.com",
+						"prometheusURL":   "https://prometheus.url.com",
+					},
+					LoggingURLs: map[string]string{
+						"kibanaAppURL": "https://kibanaApp.url.com",
+					},
 				},
 				Auth: Auth{
 					ClientID:            api.OpenShiftConsoleName,
@@ -193,6 +214,18 @@ providers: {}
 					APIServerURL("https://foobar.com/api").
 					Host("https://foobar.com/host").
 					LogoutURL("https://foobar.com/logout").
+					MonitoringURLs(&corev1.ConfigMap{
+						Data: map[string]string{
+							"alertmanagerURL": "https://alertmanager.url.com",
+							"grafanaURL":      "https://grafana.url.com",
+							"prometheusURL":   "https://prometheus.url.com",
+						},
+					}).
+					LoggingURLs(&corev1.ConfigMap{
+						Data: map[string]string{
+							"kibanaAppURL": "https://kibanaApp.url.com",
+						},
+					}).
 					DefaultIngressCert(false).
 					ConfigYAML()
 			},
@@ -205,6 +238,12 @@ servingInfo:
 clusterInfo:
   consoleBaseAddress: https://foobar.com/host
   masterPublicURL: https://foobar.com/api
+  monitoringURLs:
+    alertmanagerURL: https://alertmanager.url.com
+    grafanaURL: https://grafana.url.com
+    prometheusURL: https://prometheus.url.com
+  loggingURLs:
+    kibanaAppURL: https://kibanaApp.url.com
 auth:
   clientID: console
   clientSecretFile: /var/oauth-config/clientSecret
@@ -246,6 +285,18 @@ providers:
 					DocURL("https://foobar.com/docs").
 					APIServerURL("https://foobar.com/api").
 					StatusPageID("status-12345").
+					MonitoringURLs(&corev1.ConfigMap{
+						Data: map[string]string{
+							"alertmanagerURL": "https://alertmanager.url.com",
+							"grafanaURL":      "https://grafana.url.com",
+							"prometheusURL":   "https://prometheus.url.com",
+						},
+					}).
+					LoggingURLs(&corev1.ConfigMap{
+						Data: map[string]string{
+							"kibanaAppURL": "https://kibanaApp.url.com",
+						},
+					}).
 					DefaultIngressCert(true)
 				return b.ConfigYAML()
 			},
@@ -257,6 +308,12 @@ servingInfo:
   keyFile: /var/serving-cert/tls.key
 clusterInfo:
   masterPublicURL: https://foobar.com/api
+  monitoringURLs:
+    alertmanagerURL: https://alertmanager.url.com
+    grafanaURL: https://grafana.url.com
+    prometheusURL: https://prometheus.url.com
+  loggingURLs:
+    kibanaAppURL: https://kibanaApp.url.com
 auth:
   clientID: console
   clientSecretFile: /var/oauth-config/clientSecret

--- a/pkg/console/subresource/consoleserver/types.go
+++ b/pkg/console/subresource/consoleserver/types.go
@@ -39,9 +39,11 @@ type ServingInfo struct {
 
 // ClusterInfo holds information the about the cluster such as master public URL and console public URL.
 type ClusterInfo struct {
-	ConsoleBaseAddress string `yaml:"consoleBaseAddress,omitempty"`
-	ConsoleBasePath    string `yaml:"consoleBasePath,omitempty"`
-	MasterPublicURL    string `yaml:"masterPublicURL,omitempty"`
+	ConsoleBaseAddress string            `yaml:"consoleBaseAddress,omitempty"`
+	ConsoleBasePath    string            `yaml:"consoleBasePath,omitempty"`
+	MasterPublicURL    string            `yaml:"masterPublicURL,omitempty"`
+	MonitoringURLs     map[string]string `yaml:"monitoringURLs,omitempty"`
+	LoggingURLs        map[string]string `yaml:"loggingURLs,omitempty"`
 }
 
 // Auth holds configuration for authenticating with OpenShift. The auth method is assumed to be "openshift".


### PR DESCRIPTION
Monitoring and logging URLs will be available at `console-config` in `openshift-console` namespace so that they available.

<img width="1135" alt="Screenshot 2020-02-12 at 17 39 40" src="https://user-images.githubusercontent.com/1668218/74357003-872a2580-4dbf-11ea-9911-7e6d90f0d34f.png">

/assign @benjaminapetersen 