### PR TITLE
Bug 1813775: Publish license file of oc on downloads-openshift-console

### DIFF
--- a/manifests/07-downloads-deployment.yaml
+++ b/manifests/07-downloads-deployment.yaml
@@ -89,10 +89,14 @@ spec:
               os.mkdir(arch)
               for operating_system in ['linux', 'mac', 'windows']:
                   os.mkdir(os.path.join(arch, operating_system))
+                  target_path = os.path.join(arch, operating_system, 'LICENSE')
+                  os.symlink('/usr/share/openshift/LICENSE', target_path)
           for arch in ['arm64', 'ppc64le', 's390x']:
               os.mkdir(arch)
               for operating_system in ['linux']:
                   os.mkdir(os.path.join(arch, operating_system))
+                  target_path = os.path.join(arch, operating_system, 'LICENSE')
+                  os.symlink('/usr/share/openshift/LICENSE', target_path)
 
           for arch, operating_system, path in [
                   ('amd64', 'linux', '/usr/share/openshift/linux_amd64/oc'),

--- a/pkg/console/controllers/clidownloads/controller.go
+++ b/pkg/console/controllers/clidownloads/controller.go
@@ -188,6 +188,41 @@ The oc binary offers the same capabilities as the kubectl binary, but it is furt
 	}
 }
 
+func LicenseDownloads(host, cliDownloadsName string) *v1.ConsoleCLIDownload {
+	baseURL := fmt.Sprintf("%s", util.HTTPS(host))
+	platforms := []struct {
+		label    string
+		key      string
+		archType string
+	}{
+		{"Linux for x86_64", "amd64/linux", "LICENSE"},
+		{"Linux for ARM 64", "arm64/linux", "LICENSE"},
+		{"Linux for IBM Power, little endian", "ppc64le/linux", "LICENSE"},
+		{"Linux for IBM Z", "s390x/linux", "LICENSE"},
+		{"Mac for x86_64", "amd64/mac", "LICENSE"},
+		{"Windows for x86_64", "amd64/windows", "LICENSE"},
+	}
+
+	links := []v1.CLIDownloadLink{}
+	for _, platform := range platforms {
+		links = append(links, v1.CLIDownloadLink{
+			Href: GetPlatformURL(baseURL, platform.key, platform.archType),
+			Text: fmt.Sprintf("Download LICENSE at %s", platform.label),
+		})
+	}
+
+	return &v1.ConsoleCLIDownload{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: cliDownloadsName,
+		},
+		Spec: v1.ConsoleCLIDownloadSpec{
+			Description: `Apache License v2.0 for the OpenShift command line interface.`,
+			DisplayName: "LICENSE - license of OpenShift Command Line Interface",
+			Links:       links,
+		},
+	}
+}
+
 func ODOConsoleCLIDownloads() *v1.ConsoleCLIDownload {
 	return &v1.ConsoleCLIDownload{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/console/controllers/clidownloads/controller_test.go
+++ b/pkg/console/controllers/clidownloads/controller_test.go
@@ -148,3 +148,141 @@ The oc binary offers the same capabilities as the kubectl binary, but it is furt
 		})
 	}
 }
