### PR TITLE
Bug 1833465: Updating operator status - cleanUp

### DIFF
--- a/pkg/console/operator/sync_v400.go
+++ b/pkg/console/operator/sync_v400.go
@@ -123,7 +123,7 @@ func (co *consoleOperator) sync_v400(updatedOperatorConfig *operatorv1.Console, 
 		return statusHandler.FlushAndReturn(depErr)
 	}
 
-	statusHandler.UpdateDeploymentsLastGeneration(actualDeployment)
+	statusHandler.UpdateDeploymentGeneration(actualDeployment)
 	statusHandler.UpdateReadyReplicas(actualDeployment.Status.ReadyReplicas)
 	statusHandler.UpdateObservedGeneration(set.Operator.ObjectMeta.Generation)
 
@@ -467,14 +467,6 @@ func (co *consoleOperator) ValidateCustomLogo(operatorConfig *operatorv1.Console
 
 	klog.V(4).Infoln("custom logo ok to mount")
 	return true, "", nil
-}
-
-func getDeploymentGeneration(co *consoleOperator) int64 {
-	deployment, err := co.deploymentClient.Deployments(api.TargetNamespace).Get(co.ctx, deploymentsub.Stub().Name, metav1.GetOptions{})
-	if err != nil {
-		return -1
-	}
-	return deployment.Generation
 }
 
 func getConsoleURL(route *routev1.Route) string {

--- a/pkg/console/status/status.go
+++ b/pkg/console/status/status.go
@@ -141,7 +141,7 @@ func (c *StatusHandler) UpdateReadyReplicas(newReadyReplicas int32) {
 	c.statusFuncs = append(c.statusFuncs, generationFunc)
 }
 
-func (c *StatusHandler) UpdateDeploymentsLastGeneration(actualDeployment *appsv1.Deployment) {
+func (c *StatusHandler) UpdateDeploymentGeneration(actualDeployment *appsv1.Deployment) {
 	generationFunc := func(oldStatus *operatorsv1.OperatorStatus) error {
 		resourcemerge.SetDeploymentGeneration(&oldStatus.Generations, actualDeployment)
 		return nil


### PR DESCRIPTION
Items:
- remove unused `getDeploymentGeneration()`
- use library-go's SetDeploymentGeneration - already done in https://github.com/openshift/console-operator/pull/424 by adding `status.UpdateDeploymentGeneration()`
- do not ignore errors when we flush status https://github.com/openshift/console-operator/pull/424#discussion_r421744310 - taken care in https://github.com/openshift/console-operator/pull/424

@benjaminapetersen not sure if other refact/cleanUp is needed at this point. We can go through it..

PTAL