### PR TITLE
Bug 1809665: The console should wait until it is out of rotation to shut down

### DIFF
--- a/pkg/console/subresource/deployment/deployment_test.go
+++ b/pkg/console/subresource/deployment/deployment_test.go
@@ -21,7 +21,7 @@ func TestDefaultDeployment(t *testing.T) {
 	var (
 		replicaCount int32 = 2
 		labels             = map[string]string{"app": api.OpenShiftConsoleName, "component": "ui"}
-		gracePeriod  int64 = 30
+		gracePeriod  int64 = 40
 	)
 	type args struct {
 		config             *operatorsv1.Console


### PR DESCRIPTION
When a pod is marked deleted, endpoints are updated instantly and
propagate to load balancers, routers, and nodes. A component that
wishes to remain available during upgrades must wait longer than
the default propagation interval for these changes to avoid having
requests delivered to pods that are shutting down.

Change the console to wait 25s before terminating the serving
process and up to 40s on the node to ensure all front ends have
time to drain. The minimum interval here is how long an average
connection can take behind the router to drain, once new connections
stop getting created. I.e.

    wait = time to propagate endpoints (5s) +
           time for router reload (5s) +
           time for longest request to finish (15s)
         = 25s

This change should result in the console not being disrupted during
upgrade (0s disruption to the console route).

Downtime documented in https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-upgrade/19447