### PR TITLE
WIP Bug 1834852: Add make target to run operator with telepresence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store 
 .idea
 ./deploy
+telepresence.log
 
 # tools output reports into _output
 _output

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ include $(addprefix ./vendor/github.com/openshift/build-machinery-go/make/, \
     targets/openshift/deps-gomod.mk \
     targets/openshift/images.mk \
     targets/openshift/bindata.mk \
+    targets/openshift/operator/telepresence.mk \
 )
 
 # Run core verification and all self contained tests.
@@ -47,3 +48,8 @@ test-e2e:
 clean:
 	rm -rf $(OUT_DIR)
 .PHONY: clean
+
+# Configure the 'telepresence' target
+# See vendor/github.com/openshift/build-machinery-go/scripts/run-telepresence.sh for usage and configuration details
+export TP_DEPLOYMENT_YAML ?=./manifests/07-operator.yaml
+export TP_CMD_PATH ?=./cmd/console

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The console-operator installs and maintains the web console on a cluster.
 
 ## Run on a 4.0.0 Cluster
 
-The console operator is installed by default and will automatically maintain a console.  
+The console operator is installed by default and will automatically maintain a console.
 
 ## Development Setup
 
@@ -15,32 +15,32 @@ The console operator is installed by default and will automatically maintain a c
 
 ## Clone the Repo & Build Locally
 
-To avoid some of the standard quirks of `gopath`, the recommended way to clone and 
+To avoid some of the standard quirks of `gopath`, the recommended way to clone and
 work with this repository is to do the following:
 
 ### Cloning the Repo
 
-```bash 
+```bash
 # rather than ~/go for everything, provide separate gopaths
 mkdir $HOME/gopaths
-``` 
+```
 
 It is fine to have `~/gopaths` next to `~/go` if you have some legacy projects.
 
 Now, create a `dir` under `~gopaths` to hold the project:
 
-```bash 
-mkdir $HOME/gopaths/consoleoperator 
+```bash
+mkdir $HOME/gopaths/consoleoperator
 ```
 
-The name of this directory doesn't matter much, but the child directories are 
+The name of this directory doesn't matter much, but the child directories are
 important in order to install dependencies and build the project appropriately.
 
 An `src` and `bin` dir is expected:
 
-```bash 
+```bash
 mkdir $HOME/gopaths/consoleoperator/src
-mkdir $HOME/gopaths/consoleoperator/bin 
+mkdir $HOME/gopaths/consoleoperator/bin
 ```
 
 Then the familiar path for source code `src/github.com/openshift/console-operator`:
@@ -54,9 +54,9 @@ cd $HOME/gopaths/consoleoperator/src/github.com/openshift
 
 Now clone (or fork, then clone) into this directory:
 
-```bash 
-git clone git@github.com:openshift/console-operator.git 
-# or your fork 
+```bash
+git clone git@github.com:openshift/console-operator.git
+# or your fork
 git clone git@github.com:<your-fork>/console-operator.git
 ```
 
@@ -65,13 +65,13 @@ git clone git@github.com:<your-fork>/console-operator.git
 Note that we created `$HOME/gopaths`.  This implies that each project will have
 its own gopath, so you will need to set that while working:
 
-```bash 
+```bash
 export GOPATH=$HOME/gopaths/consoleoperator
-``` 
+```
 
 If you have multiple goprojects and don't want to fuss with maintaining this when
 you `cd` to different projects, give [this script](https://www.jtolio.com/2017/01/magic-gopath/)
-a try. It will add a command called `calc_gopath` to your `prompt_command` and 
+a try. It will add a command called `calc_gopath` to your `prompt_command` and
 set your gopath appropriately depending on the current working directory.
 
 (At some point `golang` will fix `$GOPATH` and this won't be necessary)
@@ -80,24 +80,24 @@ set your gopath appropriately depending on the current working directory.
 
 Running the `make` command will build the binary:
 
-```bash 
-make 
+```bash
+make
 ```
 
 The binary output will be:
 
-```bash 
+```bash
 ./_output/local/bin/<os>/<arch>/console
 ```
 
 You may want to add this to your path or symlink it:
 
-```bash 
+```bash
 # if your ~/bin is in your path:
-ln -s ./_output/local/bin/<os>/<arch>/console ~/bin/console 
+ln -s ./_output/local/bin/<os>/<arch>/console ~/bin/console
 ```
 
