### PR TITLE
Implement inactivity timeout for logging user out

### DIFF
--- a/manifests/03-rbac-role-cluster.yaml
+++ b/manifests/03-rbac-role-cluster.yaml
@@ -17,6 +17,14 @@ rules:
 - apiGroups:
   - config.openshift.io
   resources:
+  - oauths
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - config.openshift.io
+  resources:
   - infrastructures
   - ingresses
   verbs:

--- a/pkg/console/starter/starter.go
+++ b/pkg/console/starter/starter.go
@@ -259,6 +259,7 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 			{Group: configv1.GroupName, Resource: "consoles", Name: api.ConfigResourceName},
 			{Group: configv1.GroupName, Resource: "infrastructures", Name: api.ConfigResourceName},
 			{Group: configv1.GroupName, Resource: "proxies", Name: api.ConfigResourceName},
+			{Group: configv1.GroupName, Resource: "oauths", Name: api.ConfigResourceName},
 			{Group: oauth.GroupName, Resource: "oauthclients", Name: api.OAuthClientName},
 			{Group: corev1.GroupName, Resource: "namespaces", Name: api.OpenShiftConsoleOperatorNamespace},
 			{Group: corev1.GroupName, Resource: "namespaces", Name: api.OpenShiftConsoleNamespace},

--- a/pkg/console/subresource/configmap/configmap.go
+++ b/pkg/console/subresource/configmap/configmap.go
@@ -42,7 +42,8 @@ func DefaultConfigMap(
 	monitoringSharedConfig *corev1.ConfigMap,
 	infrastructureConfig *configv1.Infrastructure,
 	activeConsoleRoute *routev1.Route,
-	useDefaultCAFile bool) (consoleConfigmap *corev1.ConfigMap, unsupportedOverridesHaveMerged bool, err error) {
+	useDefaultCAFile bool,
+	inactivityTimeoutSeconds int) (consoleConfigmap *corev1.ConfigMap, unsupportedOverridesHaveMerged bool, err error) {
 
 	defaultBuilder := &consoleserver.ConsoleServerCLIConfigBuilder{}
 	defaultConfig, err := defaultBuilder.Host(activeConsoleRoute.Spec.Host).
@@ -52,6 +53,7 @@ func DefaultConfigMap(
 		DefaultIngressCert(useDefaultCAFile).
 		APIServerURL(getApiUrl(infrastructureConfig)).
 		Monitoring(monitoringSharedConfig).
+		InactivityTimeout(inactivityTimeoutSeconds).
 		ConfigYAML()
 
 	extractedManagedConfig := extractYAML(managedConfig)
@@ -67,6 +69,7 @@ func DefaultConfigMap(
 		CustomProductName(operatorConfig.Spec.Customization.CustomProductName).
 		CustomHostnameRedirectPort(routesub.IsCustomRouteSet(operatorConfig)).
 		StatusPageID(statusPageId(operatorConfig)).
+		InactivityTimeout(inactivityTimeoutSeconds).
 		ConfigYAML()
 
 	unsupportedConfigOverride := operatorConfig.Spec.UnsupportedConfigOverrides.Raw

--- a/pkg/console/subresource/configmap/configmap_test.go
+++ b/pkg/console/subresource/configmap/configmap_test.go
@@ -30,13 +30,14 @@ const (
 // To manually run these tests: go test -v ./pkg/console/subresource/configmap/...
 func TestDefaultConfigMap(t *testing.T) {
 	type args struct {
-		operatorConfig         *operatorv1.Console
-		consoleConfig          *configv1.Console
-		managedConfig          *corev1.ConfigMap
-		monitoringSharedConfig *corev1.ConfigMap
-		infrastructureConfig   *configv1.Infrastructure
-		rt                     *routev1.Route
-		useDefaultCAFile       bool
+		operatorConfig           *operatorv1.Console
+		consoleConfig            *configv1.Console
+		managedConfig            *corev1.ConfigMap
+		monitoringSharedConfig   *corev1.ConfigMap
+		infrastructureConfig     *configv1.Infrastructure
+		rt                       *routev1.Route
+		useDefaultCAFile         bool
+		inactivityTimeoutSeconds int
 	}
 	tests := []struct {
 		name string
@@ -60,7 +61,8 @@ func TestDefaultConfigMap(t *testing.T) {
 						Host: host,
 					},
 				},
-				useDefaultCAFile: true,
+				useDefaultCAFile:         true,
+				inactivityTimeoutSeconds: 0,
 			},
 			want: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
@@ -107,7 +109,8 @@ providers: {}
 						Host: host,
 					},
 				},
-				useDefaultCAFile: false,
+				useDefaultCAFile:         false,
+				inactivityTimeoutSeconds: 0,
 			},
 			want: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
@@ -162,7 +165,8 @@ customization:
 						Host: host,
 					},
 				},
