### PR TITLE
Bug 1835221: Sync loop should error out on resources that depend on route that is not admitted

### DIFF
--- a/pkg/console/controllers/route/controller.go
+++ b/pkg/console/controllers/route/controller.go
@@ -34,7 +34,6 @@ import (
 
 	// console-operator
 	"github.com/openshift/console-operator/pkg/api"
-	customerrors "github.com/openshift/console-operator/pkg/console/errors"
 	"github.com/openshift/console-operator/pkg/console/status"
 	routesub "github.com/openshift/console-operator/pkg/console/subresource/route"
 )
@@ -182,8 +181,8 @@ func (c *RouteSyncController) SyncDefaultRoute(operatorConfig *operatorsv1.Conso
 		return nil, "FailedDefaultRouteApply", defaultRouteError
 	}
 
-	if len(routesub.GetCanonicalHost(defaultRoute)) == 0 {
-		return nil, "FailedDefaultRouteHost", customerrors.NewSyncError(fmt.Sprintf("default route is not available at canonical host %s", defaultRoute.Status.Ingress))
+	if _, defaultRouteError = routesub.GetCanonicalHost(defaultRoute); defaultRouteError != nil {
+		return nil, "FailedAdmitDefaultRoute", defaultRouteError
 	}
 
 	return defaultRoute, "", defaultRouteError
@@ -218,8 +217,8 @@ func (c *RouteSyncController) SyncCustomRoute(operatorConfig *operatorsv1.Consol
 		return nil, "FailedCustomRouteApply", customRouteError
 	}
 
-	if len(routesub.GetCanonicalHost(customRoute)) == 0 {
-		return nil, "FailedCustomRouteHost", customerrors.NewSyncError(fmt.Sprintf("custom route is not available at canonical host %s", customRoute.Status.Ingress))
+	if _, customRouteError = routesub.GetCanonicalHost(customRoute); customRouteError != nil {
+		return nil, "FailedAdmitCustomRoute", customRouteError
 	}
 
 	return customRoute, "", customRouteError

--- a/pkg/console/subresource/route/route_test.go
+++ b/pkg/console/subresource/route/route_test.go
@@ -1,6 +1,7 @@
 package route
 
 import (
+	"fmt"
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
@@ -13,6 +14,7 @@ import (
 	operatorv1 "github.com/openshift/api/operator/v1"
 	routev1 "github.com/openshift/api/route/v1"
 	"github.com/openshift/console-operator/pkg/api"
+	customerrors "github.com/openshift/console-operator/pkg/console/errors"
 )
 
 const (
@@ -254,6 +256,117 @@ func TestStub(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if diff := deep.Equal(DefaultStub(), tt.want); diff != nil {
+				t.Error(diff)
+			}
+		})
+	}
+}
+
+func TestGetCanonicalHost(t *testing.T) {
+	var (
+		validHost = "validhost.com"
+
+		customControllerIngress = []routev1.RouteIngress{
+			{
+				Host:       validHost,
+				RouterName: "custom",
+				Conditions: []routev1.RouteIngressCondition{{
+					Type:   routev1.RouteAdmitted,
+					Status: v1.ConditionTrue,
+				}},
+			},
+		}
+		notAdmittedIngress = []routev1.RouteIngress{
+			{
+				Host:       validHost,
+				RouterName: "default",
+				Conditions: []routev1.RouteIngressCondition{{
+					Type:   routev1.RouteAdmitted,
+					Status: v1.ConditionFalse,
+				}},
+			},
+		}
+	)
+	type args struct {
+		route *routev1.Route
+	}
+	type want struct {
+		host string
+		err  error
+	}
+	tests := []struct {
+		name string
+		args args
+		want want
+	}{
+		{
+			name: "Test admitted route with default controller",
+			args: args{
+				route: &routev1.Route{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: api.OpenShiftConsoleRouteName,
+					},
+					Status: routev1.RouteStatus{
+						Ingress: []routev1.RouteIngress{
+							{
+								Host:       validHost,
+								RouterName: "default",
+								Conditions: []routev1.RouteIngressCondition{{
+									Type:   routev1.RouteAdmitted,
+									Status: v1.ConditionTrue,
+								}},
+							},
+						},
+					},
+				},
+			},
+			want: want{
+				host: "validhost.com",
+				err:  nil,
+			},
+		},
+		{
+			name: "Test admitted route with custom controller",
+			args: args{
+				route: &routev1.Route{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: api.OpenShiftConsoleRouteName,
+					},
+					Status: routev1.RouteStatus{
+						Ingress: customControllerIngress,
+					},
+				},
+			},
+			want: want{
+				host: "",
+				err:  customerrors.NewSyncError(fmt.Sprintf("route %q is not available at canonical host %s", api.OpenShiftConsoleRouteName, customControllerIngress)),
+			},
+		},
+		{
+			name: "Test not admitted route with default controller",
+			args: args{
+				route: &routev1.Route{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: api.OpenShiftConsoleRouteName,
+					},
+					Status: routev1.RouteStatus{
+						Ingress: notAdmittedIngress,
+					},
+				},
+			},
+			want: want{
+				host: "",
+				err:  customerrors.NewSyncError(fmt.Sprintf("route %q is not available at canonical host %s", api.OpenShiftConsoleRouteName, notAdmittedIngress)),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			host, err := GetCanonicalHost(tt.args.route)
+			if diff := deep.Equal(host, tt.want.host); diff != nil {
+				t.Error(diff)
+			}
+			if diff := deep.Equal(err, tt.want.err); diff != nil {
 				t.Error(diff)
 			}
 		})

--- a/test/e2e/downloads_test.go
+++ b/test/e2e/downloads_test.go
@@ -30,7 +30,10 @@ func TestDownloadsEndpoint(t *testing.T) {
 	if err != nil {
 		t.Fatalf("could not get route: %s", err)
 	}
-	host := routesub.GetCanonicalHost(route)
+	host, err := routesub.GetCanonicalHost(route)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	ocDownloads := clidownloads.PlatformBasedOCConsoleCLIDownloads(host, api.OCCLIDownloadsCustomResourceName)
 


### PR DESCRIPTION
This basically refacts a bit the `GetCanonicalHost` function and adds unit test for it.

/assign @benjaminapetersen 