-However, it is no longer recommended to run the operator locally.  Instead, you 
+However, it is no longer recommended to run the operator locally.  Instead, you
 should be building a docker image and deploying it into a development cluster.
 Continue below for instructions to do this with a reasonable feedback loop.
 
@@ -105,15 +105,15 @@ Continue below for instructions to do this with a reasonable feedback loop.
 
 Test `gofmt` and other verification tools:
 
-```bash 
+```bash
 make verify
 ```
 
 Let `gofmt` automatically update your source:
 
-```bash 
+```bash
 gofmt -w ./pkg
-gofmt -w ./cmd 
+gofmt -w ./cmd
 ```
 
 ### Run Unit Tests
@@ -125,19 +125,19 @@ make test-unit
 It is suggested to run `integration` and `e2e` tests with CI.  This is automatic when opening a PR.
 
 
-### Development Against a 4.0 Dev Cluster 
+### Development Against a 4.0 Dev Cluster
 
-The approach here is to build & deploy your code in a new container on a development cluster.  Don't 
+The approach here is to build & deploy your code in a new container on a development cluster.  Don't
 be put off by the need to redeploy your container, this is intended to provide a quick feedback loop.
 
 #### Create a Cluster
 To develop features for the `console-operator`, you will need to run your code against a dev cluster.
-The `console-operator` expects to be running in a container.  It is difficult to fake a local 
-environment, and the debuggin experience is not like debugging a real container.  Instead, do the following 
+The `console-operator` expects to be running in a container.  It is difficult to fake a local
+environment, and the debuggin experience is not like debugging a real container.  Instead, do the following
 to set yourself up to build your binary & deploy a new container quickly and frequently.
 
