### PR TITLE
Bug 1828272: Update 'Learning Portal' console helpMenu url to track where request it is coming from

### DIFF
--- a/manifests/09-console-link-openshift-learning-portal.yaml
+++ b/manifests/09-console-link-openshift-learning-portal.yaml
@@ -3,6 +3,6 @@ kind: ConsoleLink
 metadata:
   name: openshift-learning-portal
 spec:
-  href: 'https://learn.openshift.com/'
+  href: 'https://learn.openshift.com/?ref=webconsole'
   location: HelpMenu
   text: Learning Portal


### PR DESCRIPTION
Jan Kleinert
I'd like to append:
`?ref=webconsole`
That way we can filter for this traffic without stomping on any referral info