### PR TITLE
Update oc clidownload cr to indicate that certain builds are unsupported

### DIFF
--- a/pkg/console/controllers/clidownloads/controller.go
+++ b/pkg/console/controllers/clidownloads/controller.go
@@ -158,11 +158,11 @@ func PlatformBasedOCConsoleCLIDownloads(host, cliDownloadsName string) *v1.Conso
 		archType string
 	}{
 		{"Linux for x86_64", "amd64/linux", "oc.tar"},
-		{"Linux for ARM 64", "arm64/linux", "oc.tar"},
-		{"Linux for IBM Power, little endian", "ppc64le/linux", "oc.tar"},
-		{"Linux for IBM Z", "s390x/linux", "oc.tar"},
 		{"Mac for x86_64", "amd64/mac", "oc.zip"},
 		{"Windows for x86_64", "amd64/windows", "oc.zip"},
+		{"Linux for ARM 64 (unsupported)", "arm64/linux", "oc.tar"},
+		{"Linux for IBM Power, little endian (unsupported)", "ppc64le/linux", "oc.tar"},
+		{"Linux for IBM Z (unsupported)", "s390x/linux", "oc.tar"},
 	}
 
 	links := []v1.CLIDownloadLink{}

--- a/pkg/console/controllers/clidownloads/controller_test.go
+++ b/pkg/console/controllers/clidownloads/controller_test.go
@@ -116,24 +116,24 @@ The oc binary offers the same capabilities as the kubectl binary, but it is furt
 							Text: "Download oc for Linux for x86_64",
 						},
 						{
-							Href: "https://www.example.com/arm64/linux/oc.tar",
-							Text: "Download oc for Linux for ARM 64",
-						},
-						{
-							Href: "https://www.example.com/ppc64le/linux/oc.tar",
-							Text: "Download oc for Linux for IBM Power, little endian",
-						},
-						{
-							Href: "https://www.example.com/s390x/linux/oc.tar",
-							Text: "Download oc for Linux for IBM Z",
-						},
-						{
 							Href: "https://www.example.com/amd64/mac/oc.zip",
 							Text: "Download oc for Mac for x86_64",
 						},
 						{
 							Href: "https://www.example.com/amd64/windows/oc.zip",
 							Text: "Download oc for Windows for x86_64",
+						},
+						{
+							Href: "https://www.example.com/arm64/linux/oc.tar",
+							Text: "Download oc for Linux for ARM 64 (unsupported)",
+						},
+						{
+							Href: "https://www.example.com/ppc64le/linux/oc.tar",
+							Text: "Download oc for Linux for IBM Power, little endian (unsupported)",
+						},
+						{
+							Href: "https://www.example.com/s390x/linux/oc.tar",
+							Text: "Download oc for Linux for IBM Z (unsupported)",
 						},
 					},
 				},


### PR DESCRIPTION
Will be a backport to 4.4 & 4.3.z.

