### PR TITLE
Custom console route

### DIFF
--- a/manifests/03-rbac-role-cluster.yaml
+++ b/manifests/03-rbac-role-cluster.yaml
@@ -18,6 +18,7 @@ rules:
   - config.openshift.io
   resources:
   - infrastructures
+  - ingresses
   verbs:
   - get
   - list

--- a/manifests/03-rbac-role-ns-console.yaml
+++ b/manifests/03-rbac-role-ns-console.yaml
@@ -63,6 +63,7 @@ rules:
   - route.openshift.io
   resources:
   - routes
+  - routes/custom-host
   verbs:
   - get
   - list

--- a/manifests/03-rbac-role-ns-openshift-config.yaml
+++ b/manifests/03-rbac-role-ns-openshift-config.yaml
@@ -8,6 +8,7 @@ rules:
       - ""
     resources:
       - configmaps
+      - secrets
     verbs:
       - get
       - list

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -14,6 +14,7 @@ const (
 	OpenShiftConsoleOperator            = "console-operator"
 	OpenShiftConsoleConfigMapName       = "console-config"
 	OpenShiftConsolePublicConfigMapName = "console-public"
+	OpenshiftConsoleCustomRouteName     = "console-custom"
 	ServiceCAConfigMapName              = "service-ca"
 	DefaultIngressCertConfigMapName     = "default-ingress-cert"
 	OpenShiftConsoleDeploymentName      = OpenShiftConsoleName

--- a/pkg/console/controllers/route/controller_test.go
+++ b/pkg/console/controllers/route/controller_test.go
@@ -1,0 +1,202 @@
+package route
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"testing"
+
+	"github.com/go-test/deep"
+
+	// k8s
+	corev1 "k8s.io/api/core/v1"
+
+	// console-operator
+	routesub "github.com/openshift/console-operator/pkg/console/subresource/route"
+)
+
+const (
+	validCertificate = `-----BEGIN CERTIFICATE-----
+MIICRzCCAfGgAwIBAgIJAIydTIADd+yqMA0GCSqGSIb3DQEBCwUAMH4xCzAJBgNV
+BAYTAkdCMQ8wDQYDVQQIDAZMb25kb24xDzANBgNVBAcMBkxvbmRvbjEYMBYGA1UE
+CgwPR2xvYmFsIFNlY3VyaXR5MRYwFAYDVQQLDA1JVCBEZXBhcnRtZW50MRswGQYD
+VQQDDBJ0ZXN0LWNlcnRpZmljYXRlLTIwIBcNMTcwNDI2MjMyNDU4WhgPMjExNzA0
+MDIyMzI0NThaMH4xCzAJBgNVBAYTAkdCMQ8wDQYDVQQIDAZMb25kb24xDzANBgNV
+BAcMBkxvbmRvbjEYMBYGA1UECgwPR2xvYmFsIFNlY3VyaXR5MRYwFAYDVQQLDA1J
+VCBEZXBhcnRtZW50MRswGQYDVQQDDBJ0ZXN0LWNlcnRpZmljYXRlLTIwXDANBgkq
+hkiG9w0BAQEFAANLADBIAkEAuiRet28DV68Dk4A8eqCaqgXmymamUEjW/DxvIQqH
+3lbhtm8BwSnS9wUAajSLSWiq3fci2RbRgaSPjUrnbOHCLQIDAQABo1AwTjAdBgNV
+HQ4EFgQU0vhI4OPGEOqT+VAWwxdhVvcmgdIwHwYDVR0jBBgwFoAU0vhI4OPGEOqT
++VAWwxdhVvcmgdIwDAYDVR0TBAUwAwEB/zANBgkqhkiG9w0BAQsFAANBALNeJGDe
+nV5cXbp9W1bC12Tc8nnNXn4ypLE2JTQAvyp51zoZ8hQoSnRVx/VCY55Yu+br8gQZ
++tW+O/PoE7B3tuY=
+-----END CERTIFICATE-----`
+	validKey = `-----BEGIN RSA PRIVATE KEY-----
+MIIBVgIBADANBgkqhkiG9w0BAQEFAASCAUAwggE8AgEAAkEAuiRet28DV68Dk4A8
+eqCaqgXmymamUEjW/DxvIQqH3lbhtm8BwSnS9wUAajSLSWiq3fci2RbRgaSPjUrn
+bOHCLQIDAQABAkEArDR1g9IqD3aUImNikDgAngbzqpAokOGyMoxeavzpEaFOgCzi
+gi7HF7yHRmZkUt8CzdEvnHSqRjFuaaB0gGA+AQIhAOc8Z1h8ElLRSqaZGgI3jCTp
+Izx9HNY//U5NGrXD2+ttAiEAzhOqkqI4+nDab7FpiD7MXI6fO549mEXeVBPvPtsS
+OcECIQCIfkpOm+ZBBpO3JXaJynoqK4gGI6ALA/ik6LSUiIlfPQIhAISjd9hlfZME
+bDQT1r8Q3Gx+h9LRqQeHgPBQ3F5ylqqBAiBaJ0hkYvrIdWxNlcLqD3065bJpHQ4S
+WQkuZUQN1M/Xvg==
+-----END RSA PRIVATE KEY-----`
+	invalidCertificate = `
+-----BEGIN CERTIFICATE-----
+MIIEBDCCAuygAwIBAgIDAjppMA0GCSqGSIb3DQEBBQUAMEIxCzAJBgNVBAYTAlVT
+WHPbqCRiOwY1nQ2pM714A5AuTHhdUDqB1O6gyHA43LL5Z/qHQF1hwFGPa4NrzQU6
+yuGnBXj8ytqU0CwIPX4WecigUCAkVDNx
+-----END CERTIFICATE-----`
+	invalidKey = `
+-----BEGIN RSA PRIVATE KEY-----
+MIIJKQIBAAKCAgEAw2jtDhf4X2W8182vtAiwXUk/Zr7mruiiFt3y4l7YRBXaazmI
+eIWaEkvN9O90gL09Cx5jgq6mP1pjCzHsEFhnICziFd1r+M3cMeb4EAqwMZ84
+-----END RSA PRIVATE KEY-----`
+)
+
+type certificateData struct {
+	keyPEM         []byte
+	certificatePEM []byte
+	certificate    *tls.Certificate
+}
+
+func newCertificateData(certificatePEM string, keyPEM string) *certificateData {
+	certificate, err := tls.X509KeyPair([]byte(certificatePEM), []byte(keyPEM))
+	if err != nil {
+		panic(fmt.Sprintf("Unable to initialize certificate: %v", err))
+	}
+	certs, err := x509.ParseCertificates(certificate.Certificate[0])
+	if err != nil {
+		panic(fmt.Sprintf("Unable to initialize certificate leaf: %v", err))
+	}
+	certificate.Leaf = certs[0]
+	return &certificateData{
+		keyPEM:         []byte(keyPEM),
+		certificatePEM: []byte(certificatePEM),
+		certificate:    &certificate,
+	}
+}
+
+func TestValidateCustomCertSecret(t *testing.T) {
+	type args struct {
+		secret *corev1.Secret
+	}
+	type want struct {
+		customTLSCert *routesub.CustomTLSCert
+		err           error
+	}
+	tests := []struct {
+		name string
+		args args
+		want want
+	}{
+		{
+			name: "Test valid custom cert secret",
+			args: args{
+				secret: &corev1.Secret{
+					Type: corev1.SecretTypeTLS,
+					Data: map[string][]byte{
+						corev1.TLSCertKey:       []byte(validCertificate),
+						corev1.TLSPrivateKeyKey: []byte(validKey),
+					},
+				},
+			},
+			want: want{
+				customTLSCert: &routesub.CustomTLSCert{
+					Certificate: validCertificate,
+					Key:         validKey,
+				},
+				err: nil,
+			},
+		},
+		{
+			name: "Test custom cert secret with invalid type",
+			args: args{
+				secret: &corev1.Secret{
+					Type: corev1.SecretTypeSSHAuth,
+					Data: map[string][]byte{
+						corev1.TLSCertKey:       []byte(validCertificate),
+						corev1.TLSPrivateKeyKey: []byte(validKey),
+					},
+				},
+			},
+			want: want{
+				customTLSCert: nil,
+				err:           fmt.Errorf("custom cert secret is not in %q type, instead uses %q type", corev1.SecretTypeTLS, corev1.SecretTypeSSHAuth),
+			},
+		},
+		{
+			name: "Test custom cert secret missing 'tls.key' data field",
+			args: args{
+				secret: &corev1.Secret{
+					Type: corev1.SecretTypeTLS,
+					Data: map[string][]byte{
+						corev1.TLSCertKey: []byte(validCertificate),
+					},
+				},
+			},
+			want: want{
+				customTLSCert: nil,
+				err:           fmt.Errorf("custom cert secret data doesn't contain '%s' entry", corev1.TLSPrivateKeyKey),
+			},
+		},
+		{
+			name: "Test custom cert secret missing 'tls.crt' data field",
+			args: args{
+				secret: &corev1.Secret{
+					Type: corev1.SecretTypeTLS,
+					Data: map[string][]byte{
+						corev1.TLSPrivateKeyKey: []byte(validKey),
+					},
+				},
+			},
+			want: want{
+				customTLSCert: nil,
+				err:           fmt.Errorf("custom cert secret data doesn't contain '%s' entry", corev1.TLSCertKey),
+			},
+		},
+		{
+			name: "Test custom cert secret with invalid TLS cert",
+			args: args{
+				secret: &corev1.Secret{
+					Type: corev1.SecretTypeTLS,
+					Data: map[string][]byte{
+						corev1.TLSCertKey:       []byte(invalidCertificate),
+						corev1.TLSPrivateKeyKey: []byte(validKey),
+					},
+				},
+			},
+			want: want{
+				customTLSCert: nil,
+				err:           fmt.Errorf("failed to verify custom certificate PEM: asn1: syntax error: data truncated"),
+			},
+		},
+		{
+			name: "Test custom cert secret with invalid TLS key",
+			args: args{
+				secret: &corev1.Secret{
+					Type: corev1.SecretTypeTLS,
+					Data: map[string][]byte{
+						corev1.TLSCertKey:       []byte(validCertificate),
+						corev1.TLSPrivateKeyKey: []byte(invalidKey),
+					},
+				},
+			},
+			want: want{
+				customTLSCert: nil,
+				err:           fmt.Errorf("failed to verify custom key PEM: block RSA PRIVATE KEY is not valid key PEM"),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			customTLSCert, err := ValidateCustomCertSecret(tt.args.secret)
+			if diff := deep.Equal(customTLSCert, tt.want.customTLSCert); diff != nil {
+				t.Error(diff)
+			}
+			if diff := deep.Equal(err, tt.want.err); diff != nil {
+				t.Error(diff)
+			}
+		})
+	}
+}