-Visit [https://try.openshift.com/](https://try.openshift.com/), download the installer and create 
-a cluster.  [Instructions](https://cloud.openshift.com/clusters/install) (including pull secret) 
+Visit [https://try.openshift.com/](https://try.openshift.com/), download the installer and create
+a cluster.  [Instructions](https://cloud.openshift.com/clusters/install) (including pull secret)
 are maintained here.
 
 ```bash
@@ -147,7 +147,7 @@ mkdir ~/openshift/aws/us-east
 cd ~/openshift/aws/us-east
 # generate configs using the wizard
 openshift-install create install-config
-# then run the installer to get a cluster 
+# then run the installer to get a cluster
 openshift-install create cluster --dir ~/openshift/aws/us-east --log-level debug
 ```
 
@@ -155,7 +155,7 @@ If successful, you should have gotten instructions to set `KUBECONFIG`, login to
 
 #### Shut down CVO & the Default Console Operator
 
-We don't want the default `console-operator` to run if we are going to test our own. Therefore, do 
+We don't want the default `console-operator` to run if we are going to test our own. Therefore, do
 the following:
 
 ```bash
@@ -163,7 +163,7 @@ the following:
 # CVO's job is to ensure all of the operators are functioning correctly
 # if we want to make changes to the operator, we need to tell CVO to stop caring.
 oc apply -f examples/cvo-unmanage-operator.yaml
-# Then, scale down the default console-operator 
+# Then, scale down the default console-operator
 oc scale --replicas 0 deployment console-operator --namespace openshift-console-operator
 ```
 Note that you can also simply delete the CVO namespace if you want to turn it off completely (for all operators).
@@ -185,7 +185,7 @@ make build-cross
 But the `make` step is included in the `Dockerfile`, so this does not need to be done manually.
 You can instead simply build the container image and push the it to your own registry:
 
-```bash 
+```bash
 # the pattern is:
 docker build -t <registry>/<your-username>/console-operator:<version> .
 # following: docker.io/openshift/origin-console-operator:latest
@@ -197,7 +197,7 @@ You can optionally build a specific version.
 
 Then, push your image:
 
-```bash 
+```bash
 docker push <registry>/<your-username>/console-operator:<version>
 # Be sure your repository is public else the image will not be able to be pulled later
 docker push quay.io/benjaminapetersen/console-operator:latest
@@ -216,20 +216,20 @@ Then, update the image & replicas in your `07-operator-alt-image.yaml` file:
 # before
 replicas: 2
 image: docker.io/openshift/origin-console-operator:latest
-# after 
+# after
 # image: <registry>/<your-username>/console-operator:<version>
 replicas: 1
 image: quay.io/benjaminapetersen/console-operator:latest
 ```
-And ensure that the `imagePullPolicy` is still `Always`.  This will ensure a fast development feedback loop. 
+And ensure that the `imagePullPolicy` is still `Always`.  This will ensure a fast development feedback loop.
 
 ```yaml
 imagePullPolicy: Always
 ```
 
-#### Deploying 
+#### Deploying
 
-At this point, your pattern will be 
+At this point, your pattern will be
 
 - Change code
 - Build a new docker image
@@ -254,7 +254,7 @@ Docker containers are layered, so there should not be a significant time delay i
 
 If you are making changes to the manifests, you will need to `oc apply` the manifest.
 
-#### Debugging 
+#### Debugging
 
 ```bash
 # inspect the clusteroperator object
@@ -275,11 +275,11 @@ oc logs -f console-operator-<sha> -n openshift-console-operator
 
 If you don't know where your `kubeconfig` is due to running against multiple clusters this can be handy:
 
-```bash 
+```bash
 # just a high number
 oc whoami --loglevel=100
-# likely output will be $HOME/.kube/config 
-``` 
+# likely output will be $HOME/.kube/config
+```
 If you need to know information about your cluster:
 
 ```bash
@@ -289,12 +289,5 @@ oc adm release info --commits
 # get just the list of images & sha256 digest
 oc adm release info
 # coming soon...
-oc adm release extract 
+oc adm release extract
 ```
-
-
-
-
-
-
-

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-test/deep v1.0.5
 	github.com/openshift/api v0.0.0-20200429152225-b98a784d8e6d
-	github.com/openshift/build-machinery-go v0.0.0-20200424080330-082bf86082cc
+	github.com/openshift/build-machinery-go v0.0.0-20200512074546-3744767c4131
 	github.com/openshift/client-go v0.0.0-20200422192633-6f6c07fc2a70
 	github.com/openshift/library-go v0.0.0-20200429122220-9e6c27e916a0
 	github.com/pkg/profile v1.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -287,10 +287,10 @@ github.com/openshift/api v0.0.0-20200424083944-0422dc17083e h1:VDcwVyMEVbLyekLmt
 github.com/openshift/api v0.0.0-20200424083944-0422dc17083e/go.mod h1:VnbEzX8SAaRj7Yfl836NykdQIlbEjfL6/CD+AaJQg5Q=
 github.com/openshift/api v0.0.0-20200429152225-b98a784d8e6d h1:E6wmob+4UwmxOWf/yA26q2PTBtLdAjo/aY5gAUfGS+E=
 github.com/openshift/api v0.0.0-20200429152225-b98a784d8e6d/go.mod h1:VnbEzX8SAaRj7Yfl836NykdQIlbEjfL6/CD+AaJQg5Q=
-github.com/openshift/build-machinery-go v0.0.0-20200211121458-5e3d6e570160 h1:V4E6yt4XWiBEPKnJbs/E8pgUq9AjZqzQfsL3eeT84Qs=
 github.com/openshift/build-machinery-go v0.0.0-20200211121458-5e3d6e570160/go.mod h1:1CkcsT3aVebzRBzVTSbiKSkJMsC/CASqxesfqEMfJEc=
-github.com/openshift/build-machinery-go v0.0.0-20200424080330-082bf86082cc h1:Bu1p7+ItPqhJhmMve7sVluKCYV+o+x1Ede0WY2/BI8Q=
 github.com/openshift/build-machinery-go v0.0.0-20200424080330-082bf86082cc/go.mod h1:1CkcsT3aVebzRBzVTSbiKSkJMsC/CASqxesfqEMfJEc=
+github.com/openshift/build-machinery-go v0.0.0-20200512074546-3744767c4131 h1:JW0jMasT83C7ZYEYXpCH7bfwqE/QqyOJwGB7u6N3/X0=
+github.com/openshift/build-machinery-go v0.0.0-20200512074546-3744767c4131/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20200326155132-2a6cd50aedd0 h1:kMiuiZXH1GdfbiMwsuAQOqGaMxlo9NCUk0wT4XAdfNM=
 github.com/openshift/client-go v0.0.0-20200326155132-2a6cd50aedd0/go.mod h1:uUQ4LClRO+fg5MF/P6QxjMCb1C9f7Oh4RKepftDnEJE=
 github.com/openshift/client-go v0.0.0-20200422192633-6f6c07fc2a70 h1:LvJxSt/lnLTBbKJC5DfWM9ZvT9Jk0nQa+xPozSJtkqc=

--- a/vendor/github.com/openshift/api/config/v1/0000_10_config-operator_01_oauth.crd.yaml
+++ b/vendor/github.com/openshift/api/config/v1/0000_10_config-operator_01_oauth.crd.yaml
@@ -637,17 +637,8 @@ spec:
               type: object
               properties:
                 accessTokenInactivityTimeoutSeconds:
-                  description: 'accessTokenInactivityTimeoutSeconds defines the default
-                    token inactivity timeout for tokens granted by any client. The
-                    value represents the maximum amount of time that can occur between
-                    consecutive uses of the token. Tokens become invalid if they are
-                    not used within this temporal window. The user will need to acquire
-                    a new token to regain access once a token times out. Valid values
-                    are integer values:   x < 0  Tokens time out is enabled but tokens
-                    never timeout unless configured per client (e.g. `-1`)   x = 0  Tokens
-                    time out is disabled (default)   x > 0  Tokens time out if there
-                    is no activity for x seconds The current minimum allowed value
-                    for X is 300 (5 minutes)'
+                  description: 'accessTokenInactivityTimeoutSeconds - DEPRECATED:
+                    setting this field has no effect.'
                   type: integer
                   format: int32
                 accessTokenMaxAgeSeconds:

--- a/vendor/github.com/openshift/api/config/v1/types_oauth.go
+++ b/vendor/github.com/openshift/api/config/v1/types_oauth.go
@@ -47,17 +47,7 @@ type TokenConfig struct {
 	// accessTokenMaxAgeSeconds defines the maximum age of access tokens
 	AccessTokenMaxAgeSeconds int32 `json:"accessTokenMaxAgeSeconds"`
 
-	// accessTokenInactivityTimeoutSeconds defines the default token
-	// inactivity timeout for tokens granted by any client.
-	// The value represents the maximum amount of time that can occur between
-	// consecutive uses of the token. Tokens become invalid if they are not
-	// used within this temporal window. The user will need to acquire a new
-	// token to regain access once a token times out.
-	// Valid values are integer values:
-	//   x < 0  Tokens time out is enabled but tokens never timeout unless configured per client (e.g. `-1`)
-	//   x = 0  Tokens time out is disabled (default)
-	//   x > 0  Tokens time out if there is no activity for x seconds
-	// The current minimum allowed value for X is 300 (5 minutes)
+	// accessTokenInactivityTimeoutSeconds - DEPRECATED: setting this field has no effect.
 	// +optional
 	AccessTokenInactivityTimeoutSeconds int32 `json:"accessTokenInactivityTimeoutSeconds,omitempty"`
 }

--- a/vendor/github.com/openshift/api/config/v1/zz_generated.swagger_doc_generated.go
+++ b/vendor/github.com/openshift/api/config/v1/zz_generated.swagger_doc_generated.go
@@ -1208,7 +1208,7 @@ func (RequestHeaderIdentityProvider) SwaggerDoc() map[string]string {
 var map_TokenConfig = map[string]string{
 	"":                                    "TokenConfig holds the necessary configuration options for authorization and access tokens",
 	"accessTokenMaxAgeSeconds":            "accessTokenMaxAgeSeconds defines the maximum age of access tokens",
-	"accessTokenInactivityTimeoutSeconds": "accessTokenInactivityTimeoutSeconds defines the default token inactivity timeout for tokens granted by any client. The value represents the maximum amount of time that can occur between consecutive uses of the token. Tokens become invalid if they are not used within this temporal window. The user will need to acquire a new token to regain access once a token times out. Valid values are integer values:\n  x < 0  Tokens time out is enabled but tokens never timeout unless configured per client (e.g. `-1`)\n  x = 0  Tokens time out is disabled (default)\n  x > 0  Tokens time out if there is no activity for x seconds\nThe current minimum allowed value for X is 300 (5 minutes)",
+	"accessTokenInactivityTimeoutSeconds": "accessTokenInactivityTimeoutSeconds - DEPRECATED: setting this field has no effect.",
 }
 
 func (TokenConfig) SwaggerDoc() map[string]string {

--- a/vendor/github.com/openshift/build-machinery-go/go.mod
+++ b/vendor/github.com/openshift/build-machinery-go/go.mod
@@ -1,0 +1,3 @@
+module github.com/openshift/build-machinery-go
+
+go 1.13

--- a/vendor/github.com/openshift/build-machinery-go/make/operator.example.mk.help.log
+++ b/vendor/github.com/openshift/build-machinery-go/make/operator.example.mk.help.log
@@ -6,6 +6,7 @@ clean-binaries
 help
 image-ocp-openshift-apiserver-operator
 images
+telepresence
 test
 test-unit
 update

--- a/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/operator/telepresence.mk
+++ b/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/operator/telepresence.mk
@@ -1,0 +1,12 @@
+self_dir :=$(dir $(lastword $(MAKEFILE_LIST)))
+scripts_dir :=$(shell realpath $(self_dir)../../../../scripts)
+
+telepresence:
+	$(info Running operator locally against a remote cluster using telepresence (https://telepresence.io))
+	$(info )
+	$(info To override the operator log level, set TP_VERBOSITY=<log level>)
+	$(info To debug the operator, set TP_DEBUG=y (requires the delve debugger))
+	$(info See the run-telepresence.sh script for more usage and configuration details)
+	$(info )
+	bash $(scripts_dir)/run-telepresence.sh
+.PHONY: telepresence

--- a/vendor/github.com/openshift/build-machinery-go/scripts/run-telepresence.sh
+++ b/vendor/github.com/openshift/build-machinery-go/scripts/run-telepresence.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# This script executes telepresence against an operator deployment.
+#
+#   KUBECONFIG=... TP_DEPLOYMENT_YAML=... TP_CMD_PATH=... run-telepresence.sh
+#
+# The script is parameterized by env vars prefixed with 'TP_'.
+#
+# Dependencies:
+#
+# - oc
+# - jq (fedora: dnf install jq; macos: brew install jq)
+# - telepresence (https://www.telepresence.io/reference/install)
+#   - >= 0.105 is compatible with OCP
+# - delve (go get github.com/go-delve/delve/cmd/dlv)
+
+KUBECONFIG="${KUBECONFIG:-}"
+if [[ "${KUBECONFIG}" == "" ]]; then
+  >&2 echo "KUBECONFIG is not set"
+  exit 1
+fi
+
+# The yaml defining the operator's deployment resource. Will be parsed
+# for configuration like resource name, namespace, and command.
+TP_DEPLOYMENT_YAML="${TP_DEPLOYMENT_YAML:-}"
+if [[ ! "${TP_DEPLOYMENT_YAML}" ]]; then
+  >&2 echo "TP_DEPLOYMENT_YAML is not set"
+  exit 1
+fi
+
+# The path to the golang package to run or debug
+# (e.g. `/my/project/cmd/operator`)
+TP_CMD_PATH="${TP_CMD_PATH:-}"
+if [[ ! "${TP_CMD_PATH}" ]]; then
+  >&2 echo "TP_CMD_PATH is not set"
+  exit 1
+fi
+
+# By default the operator will be run via 'go run'. Providing TP_DEBUG=y
+# will run `dlv debug` instead.
+TP_DEBUG="${TP_DEBUG:-}"
+
+# Whether to add an entry in /etc/hosts for the api server host. This
+# is necessary if targeting a cluster deployed in aws.
+TP_ADD_AWS_HOST_ENTRY="${TP_ADD_AWS_HOST_ENTRY:-y}"
+
+# The arguments for the command that will be executed will be parsed
+# from the deployment by default, but can be overridden by setting
+# this var. The name of the command itself is implicitly determined by
+# `go run` or `dlv debug` from TP_CMD_PATH.
+TP_CMD_ARGS="${TP_CMD_ARGS:-}"
+
+# Will add a -v=<value> argument to the command to set the logging
+# verbosity. If a verbosity argument was already supplied, this value
+# will override it.
+TP_VERBOSITY="${TP_VERBOSITY:-}"
+
+# The command telepresence should run in the local deployment
+# environment. By default it will run or debug the operator but it can
+# be useful to run a shell (e.g. `bash`) for troubleshooting.
+TP_RUN_CMD="${TP_RUN_CMD:-}"
+if [[ ! "${TP_RUN_CMD}" ]]; then
+  # Default to a recursive call
+  TP_RUN_CMD="${0}"
+  if [[ ! -x "${TP_RUN_CMD}" ]]; then
+    # Prefix the recursive call with bash if the script is not
+    # executable as will be the case when build-machinery-go is
+    # vendored.
+    TP_RUN_CMD="bash ${TP_RUN_CMD}"
+  fi
+fi
+
+# Whether this script should run telepresence or is being run by
+# telepresence. Used as an internal control var, not necessary to set
+# manually.
+_TP_INTERNAL_RUN="${_TP_INTERNAL_RUN:-}"
+
+# Some operators (e.g. auth operator) specify build flags to generate
+# different binaries for ocp or okd.
+TP_BUILD_FLAGS="${TP_BUILD_FLAGS:-}"
+
+# Simplify querying the deployment yaml with jq
+function jq_deployment () {
+  local jq_arg="${1}"
+  cat "${TP_DEPLOYMENT_YAML}"\
+    | python -c 'import json, sys, yaml ; y=yaml.safe_load(sys.stdin.read()) ; print(json.dumps(y))'\
+    | jq -r "${jq_arg}"
+}
+
+NAMESPACE="$(jq_deployment '.metadata.namespace')"
+NAME="$(jq_deployment '.metadata.name')"
+
+# If not provided, the lock configmap will be defaulted to the name of
+# the deployment suffixed by `-lock`.
+TP_LOCK_CONFIGMAP="${TP_LOCK_CONFIGMAP:-${NAME}-lock}"
+
+if [ "${_TP_INTERNAL_RUN}" ]; then
+  # Delete the leader election lock to ensure that the local process
+  # becomes the leader as quickly as possible.
+  oc delete configmap "${TP_LOCK_CONFIGMAP}" --namespace "${NAMESPACE}" --ignore-not-found=true
+
+  if [[ ! "${TP_CMD_ARGS}" ]]; then
+    # Parse the arguments from the deployment
+    TP_CMD_ARGS="$(jq_deployment '.spec.template.spec.containers[0].command[1:] | join(" ")' )"
+    TP_CMD_ARGS+=" $(jq_deployment '.spec.template.spec.containers[0].args | join(" ")' )"
+  fi
+
+  if [[ "${TP_VERBOSITY}" ]]; then
+    # Setting log level last ensures that any existing -v argument will be overridden.
+    TP_CMD_ARGS+=" -v=${TP_VERBOSITY}"
+  fi
+
+  pushd "${TP_CMD_PATH}" > /dev/null
+    if [[ "${TP_DEBUG}" ]]; then
+      if [[ "${TP_BUILD_FLAGS}" ]]; then
+        TP_BUILD_FLAGS="--build-flags=${TP_BUILD_FLAGS}"
+      fi
+      dlv debug ${TP_BUILD_FLAGS} -- ${TP_CMD_ARGS}
+    else
+      go run ${TP_BUILD_FLAGS} . ${TP_CMD_ARGS}
+    fi
+  popd > /dev/null
+else
+  if [[ "${TP_ADD_AWS_HOST_ENTRY}" ]]; then
+    # Add an entry in /etc/hosts for the api endpoint in the configured
+    # KUBECONFIG (which is assumed to have at most one server).
+    #
+    # This supports using telepresence with kube clusters running in
+    # aws. telepresence will proxy dns requests to the cluster and will
+    # return an internal aws address for the api endpoint otherwise.
+    SERVER_HOST="$(grep server "${KUBECONFIG}" | sed -e 's+    server: https://\(.*\):.*+\1+')"
+    SERVER_IP="$(dig "${SERVER_HOST}" +short | head -n 1)"
+    ENTRY="${SERVER_IP} ${SERVER_HOST}"
+    if ! grep "${ENTRY}" /etc/hosts > /dev/null; then
+      >&2 echo "Attempting to add '${ENTRY}' to /etc/hosts to ensure access to an aws cluster. This requires sudo."
+      >&2 echo "If this cluster is not in aws, specify TP_ADD_AWS_HOST_ENTRY="
+      grep -q "${SERVER_HOST}" /etc/hosts && \
+        (cp -f /etc/hosts /tmp/etc-hosts && \
+           sed -i 's+.*'"${SERVER_HOST}"'$+'"${ENTRY}"'+' /tmp/etc-hosts && \
+           sudo cp /tmp/etc-hosts /etc/hosts)\
+          || echo "${ENTRY}" | sudo tee -a /etc/hosts > /dev/null
+    fi
+  fi
+
+  # Ensure pod volumes are symlinked to the expected location
+  if [[ ! -L '/var/run/configmaps' ]]; then
+     >&2 echo "Attempting to symlink /tmp/tel_root/var/run/configmaps to /var/run/configmaps. This requires sudo."
+     sudo ln -s /tmp/tel_root/var/run/configmaps /var/run/configmaps
+  fi
+  if [[ ! -L '/var/run/secrets' ]]; then
+    >&2 echo "Attempting to symlink /tmp/tel_root/var/run/secrets to /var/run/secrets. This requires sudo."
+    sudo ln -s /tmp/tel_root/var/run/secrets /var/run/secrets
+  fi
+
+  KIND="$(jq_deployment '.kind')"
+  GROUP="$(jq_deployment '.apiVersion')"
+
+  # Ensure the operator is not managed by CVO
+  oc patch clusterversion/version --type='merge' -p "$(cat <<- EOF
+spec:
+  overrides:
+  - group: ${GROUP}
+    kind: ${KIND}
+    name: ${NAME}
+    namespace: ${NAMESPACE}
+    unmanaged: true
+EOF
+)"
+
+  # Ensure the operator is managed again on shutdown
+  function cleanup {
+    oc patch clusterversion/version --type='merge' -p "$(cat <<- EOF
+spec:
+  overrides:
+  - group: ${GROUP}
+    kind: ${KIND}
+    name: ${NAME}
+    namespace: ${NAMESPACE}
+    unmanaged: false
+EOF
+)"
+  }
+  trap cleanup EXIT
+
+  # Ensure that traffic for all machines in the cluster is also
+  # proxied so that the local operator will be able to access them.
+  ALSO_PROXY="$(oc get machines -A -o json | jq -jr '.items[] | .status.addresses[0].address | @text "--also-proxy=\(.) "')"
+
+  TELEPRESENCE_USE_OCP_IMAGE=NO _TP_INTERNAL_RUN=y telepresence --namespace="${NAMESPACE}"\
+    --swap-deployment "${NAME}" ${ALSO_PROXY} --mount=/tmp/tel_root --run ${TP_RUN_CMD}
+fi

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -88,7 +88,7 @@ github.com/modern-go/concurrent
 github.com/modern-go/reflect2
 # github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
 github.com/munnerz/goautoneg
-# github.com/openshift/api v0.0.0-20200424083944-0422dc17083e
+# github.com/openshift/api v0.0.0-20200429152225-b98a784d8e6d
 github.com/openshift/api
 github.com/openshift/api/apps
 github.com/openshift/api/apps/v1
@@ -136,7 +136,7 @@ github.com/openshift/api/template
 github.com/openshift/api/template/v1
 github.com/openshift/api/user
 github.com/openshift/api/user/v1
-# github.com/openshift/build-machinery-go v0.0.0-20200424080330-082bf86082cc
+# github.com/openshift/build-machinery-go v0.0.0-20200512074546-3744767c4131
 github.com/openshift/build-machinery-go
 github.com/openshift/build-machinery-go/make
 github.com/openshift/build-machinery-go/make/lib
@@ -145,7 +145,7 @@ github.com/openshift/build-machinery-go/make/targets/golang
 github.com/openshift/build-machinery-go/make/targets/openshift
 github.com/openshift/build-machinery-go/make/targets/openshift/operator
 github.com/openshift/build-machinery-go/scripts
-# github.com/openshift/client-go v0.0.0-20200326155132-2a6cd50aedd0
+# github.com/openshift/client-go v0.0.0-20200422192633-6f6c07fc2a70
 github.com/openshift/client-go/config/clientset/versioned
 github.com/openshift/client-go/config/clientset/versioned/scheme
 github.com/openshift/client-go/config/clientset/versioned/typed/config/v1


### PR DESCRIPTION
Once telepresence has been installed (see the run-telepresence.sh script for instructions), `make telepresence` will replace the operator's pod with a local process that has access to the same environment as the pod. This can speed up development since iteration doesn't rely on image build/push/pull. See https://telepresence.io for more details.