-				useDefaultCAFile: true,
+				useDefaultCAFile:         true,
+				inactivityTimeoutSeconds: 0,
 			},
 			want: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
@@ -226,7 +230,8 @@ customization:
 						Host: host,
 					},
 				},
-				useDefaultCAFile: true,
+				useDefaultCAFile:         true,
+				inactivityTimeoutSeconds: 0,
 			},
 			want: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
@@ -295,7 +300,8 @@ customization:
 						Host: host,
 					},
 				},
-				useDefaultCAFile: true,
+				useDefaultCAFile:         true,
+				inactivityTimeoutSeconds: 0,
 			},
 			want: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
@@ -366,7 +372,8 @@ customization:
 						Host: host,
 					},
 				},
-				useDefaultCAFile: true,
+				useDefaultCAFile:         true,
+				inactivityTimeoutSeconds: 0,
 			},
 			want: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
@@ -421,7 +428,8 @@ providers:
 						Host: host,
 					},
 				},
-				useDefaultCAFile: true,
+				useDefaultCAFile:         true,
+				inactivityTimeoutSeconds: 0,
 			},
 			want: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
@@ -457,7 +465,7 @@ providers: {}
 			},
 		},
 		{
-			name: "Test configmap with custom route hostname",
+			name: "Test operator config with custom route hostname",
 			args: args{
 				operatorConfig: &operatorv1.Console{
 					Spec: operatorv1.ConsoleSpec{
@@ -479,7 +487,8 @@ providers: {}
 						Host: customHostname,
 					},
 				},
-				useDefaultCAFile: false,
+				useDefaultCAFile:         false,
+				inactivityTimeoutSeconds: 0,
 			},
 			want: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
@@ -510,6 +519,55 @@ providers: {}
 				},
 			},
 		},
+		{
+			name: "Test operator config, with inactivityTimeoutSeconds set",
+			args: args{
+				operatorConfig:         &operatorv1.Console{},
+				consoleConfig:          &configv1.Console{},
+				managedConfig:          &corev1.ConfigMap{},
+				monitoringSharedConfig: &corev1.ConfigMap{},
+				infrastructureConfig: &configv1.Infrastructure{
+					Status: configv1.InfrastructureStatus{
+						APIServerURL: mockAPIServer,
+					},
+				},
+				rt: &routev1.Route{
+					Spec: routev1.RouteSpec{
+						Host: host,
+					},
+				},
+				useDefaultCAFile:         true,
+				inactivityTimeoutSeconds: 60,
+			},
+			want: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        api.OpenShiftConsoleConfigMapName,
+					Namespace:   api.OpenShiftConsoleNamespace,
+					Labels:      map[string]string{"app": api.OpenShiftConsoleName},
+					Annotations: map[string]string{},
+				},
+				Data: map[string]string{configKey: `kind: ConsoleConfig
+apiVersion: console.openshift.io/v1
+auth:
+  clientID: console
+  clientSecretFile: /var/oauth-config/clientSecret
+  inactivityTimeoutSeconds: 60
+  oauthEndpointCAFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+clusterInfo:
+  consoleBaseAddress: https://` + host + `
+  masterPublicURL: ` + mockAPIServer + `
+customization:
+  branding: ` + DEFAULT_BRAND + `
+  documentationBaseURL: ` + DEFAULT_DOC_URL + `
+servingInfo:
+  bindAddress: https://[::]:8443
+  certFile: /var/serving-cert/tls.crt
+  keyFile: /var/serving-cert/tls.key
+providers: {}
+`,
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -519,7 +577,9 @@ providers: {}
 				tt.args.managedConfig,
 				tt.args.monitoringSharedConfig,
 				tt.args.infrastructureConfig,
-				tt.args.rt, tt.args.useDefaultCAFile,
+				tt.args.rt,
+				tt.args.useDefaultCAFile,
+				tt.args.inactivityTimeoutSeconds,
 			)
 
 			// marshall the exampleYaml to map[string]interface{} so we can use it in diff below

