### PR TITLE
Bug 1835551: Inject proxy envars to console-operator deployment

### DIFF
--- a/manifests/07-operator.yaml
+++ b/manifests/07-operator.yaml
@@ -3,6 +3,8 @@ kind: Deployment
 metadata:
   name: console-operator
   namespace: openshift-console-operator
+  annotations:
+    config.openshift.io/inject-proxy: console-operator
 spec:
   replicas: 1
   selector:

--- a/pkg/console/controllers/route/controller.go
+++ b/pkg/console/controllers/route/controller.go
@@ -437,6 +437,7 @@ func clientWithCA(caPool *x509.CertPool) *http.Client {
 	return &http.Client{
 		Timeout: 5 * time.Second,
 		Transport: &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
 			TLSClientConfig: &tls.Config{
 				RootCAs: caPool,
 			},


### PR DESCRIPTION
not sure if we should not backport to 4.4 ?

/assign @benjaminapetersen 