--- a/pkg/console/subresource/configmap/configmap.go
+++ b/pkg/console/subresource/configmap/configmap.go
@@ -40,11 +40,11 @@ func DefaultConfigMap(
 	managedConfig *corev1.ConfigMap,
 	monitoringSharedConfig *corev1.ConfigMap,
 	infrastructureConfig *configv1.Infrastructure,
-	rt *routev1.Route,
+	activeConsoleRoute *routev1.Route,
 	useDefaultCAFile bool) (consoleConfigmap *corev1.ConfigMap, unsupportedOverridesHaveMerged bool, err error) {
 
 	defaultBuilder := &consoleserver.ConsoleServerCLIConfigBuilder{}
-	defaultConfig, err := defaultBuilder.Host(rt.Spec.Host).
+	defaultConfig, err := defaultBuilder.Host(activeConsoleRoute.Spec.Host).
 		LogoutURL(defaultLogoutURL).
 		Brand(DEFAULT_BRAND).
 		DocURL(DEFAULT_DOC_URL).
@@ -55,7 +55,7 @@ func DefaultConfigMap(
 
 	extractedManagedConfig := extractYAML(managedConfig)
 	userDefinedBuilder := &consoleserver.ConsoleServerCLIConfigBuilder{}
-	userDefinedConfig, err := userDefinedBuilder.Host(rt.Spec.Host).
+	userDefinedConfig, err := userDefinedBuilder.Host(activeConsoleRoute.Spec.Host).
 		LogoutURL(consoleConfig.Spec.Authentication.LogoutRedirect).
 		Brand(operatorConfig.Spec.Customization.Brand).
 		DocURL(operatorConfig.Spec.Customization.DocumentationBaseURL).

--- a/pkg/console/subresource/deployment/deployment.go
+++ b/pkg/console/subresource/deployment/deployment.go
@@ -16,7 +16,6 @@ import (
 	// openshift
 	configv1 "github.com/openshift/api/config/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
-	routev1 "github.com/openshift/api/route/v1"
 	"github.com/openshift/console-operator/pkg/api"
 	"github.com/openshift/console-operator/pkg/console/subresource/util"
 )
@@ -64,7 +63,7 @@ type volumeConfig struct {
 	mappedKeys  map[string]string
 }
 
-func DefaultDeployment(operatorConfig *operatorv1.Console, cm *corev1.ConfigMap, serviceCAConfigMap *corev1.ConfigMap, defaultIngressCertConfigMap *corev1.ConfigMap, trustedCAConfigMap *corev1.ConfigMap, sec *corev1.Secret, rt *routev1.Route, proxyConfig *configv1.Proxy, canMountCustomLogo bool) *appsv1.Deployment {
+func DefaultDeployment(operatorConfig *operatorv1.Console, cm *corev1.ConfigMap, serviceCAConfigMap *corev1.ConfigMap, defaultIngressCertConfigMap *corev1.ConfigMap, trustedCAConfigMap *corev1.ConfigMap, sec *corev1.Secret, proxyConfig *configv1.Proxy, canMountCustomLogo bool) *appsv1.Deployment {
 	labels := util.LabelsForConsole()
 	meta := util.SharedMeta()
 	meta.Labels = labels

--- a/pkg/console/subresource/deployment/deployment_test.go
+++ b/pkg/console/subresource/deployment/deployment_test.go
@@ -11,7 +11,6 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 	operatorsv1 "github.com/openshift/api/operator/v1"
-	v1 "github.com/openshift/api/route/v1"
 	"github.com/openshift/console-operator/pkg/api"
 	"github.com/openshift/console-operator/pkg/console/subresource/configmap"
 	"github.com/openshift/console-operator/pkg/console/subresource/util"
@@ -30,7 +29,6 @@ func TestDefaultDeployment(t *testing.T) {
 		dica               *corev1.ConfigMap
 		tca                *corev1.ConfigMap
 		sec                *corev1.Secret
-		rt                 *v1.Route
 		proxy              *configv1.Proxy
 		canMountCustomLogo bool
 	}
@@ -176,10 +174,6 @@ func TestDefaultDeployment(t *testing.T) {
 					StringData: nil,
 					Type:       "",
 				},
-				rt: &v1.Route{
-					TypeMeta:   metav1.TypeMeta{},
-					ObjectMeta: metav1.ObjectMeta{},
-				},
 				proxy: proxyConfig,
 			},
 			want: &appsv1.Deployment{
@@ -242,10 +236,6 @@ func TestDefaultDeployment(t *testing.T) {
 					StringData: nil,
 					Type:       "",
 				},
-				rt: &v1.Route{
-					TypeMeta:   metav1.TypeMeta{},
-					ObjectMeta: metav1.ObjectMeta{},
-				},
 				proxy: proxyConfig,
 			},
 			want: &appsv1.Deployment{
@@ -294,7 +284,7 @@ func TestDefaultDeployment(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if diff := deep.Equal(DefaultDeployment(tt.args.config, tt.args.cm, tt.args.dica, tt.args.cm, tt.args.tca, tt.args.sec, tt.args.rt, tt.args.proxy, tt.args.canMountCustomLogo), tt.want); diff != nil {
+			if diff := deep.Equal(DefaultDeployment(tt.args.config, tt.args.cm, tt.args.dica, tt.args.cm, tt.args.tca, tt.args.sec, tt.args.proxy, tt.args.canMountCustomLogo), tt.want); diff != nil {
 				t.Error(diff)
 			}
 		})

--- a/pkg/console/subresource/route/route.go
+++ b/pkg/console/subresource/route/route.go
@@ -1,9 +1,9 @@
 package route
 
 import (
-	// kube
 	"context"
 
+	// kube
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -14,7 +14,10 @@ import (
 	operatorv1 "github.com/openshift/api/operator/v1"
 	routev1 "github.com/openshift/api/route/v1"
 	routeclient "github.com/openshift/client-go/route/clientset/versioned/typed/route/v1"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/resource/resourcemerge"
 
+	"github.com/openshift/console-operator/pkg/api"
 	"github.com/openshift/console-operator/pkg/console/subresource/util"
 )
 
@@ -23,6 +26,38 @@ const (
 	// this is an implicit stable API
 	defaultIngressController = "default"
 )
+
+// holds information about custom TLS certificate and its key
+type CustomTLSCert struct {
+	Certificate string
+	Key         string
+}
+
+func ApplyRoute(client routeclient.RoutesGetter, recorder events.Recorder, required *routev1.Route) (*routev1.Route, bool, error) {
+	existing, err := client.Routes(required.Namespace).Get(context.TODO(), required.Name, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		requiredCopy := required.DeepCopy()
+		actual, err := client.Routes(requiredCopy.Namespace).Create(context.TODO(), resourcemerge.WithCleanLabelsAndAnnotations(requiredCopy).(*routev1.Route), metav1.CreateOptions{})
+		return actual, true, err
+	}
+	if err != nil {
+		return nil, false, err
+	}
+
+	existingCopy := existing.DeepCopy()
+	modified := resourcemerge.BoolPtr(false)
+	resourcemerge.EnsureObjectMeta(modified, &existingCopy.ObjectMeta, required.ObjectMeta)
+	specSame := equality.Semantic.DeepEqual(existingCopy.Spec, required.Spec)
+
+	if specSame && !*modified {
+		klog.V(4).Infof("%s route exists and is in the correct state", existingCopy.ObjectMeta.Name)
+		return existingCopy, false, nil
+	}
+
+	existingCopy.Spec = required.Spec
+	actual, err := client.Routes(required.Namespace).Update(context.TODO(), existingCopy, metav1.UpdateOptions{})
+	return actual, true, err
+}
 
 // ensures route exists.
 // handles 404 with a create
@@ -34,6 +69,7 @@ func GetOrCreate(ctx context.Context, client routeclient.RoutesGetter, required 
 		isNew = true
 		route, err = client.Routes(required.Namespace).Create(ctx, required, metav1.CreateOptions{})
 	}
+
 	if err != nil {
 		return nil, isNew, err
 	}
@@ -41,53 +77,36 @@ func GetOrCreate(ctx context.Context, client routeclient.RoutesGetter, required 
 }
 
 func DefaultRoute(cr *operatorv1.Console) *routev1.Route {
-	route := Stub()
+	route := DefaultStub()
 	route.Spec = routev1.RouteSpec{
 		To:             toService(),
 		Port:           port(),
-		TLS:            tls(),
+		TLS:            tls(nil),
 		WildcardPolicy: wildcard(),
 	}
 	util.AddOwnerRef(route, util.OwnerRefFrom(cr))
 	return route
 }
 
-func Stub() *routev1.Route {
+func DefaultStub() *routev1.Route {
 	meta := util.SharedMeta()
 	return &routev1.Route{
 		ObjectMeta: meta,
 	}
 }
 
-// we can't just blindly apply the route, we need the route.Spec.Host
-// and we don't want to trigger a sync loop.
-// TODO: evaluate metadata.annotations to see what will affect our route in
-// an undesirable way:
-// - https://docs.openshift.com/container-platform/3.9/architecture/networking/routes.html#alternateBackends
-func Validate(route *routev1.Route) (*routev1.Route, bool) {
-	changed := false
-
-	if toServiceSame := equality.Semantic.DeepEqual(route.Spec.To, toService()); !toServiceSame {
-		changed = true
-		route.Spec.To = toService()
+func CustomRoute(cr *operatorv1.Console, tlsConfig *CustomTLSCert) *routev1.Route {
+	route := DefaultStub()
+	route.ObjectMeta.Name = api.OpenshiftConsoleCustomRouteName
+	route.Spec = routev1.RouteSpec{
+		Host:           cr.Spec.Route.Hostname,
+		To:             toService(),
+		Port:           port(),
+		TLS:            tls(tlsConfig),
+		WildcardPolicy: wildcard(),
 	}
-
-	if portSame := equality.Semantic.DeepEqual(route.Spec.Port, port()); !portSame {
-		changed = true
-		route.Spec.Port = port()
-	}
-
-	if tlsSame := equality.Semantic.DeepEqual(route.Spec.TLS, tls()); !tlsSame {
-		changed = true
-		route.Spec.TLS = tls()
-	}
-
-	if wildcardSame := equality.Semantic.DeepEqual(route.Spec.WildcardPolicy, wildcard()); !wildcardSame {
-		changed = true
-		route.Spec.WildcardPolicy = wildcard()
-	}
-
-	return route, changed
+	util.AddOwnerRef(route, util.OwnerRefFrom(cr))
+	return route
 }
 
 func routeMeta() metav1.ObjectMeta {
@@ -110,11 +129,16 @@ func port() *routev1.RoutePort {
 	}
 }
 
-func tls() *routev1.TLSConfig {
-	return &routev1.TLSConfig{
+func tls(tlsConfig *CustomTLSCert) *routev1.TLSConfig {
+	tls := &routev1.TLSConfig{
 		Termination:                   routev1.TLSTerminationReencrypt,
 		InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyRedirect,
 	}
+	if tlsConfig != nil {
+		tls.Certificate = tlsConfig.Certificate
+		tls.Key = tlsConfig.Key
+	}
+	return tls
 }
 
 func wildcard() routev1.WildcardPolicyType {
@@ -159,4 +183,13 @@ func isIngressAdmitted(ingress routev1.RouteIngress) bool {
 		}
 	}
 	return admitted
+}
+
+func IsCustomRouteSet(operatorConfig *operatorv1.Console) bool {
+	return len(operatorConfig.Spec.Route.Hostname) != 0
+}
+
+// Check if reference for secret holding custom TLS certificate and key is set
+func IsCustomRouteSecretSet(operatorConfig *operatorv1.Console) bool {
+	return len(operatorConfig.Spec.Route.Secret.Name) != 0
 }

--- a/pkg/console/subresource/route/route_test.go
+++ b/pkg/console/subresource/route/route_test.go
@@ -106,7 +106,7 @@ func TestStub(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if diff := deep.Equal(Stub(), tt.want); diff != nil {
+			if diff := deep.Equal(DefaultStub(), tt.want); diff != nil {
 				t.Error(diff)
 			}
 		})


### PR DESCRIPTION
Adding option do specify the custom hostname for console.
When when custom hostname is specified a new `console-custom` route is created. In case the new hostname doesnt contain the cluster domain as a suffix, secret reference needs to be specified, that points to the secret in the `openshift-config` namespace, where it needs to be created manually and contain **tls** cert and its key, which will serve as a **serving-cert** for the console pod. Also we will maintain the default route so it stays reserved for us.

/assign @benjaminapetersen 

API changes - https://github.com/openshift/api/pull/594