### PR TITLE
Bug 1835337: Update CLI download page text for odo

### DIFF
--- a/pkg/console/controllers/clidownloads/controller.go
+++ b/pkg/console/controllers/clidownloads/controller.go
@@ -204,7 +204,7 @@ func ODOConsoleCLIDownloads() *v1.ConsoleCLIDownload {
 			Name: api.ODOCLIDownloadsCustomResourceName,
 		},
 		Spec: v1.ConsoleCLIDownloadSpec{
-			Description: `OpenShift Do (odo) is a fast, iterative, and straightforward CLI tool for developers who write, build, and deploy applications on OpenShift.
+			Description: `odo is a fast, iterative, and straightforward CLI tool for developers who write, build, and deploy applications on OpenShift.
 
 odo abstracts away complex Kubernetes and OpenShift concepts, thus allowing developers to focus on what is most important to them: code.
 `,


### PR DESCRIPTION
Fixes - https://issues.redhat.com/browse/ODC-3459

Updates in this PR -
- Changes the CLI download page text odo and removes `OpenShift Do` as we are moving away from calling odo "OpenShift Do".