### PR TITLE
Bug 1777486: Add monitoring-shared-config and logging-shared-config configmaps from openshift-config-managed to the console-config

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -23,6 +23,8 @@ const (
 	OAuthClientName                     = OpenShiftConsoleName
 	OpenShiftConfigManagedNamespace     = "openshift-config-managed"
 	OpenShiftConfigNamespace            = "openshift-config"
+	OpenShiftMonitoringConfig           = "monitoring-shared-config"
+	OpenShiftLoggingConfig              = "logging-shared-config"
 	OpenShiftCustomLogoConfigMapName    = "custom-logo"
 	TrustedCAConfigMapName              = "trusted-ca-bundle"
 	TrustedCABundleKey                  = "ca-bundle.crt"

--- a/pkg/console/operator/sync_v400.go
+++ b/pkg/console/operator/sync_v400.go
@@ -289,7 +289,7 @@ func (co *consoleOperator) SyncConfigMap(
 
 	managedConfig, mcErr := co.configMapClient.ConfigMaps(api.OpenShiftConfigManagedNamespace).Get(api.OpenShiftConsoleConfigMapName, metav1.GetOptions{})
 	if mcErr != nil && !apierrors.IsNotFound(mcErr) {
-		return nil, false, "FailedManagedConfig", mcErr
+		return nil, false, "FailedGetManagedConfig", mcErr
 	}
 
 	useDefaultCAFile := true
@@ -303,7 +303,17 @@ func (co *consoleOperator) SyncConfigMap(
 		useDefaultCAFile = false
 	}
 
-	defaultConfigmap, _, err := configmapsub.DefaultConfigMap(operatorConfig, consoleConfig, managedConfig, infrastructureConfig, consoleRoute, useDefaultCAFile)
+	monitoringSharedConfig, mscErr := co.configMapClient.ConfigMaps(api.OpenShiftConfigManagedNamespace).Get(api.OpenShiftMonitoringConfig, metav1.GetOptions{})
+	if mscErr != nil && !apierrors.IsNotFound(mscErr) {
+		return nil, false, "FailedGetMonitoringSharedConfig", mscErr
+	}
+
+	loggingSharedConfig, lscErr := co.configMapClient.ConfigMaps(api.OpenShiftConfigManagedNamespace).Get(api.OpenShiftLoggingConfig, metav1.GetOptions{})
+	if lscErr != nil && !apierrors.IsNotFound(lscErr) {
+		return nil, false, "FailedGetLoggingSharedConfig", lscErr
+	}
+
+	defaultConfigmap, _, err := configmapsub.DefaultConfigMap(operatorConfig, consoleConfig, managedConfig, monitoringSharedConfig, loggingSharedConfig, infrastructureConfig, consoleRoute, useDefaultCAFile)
 	if err != nil {
 		return nil, false, "FailedConsoleConfigBuilder", err
 	}

--- a/pkg/console/subresource/configmap/configmap.go
+++ b/pkg/console/subresource/configmap/configmap.go
@@ -38,6 +38,8 @@ func DefaultConfigMap(
 	operatorConfig *operatorv1.Console,
 	consoleConfig *configv1.Console,
 	managedConfig *corev1.ConfigMap,
+	monitoringSharedConfig *corev1.ConfigMap,
+	loggingSharedConfig *corev1.ConfigMap,
 	infrastructureConfig *configv1.Infrastructure,
 	rt *routev1.Route,
 	useDefaultCAFile bool) (consoleConfigmap *corev1.ConfigMap, unsupportedOverridesHaveMerged bool, err error) {
@@ -49,6 +51,8 @@ func DefaultConfigMap(
 		DocURL(DEFAULT_DOC_URL).
 		DefaultIngressCert(useDefaultCAFile).
 		APIServerURL(getApiUrl(infrastructureConfig)).
+		Monitoring(monitoringSharedConfig).
+		Logging(loggingSharedConfig).
 		ConfigYAML()
 
 	extractedManagedConfig := extractYAML(managedConfig)
@@ -59,6 +63,8 @@ func DefaultConfigMap(
 		DocURL(operatorConfig.Spec.Customization.DocumentationBaseURL).
 		DefaultIngressCert(useDefaultCAFile).
 		APIServerURL(getApiUrl(infrastructureConfig)).
+		Monitoring(monitoringSharedConfig).
+		Logging(loggingSharedConfig).
 		CustomLogoFile(operatorConfig.Spec.Customization.CustomLogoFile.Key).
 		CustomProductName(operatorConfig.Spec.Customization.CustomProductName).
 		StatusPageID(statusPageId(operatorConfig)).

--- a/pkg/console/subresource/consoleserver/config_builder_test.go
+++ b/pkg/console/subresource/consoleserver/config_builder_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	v1 "github.com/openshift/api/operator/v1"
+	corev1 "k8s.io/api/core/v1"
 
 	"github.com/openshift/console-operator/pkg/api"
 
@@ -66,6 +67,63 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 					ConsoleBasePath:    "",
 					ConsoleBaseAddress: "https://foobar.com/host",
 					MasterPublicURL:    "https://foobar.com/api",
+				},
+				Auth: Auth{
+					ClientID:            api.OpenShiftConsoleName,
+					ClientSecretFile:    clientSecretFilePath,
+					OAuthEndpointCAFile: defaultIngressCertFilePath,
+					LogoutRedirect:      "https://foobar.com/logout",
+				},
+				Customization: Customization{},
+				Providers:     Providers{},
+			},
+		}, {
+			name: "Config builder should handle monitoring and logging info",
+			input: func() Config {
+				b := &ConsoleServerCLIConfigBuilder{}
+				return b.
+					APIServerURL("https://foobar.com/api").
+					Host("https://foobar.com/host").
+					LogoutURL("https://foobar.com/logout").
+					Monitoring(&corev1.ConfigMap{
+						Data: map[string]string{
+							"alertmanagerURL": "https://alertmanager.url.com",
+							"grafanaURL":      "https://grafana.url.com",
+							"prometheusURL":   "https://prometheus.url.com",
+							"thanosURL":       "https://thanos.url.com",
+						},
+					}).
+					Logging(&corev1.ConfigMap{
+						Data: map[string]string{
+							"kibanaAppURL":      "https://kibanaApp.url.com",
+							"kibanaInfraAppURL": "https://kibanaInfraApp.url.com",
+						},
+					}).
+					DefaultIngressCert(false).
+					Config()
+			},
+			output: Config{
+				Kind:       "ConsoleConfig",
+				APIVersion: "console.openshift.io/v1",
+				ServingInfo: ServingInfo{
+					BindAddress: "https://[::]:8443",
+					CertFile:    certFilePath,
+					KeyFile:     keyFilePath,
+				},
+				ClusterInfo: ClusterInfo{
+					ConsoleBasePath:    "",
+					ConsoleBaseAddress: "https://foobar.com/host",
+					MasterPublicURL:    "https://foobar.com/api",
+				},
+				MonitoringInfo: MonitoringInfo{
+					AlertmanagerURL: "https://alertmanager.url.com",
+					GrafanaURL:      "https://grafana.url.com",
+					PrometheusURL:   "https://prometheus.url.com",
+					ThanosURL:       "https://thanos.url.com",
+				},
+				LoggingInfo: LoggingInfo{
+					KibanaAppURL:      "https://kibanaApp.url.com",
+					KibanaInfraAppURL: "https://kibanaInfraApp.url.com",
 				},
 				Auth: Auth{
 					ClientID:            api.OpenShiftConsoleName,
@@ -215,6 +273,57 @@ providers: {}
 `,
 		},
 		{
+			name: "Config builder should handle monitoring and logging info",
+			input: func() ([]byte, error) {
+				b := &ConsoleServerCLIConfigBuilder{}
+				return b.
+					APIServerURL("https://foobar.com/api").
+					Host("https://foobar.com/host").
+					LogoutURL("https://foobar.com/logout").
+					Monitoring(&corev1.ConfigMap{
+						Data: map[string]string{
+							"alertmanagerURL": "https://alertmanager.url.com",
+							"grafanaURL":      "https://grafana.url.com",
+							"prometheusURL":   "https://prometheus.url.com",
+							"thanosURL":       "https://thanos.url.com",
+						},
+					}).
+					Logging(&corev1.ConfigMap{
+						Data: map[string]string{
+							"kibanaAppURL":      "https://kibanaApp.url.com",
+							"kibanaInfraAppURL": "https://kibanaInfraApp.url.com",
+						},
+					}).
+					DefaultIngressCert(false).
+					ConfigYAML()
+			},
+			output: `apiVersion: console.openshift.io/v1
+kind: ConsoleConfig
+servingInfo:
+  bindAddress: https://[::]:8443
+  certFile: /var/serving-cert/tls.crt
+  keyFile: /var/serving-cert/tls.key
+clusterInfo:
+  consoleBaseAddress: https://foobar.com/host
+  masterPublicURL: https://foobar.com/api
+auth:
+  clientID: console
+  clientSecretFile: /var/oauth-config/clientSecret
+  oauthEndpointCAFile: /var/default-ingress-cert/ca-bundle.crt
+  logoutRedirect: https://foobar.com/logout
+customization: {}
+providers: {}
+monitoringInfo:
+  alertmanagerURL: https://alertmanager.url.com
+  grafanaURL: https://grafana.url.com
+  prometheusURL: https://prometheus.url.com
+  thanosURL: https://thanos.url.com
+loggingInfo:
+  kibanaAppURL: https://kibanaApp.url.com
+  kibanaInfraAppURL: https://kibanaInfraApp.url.com
+`,
+		},
+		{
 			name: "Config builder should handle StatuspageID",
 			input: func() ([]byte, error) {
 				b := &ConsoleServerCLIConfigBuilder{}
@@ -246,6 +355,20 @@ providers:
 					DocURL("https://foobar.com/docs").
 					APIServerURL("https://foobar.com/api").
 					StatusPageID("status-12345").
+					Monitoring(&corev1.ConfigMap{
+						Data: map[string]string{
+							"alertmanagerURL": "https://alertmanager.url.com",
+							"grafanaURL":      "https://grafana.url.com",
+							"prometheusURL":   "https://prometheus.url.com",
+							"thanosURL":       "https://thanos.url.com",
+						},
+					}).
+					Logging(&corev1.ConfigMap{
+						Data: map[string]string{
+							"kibanaAppURL":      "https://kibanaApp.url.com",
+							"kibanaInfraAppURL": "https://kibanaInfraApp.url.com",
+						},
+					}).
 					DefaultIngressCert(true)
 				return b.ConfigYAML()
 			},
@@ -267,6 +390,14 @@ customization:
   documentationBaseURL: https://foobar.com/docs
 providers:
   statuspageID: status-12345
+monitoringInfo:
+  alertmanagerURL: https://alertmanager.url.com
+  grafanaURL: https://grafana.url.com
+  prometheusURL: https://prometheus.url.com
+  thanosURL: https://thanos.url.com
+loggingInfo:
+  kibanaAppURL: https://kibanaApp.url.com
+  kibanaInfraAppURL: https://kibanaInfraApp.url.com
 `,
 		},
 	}

--- a/pkg/console/subresource/consoleserver/types.go
+++ b/pkg/console/subresource/consoleserver/types.go
@@ -11,13 +11,15 @@ package consoleserver
 
 // Config is the top-level console server cli configuration.
 type Config struct {
-	APIVersion    string `yaml:"apiVersion"`
-	Kind          string `yaml:"kind"`
-	ServingInfo   `yaml:"servingInfo"`
-	ClusterInfo   `yaml:"clusterInfo"`
-	Auth          `yaml:"auth"`
-	Customization `yaml:"customization"`
-	Providers     `yaml:"providers"`
+	APIVersion     string `yaml:"apiVersion"`
+	Kind           string `yaml:"kind"`
+	ServingInfo    `yaml:"servingInfo"`
+	ClusterInfo    `yaml:"clusterInfo"`
+	Auth           `yaml:"auth"`
+	Customization  `yaml:"customization"`
+	Providers      `yaml:"providers"`
+	MonitoringInfo `yaml:"monitoringInfo,omitempty"`
+	LoggingInfo    `yaml:"loggingInfo,omitempty"`
 }
 
 // ServingInfo holds configuration for serving HTTP.
@@ -42,6 +44,20 @@ type ClusterInfo struct {
 	ConsoleBaseAddress string `yaml:"consoleBaseAddress,omitempty"`
 	ConsoleBasePath    string `yaml:"consoleBasePath,omitempty"`
 	MasterPublicURL    string `yaml:"masterPublicURL,omitempty"`
+}
+
+// Monitoring holds URLs for monitoring related services
+type MonitoringInfo struct {
+	AlertmanagerURL string `yaml:"alertmanagerURL,omitempty"`
+	GrafanaURL      string `yaml:"grafanaURL,omitempty"`
+	PrometheusURL   string `yaml:"prometheusURL,omitempty"`
+	ThanosURL       string `yaml:"thanosURL,omitempty"`
+}
+
+// Logging holds URLs for logging related services
+type LoggingInfo struct {
+	KibanaAppURL      string `yaml:"kibanaAppURL,omitempty"`
+	KibanaInfraAppURL string `yaml:"kibanaInfraAppURL,omitempty"`
 }
 
 // Auth holds configuration for authenticating with OpenShift. The auth method is assumed to be "openshift".


### PR DESCRIPTION
Taking `monitoring-shared-config` and `logging-shared-config` CMs from `openshift-config-managed` namespace and feeding them to the `console-config`
<img width="1182" alt="Screenshot 2020-02-21 at 10 21 07" src="https://user-images.githubusercontent.com/1668218/75020938-e9f08080-5493-11ea-9667-e77153088772.png">
(logging is missing since the [PR](https://github.com/openshift/cluster-logging-operator/pull/374) is not merged yet)

/assign @benjaminapetersen 