--- a/pkg/console/subresource/consoleserver/types.go
+++ b/pkg/console/subresource/consoleserver/types.go
@@ -56,10 +56,11 @@ type MonitoringInfo struct {
 
 // Auth holds configuration for authenticating with OpenShift. The auth method is assumed to be "openshift".
 type Auth struct {
-	ClientID            string `yaml:"clientID,omitempty"`
-	ClientSecretFile    string `yaml:"clientSecretFile,omitempty"`
-	OAuthEndpointCAFile string `yaml:"oauthEndpointCAFile,omitempty"`
-	LogoutRedirect      string `yaml:"logoutRedirect,omitempty"`
+	ClientID                 string `yaml:"clientID,omitempty"`
+	ClientSecretFile         string `yaml:"clientSecretFile,omitempty"`
+	OAuthEndpointCAFile      string `yaml:"oauthEndpointCAFile,omitempty"`
+	LogoutRedirect           string `yaml:"logoutRedirect,omitempty"`
+	InactivityTimeoutSeconds int    `yaml:"inactivityTimeoutSeconds,omitempty"`
 }
 
 // Customization holds configuration such as what logo to use.


### PR DESCRIPTION
We fetch the inactivity timeout first from the `accessTokenInactivityTimeoutSeconds` in the `OAuthClient`. If thats not set we fetch `accessTokenInactivityTimeout` field from `OAuth` config. The inactivity timeout is stored in seconds.

When the inactivity timeout is set, the console configmap will look:
```yaml
apiVersion: console.openshift.io/v1
auth:
  clientID: console
  clientSecretFile: /var/oauth-config/clientSecret
  inactivityTimeoutSeconds: 600
  oauthEndpointCAFile: /var/default-ingress-cert/ca-bundle.crt
clusterInfo:
  consoleBaseAddress: https://console-openshift-console.cluster.openshift.com
  masterPublicURL: https://api.cluster.openshift.com:6443
customization:
  branding: ocp
  documentationBaseURL: https://docs.openshift.com/container-platform/4.5/
kind: ConsoleConfig
monitoringInfo:
  alertmanagerPublicURL: https://alertmanager-main-openshift-monitoring.cluster.openshift.com
  grafanaPublicURL: https://grafana-openshift-monitoring.cluster.openshift.com
  prometheusPublicURL: https://prometheus-k8s-openshift-monitoring.cluster.openshift.com
  thanosPublicURL: https://thanos-querier-openshift-monitoring.cluster.com
providers: {}
servingInfo:
  bindAddress: https://[::]:8443
  certFile: /var/serving-cert/tls.crt
  keyFile: /var/serving-cert/tls.key
```
story: https://issues.redhat.com/browse/CONSOLE-740

/assign @spadgett 

cc'ing @stlaz 