+
+func TestGetLicenseURL(t *testing.T) {
+	type args struct {
+		baseURL     string
+		platform    string
+		archiveType string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "Test assembling linux amd64 specific URL for License",
+			args: args{
+				baseURL:     "https://www.example.com/amd64",
+				platform:    "linux",
+				archiveType: "LICENSE",
+			},
+			want: "https://www.example.com/amd64/linux/LICENSE",
+		},
+		{
+			name: "Test assembling linux arm64 specific URL for License",
+			args: args{
+				baseURL:     "https://www.example.com/arm64",
+				platform:    "linux",
+				archiveType: "LICENSE",
+			},
+			want: "https://www.example.com/arm64/linux/LICENSE",
+		},
+		{
+			name: "Test assembling linux ppc64le specific URL for License",
+			args: args{
+				baseURL:     "https://www.example.com/ppc64le",
+				platform:    "linux",
+				archiveType: "LICENSE",
+			},
+			want: "https://www.example.com/ppc64le/linux/LICENSE",
+		},
+		{
+			name: "Test assembling linux s390x specific URL for License",
+			args: args{
+				baseURL:     "https://www.example.com/s390x",
+				platform:    "linux",
+				archiveType: "LICENSE",
+			},
+			want: "https://www.example.com/s390x/linux/LICENSE",
+		},
+		{
+			name: "Test assembling mac specific URL for License",
+			args: args{
+				baseURL:     "https://www.example.com/amd64",
+				platform:    "mac",
+				archiveType: "LICENSE",
+			},
+			want: "https://www.example.com/amd64/mac/LICENSE",
+		},
+		{
+			name: "Test assembling windows 64-bit specific URL for License",
+			args: args{
+				baseURL:     "https://www.example.com/amd64",
+				platform:    "windows",
+				archiveType: "LICENSE",
+			},
+			want: "https://www.example.com/amd64/windows/LICENSE",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if diff := deep.Equal(GetPlatformURL(tt.args.baseURL, tt.args.platform, tt.args.archiveType), tt.want); diff != nil {
+				t.Error(diff)
+			}
+		})
+	}
+}
+
+func TestLicenseDownloads(t *testing.T) {
+	type args struct {
+		host             string
+		arch             string
+		cliDownloadsName string
+	}
+	tests := []struct {
+		name string
+		args args
+		want *v1.ConsoleCLIDownload
+	}{
+		{
+			name: "Test assembling platform specific URL for LICENSE",
+			args: args{
+				host:             "www.example.com",
+				cliDownloadsName: "amd64/oc-cli-downloads",
+			},
+			want: &v1.ConsoleCLIDownload{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "amd64/oc-cli-downloads",
+				},
+				Spec: v1.ConsoleCLIDownloadSpec{
+					Description: `Apache License v2.0 for the OpenShift command line interface.`,
+					DisplayName: "LICENSE - license of OpenShift Command Line Interface",
+					Links: []v1.CLIDownloadLink{
+						{
+							Href: "https://www.example.com/amd64/linux/LICENSE",
+							Text: "Download LICENSE at Linux for x86_64",
+						},
+						{
+							Href: "https://www.example.com/arm64/linux/LICENSE",
+							Text: "Download LICENSE at Linux for ARM 64",
+						},
+						{
+							Href: "https://www.example.com/ppc64le/linux/LICENSE",
+							Text: "Download LICENSE at Linux for IBM Power, little endian",
+						},
+						{
+							Href: "https://www.example.com/s390x/linux/LICENSE",
+							Text: "Download LICENSE at Linux for IBM Z",
+						},
+						{
+							Href: "https://www.example.com/amd64/mac/LICENSE",
+							Text: "Download LICENSE at Mac for x86_64",
+						},
+						{
+							Href: "https://www.example.com/amd64/windows/LICENSE",
+							Text: "Download LICENSE at Windows for x86_64",
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if diff := deep.Equal(LicenseDownloads(tt.args.host, tt.args.cliDownloadsName), tt.want); diff != nil {
+				t.Error(diff)
+			}
+		})
+	}
+}

--- a/test/e2e/downloads_test.go
+++ b/test/e2e/downloads_test.go
@@ -48,3 +48,31 @@ func TestDownloadsEndpoint(t *testing.T) {
 		t.Logf("%s %s\n", link.Text, resp.Status)
 	}
 }
+
+func TestDonwloadsLicense(t *testing.T) {
+	client, _ := setupDownloadsTestCase(t)
+	defer cleanupDownloadsTestCase(t, client)
+
+	route, err := client.Routes.Routes(api.OpenShiftConsoleNamespace).Get(api.OpenShiftConsoleName, v1.GetOptions{})
+	if err != nil {
+		t.Fatalf("could not get route: %s", err)
+	}
+	host := routesub.GetCanonicalHost(route)
+
+	licenseDownloads := clidownloads.LicenseDownloads(host, api.OCCLIDownloadsCustomResourceName)
+
+	for _, link := range licenseDownloads.Spec.Links {
+		req := getRequest(t, link.Href)
+		client := getInsecureClient()
+		resp, err := client.Do(req)
+
+		if err != nil {
+			t.Fatalf("http error getting %s at %s: %s", link.Text, link.Href, err)
+		}
+		if !httpOK(resp) {
+			t.Fatalf("http error for %s at %s: %d %s", link.Text, link.Href, resp.StatusCode, http.StatusText(resp.StatusCode))
+		}
+		resp.Body.Close()
+		t.Logf("%s %s\n", link.Text, resp.Status)
+	}
+}


### PR DESCRIPTION
Publish the license file with oc binary on downloads-openshift-console
since oc binary is applied Apache License 2.0.

This depends on openshift/oc#337 to provide the license in cli-artifacts.