### PR TITLE
Allow console service account to read HelmChartRepository CR

### DIFF
--- a/manifests/03-rbac-role-cluster.yaml
+++ b/manifests/03-rbac-role-cluster.yaml
@@ -97,3 +97,10 @@ rules:
   - validatingwebhookconfigurations
   verbs:
   - get
+- apiGroups:
+    - helm.openshift.io
+  resources:
+    - helmchartrepositories
+  verbs:
+    - get
+    - list

--- a/manifests/03-rbac-role-ns-openshift-config.yaml
+++ b/manifests/03-rbac-role-ns-openshift-config.yaml
@@ -13,3 +13,17 @@ rules:
       - get
       - list
       - watch
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: console
+  namespace: openshift-config
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - secrets
+    verbs:
+      - get

--- a/manifests/04-rbac-rolebinding.yaml
+++ b/manifests/04-rbac-rolebinding.yaml
@@ -94,3 +94,17 @@ subjects:
   - kind: ServiceAccount
     name: console
     namespace: openshift-console
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: console
+  namespace: openshift-config
+roleRef:
+  kind: Role
+  name: console
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: console
+    namespace: openshift-console


### PR DESCRIPTION
This change allows non-admin users logged through UI to browse helm charts
available in custom configured Helm chart repositories.

A separate PR will be submited to openshift/console making /api/helm/charts/index.yaml
to perform k8s api requests on behalf of the service account.