### PR TITLE
Bug 1834222: Check for custom console route hostname not to be the same as the default route

### DIFF
--- a/pkg/console/controllers/route/controller_test.go
+++ b/pkg/console/controllers/route/controller_test.go
@@ -200,3 +200,29 @@ func TestValidateCustomCertSecret(t *testing.T) {
 		})
 	}
 }
+
+func TestGetDefaultRouteHost(t *testing.T) {
+	type args struct {
+		ingressDomain string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "Test assembling linux amd64 specific URL",
+			args: args{
+				ingressDomain: "apps.devcluster.openshift.com",
+			},
+			want: "console-openshift-console.apps.devcluster.openshift.com",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if diff := deep.Equal(GetDefaultRouteHost(tt.args.ingressDomain), tt.want); diff != nil {
+				t.Error(diff)
+			}
+		})
+	}
+}

--- a/pkg/console/subresource/route/route.go
+++ b/pkg/console/subresource/route/route.go
@@ -59,23 +59,6 @@ func ApplyRoute(client routeclient.RoutesGetter, recorder events.Recorder, requi
 	return actual, true, err
 }
 
-// ensures route exists.
-// handles 404 with a create
-// returns any other error
-func GetOrCreate(ctx context.Context, client routeclient.RoutesGetter, required *routev1.Route) (*routev1.Route, bool, error) {
-	isNew := false
-	route, err := client.Routes(required.Namespace).Get(ctx, required.Name, metav1.GetOptions{})
-	if apierrors.IsNotFound(err) {
-		isNew = true
-		route, err = client.Routes(required.Namespace).Create(ctx, required, metav1.CreateOptions{})
-	}
-
-	if err != nil {
-		return nil, isNew, err
-	}
-	return route, isNew, nil
-}
-
 // Default `console` route points by default to the `console` service.
 // If custom hostname for the console is set, then the default route
 // should point to the redirect `console-redirect` service and the


### PR DESCRIPTION
We should try to sync the custom route before the default one to prevent any unwanted states in which the console could become inaccessible.

Condition screen:
<img width="1072" alt="Screenshot 2020-05-11 at 13 02 33" src="https://user-images.githubusercontent.com/1668218/81555296-a1f14380-9388-11ea-95d0-728bb27f40a0.png">


/assign @benjaminapetersen 