### PR TITLE
Bug 1846922: "downloads" pod does not work on the node which is disabled IPv6

### DIFF
--- a/manifests/07-downloads-deployment.yaml
+++ b/manifests/07-downloads-deployment.yaml
@@ -59,7 +59,7 @@ spec:
         - '-c'
         - |
           cat <<EOF >>/tmp/serve.py
-          import BaseHTTPServer, os, re, signal, SimpleHTTPServer, socket, sys, tarfile, tempfile, threading, time, zipfile
+          import BaseHTTPServer, errno, os, re, signal, SimpleHTTPServer, socket, sys, tarfile, tempfile, threading, time, zipfile
 
           signal.signal(signal.SIGTERM, lambda signum, frame: sys.exit(0))
 
@@ -116,8 +116,17 @@ spec:
           # IPv6 should handle IPv4 passively so long as it is not bound to a
           # specific address or set to IPv6_ONLY
           # https://stackoverflow.com/questions/25817848/python-3-does-http-server-support-ipv6
-          addr = ('::', 8080)
-          sock = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
+          try:
+              addr = ('::', 8080)
+              sock = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
+          except socket.error as err:
+              # errno.EAFNOSUPPORT is "socket.error: [Errno 97] Address family not supported by protocol"
+              # When IPv6 is disabled, socket will bind using IPv4.
+              if err.errno == errno.EAFNOSUPPORT:
+                  addr = ('', 8080)
+                  sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+              else:
+                  raise    
           sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
           sock.bind(addr)
           sock.listen(5)


### PR DESCRIPTION
* Version: OCP4.4+
* Description:
  When IPv6 is disabled, the socket binding will be failed, so we catch the exception and then IPv4 would use at that time.
* Reference: https://bugzilla.redhat.com/show_bug.cgi?id=1846922