### PR TITLE
Support http and https both for ConsoleLink

### DIFF
--- a/vendor/github.com/openshift/api/console/v1/0000_10_consolelink.crd.yaml
+++ b/vendor/github.com/openshift/api/console/v1/0000_10_consolelink.crd.yaml
@@ -83,10 +83,10 @@ spec:
                     section.
                   type: string
             href:
-              description: href is the absolute secure URL for the link (must use
-                https)
+              description: href is the absolute secure URL for the link (support http://
+                or https://)
               type: string
-              pattern: ^https://
+              pattern: ^http?://
             location:
               description: location determines which location in the console the link
                 will be appended to (ApplicationMenu, HelpMenu, UserMenu, NamespaceDashboard).


### PR DESCRIPTION
Support https and http url link in ConsoleLink

Signed-off-by: Phil Huang <phil.huang@redhat.com>