### PR TITLE
Add Helm and HelmChartRepo types

### DIFF
--- a/pkg/console/subresource/consoleserver/types.go
+++ b/pkg/console/subresource/consoleserver/types.go
@@ -79,3 +79,12 @@ type Customization struct {
 type Providers struct {
 	StatuspageID string `yaml:"statuspageID,omitempty"`
 }
+
+type HelmChartRepo struct {
+	URL    string `yaml:"url,omitempty"`
+	CAFile string `yaml:"caFile,omitempty"`
+}
+
+type Helm struct {
+	ChartRepo HelmChartRepo `yaml:"chartRepository"`
+}


### PR DESCRIPTION
Adding missing [types](https://github.com/openshift/console/blob/master/pkg/serverconfig/types.go#L63-L70) to have type parity with the console repo

/assign @benjaminapetersen 