### PR TITLE
Bug 1826716: RBAC to authorise service account to list CRDs

### DIFF
--- a/manifests/03-rbac-role-cluster.yaml
+++ b/manifests/03-rbac-role-cluster.yaml
@@ -68,3 +68,17 @@ rules:
   - create
   - update
   - delete
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: console
+rules:
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch

--- a/manifests/04-rbac-rolebinding-cluster.yaml
+++ b/manifests/04-rbac-rolebinding-cluster.yaml
@@ -39,3 +39,18 @@ subjects:
   - kind: ServiceAccount
     name: console-operator
     namespace: openshift-console-operator
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: console
+roleRef:
+  # CRD lists are protected from unpriviledged users, access is
+  # granted to Service Account by this ClusterRole
+  kind: ClusterRole
+  name: console
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: console
+    namespace: openshift-console


### PR DESCRIPTION
https://issues.redhat.com/browse/ODC-3398

New endpoint is being added in console backend to list knative event source CRDs. 
Ref: https://github.com/openshift/console/pull/4945. 

In order to allow an unprivileged user to get this information without read access to CRDs, new RBAC has been added here to authorise service account to list CRDs.