### PR TITLE
Bug 1839621: Grant Console SA permissions to read webhooks configurations

### DIFF
--- a/manifests/03-rbac-role-cluster.yaml
+++ b/manifests/03-rbac-role-cluster.yaml
@@ -89,4 +89,3 @@ rules:
   - validatingwebhookconfigurations
   verbs:
   - get
-  - watch

--- a/manifests/03-rbac-role-cluster.yaml
+++ b/manifests/03-rbac-role-cluster.yaml
@@ -82,3 +82,11 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - mutatingwebhookconfigurations
+  - validatingwebhookconfigurations
+  verbs:
+  - get
+  - watch


### PR DESCRIPTION
This PR grants Console SA permissions to read webhooks configurations to check if the terminal operator is correctly installed.

It's needed for https://github.com/openshift/console/pull/5332

Now we try to figure out what is the right way to detect operator installed, like check deployment in openshift-operators, or ClusterServiceVersion, ... So, probably permissions list here will be extended