### PR TITLE
Bug 1859331: manifests/07-downloads-deployment: Create index.html

### DIFF
--- a/manifests/07-downloads-deployment.yaml
+++ b/manifests/07-downloads-deployment.yaml
@@ -63,6 +63,21 @@ spec:
 
           signal.signal(signal.SIGTERM, lambda signum, frame: sys.exit(0))
 
+          def write_index(path, message):
+              with open(path, 'wb') as f:
+                  f.write('\n'.join([
+                      '<!doctype html>',
+                      '<html lang="en">',
+                      '<head>',
+                      '  <meta charset="utf-8">',
+                      '</head>',
+                      '<body>',
+                      '  {}'.format(message),
+                      '</body>',
+                      '</html>',
+                      '',
+                  ]).encode('utf-8'))
+
           # Launch multiple listeners as threads
           class Thread(threading.Thread):
               def __init__(self, i, socket):
@@ -93,6 +108,7 @@ spec:
               os.mkdir(arch)
               for operating_system in ['linux']:
                   os.mkdir(os.path.join(arch, operating_system))
+          content = ['<a href="oc-license">license</a>']
           os.symlink('/usr/share/openshift/LICENSE', 'oc-license')
 
           for arch, operating_system, path in [
@@ -112,6 +128,23 @@ spec:
                   tar.add(path, basename)
               with zipfile.ZipFile('{}.zip'.format(archive_path_root), 'w') as zip:
                   zip.write(path, basename)
+              content.append('<a href="{0}">oc ({1} {2})</a> (<a href="{0}.tar">tar</a> <a href="{0}.zip">zip</a>)'.format(target_path, arch, operating_system))
+
+          for root, directories, filenames in os.walk(temp_dir):
+              root_link = os.path.relpath(temp_dir, os.path.join(root, 'child')).replace(os.path.sep, '/')
+              for directory in directories:
+                  write_index(
+                      path=os.path.join(root, directory, 'index.html'),
+                      message='<p>Directory listings are disabled.  See <a href="">here</a> for available content.</p>'.format(root_link),
+                  )
+          write_index(
+              path=os.path.join(root, 'index.html'),
+              message='\n'.join(
+                  ['<ul>'] +
+                  ['  <li>{}</li>'.format(entry) for entry in content] +
+                  ['</ul>']
+              ),
+          )
 
           # Create socket
           # IPv6 should handle IPv4 passively so long as it is not bound to a


### PR DESCRIPTION
Conservative, filesystem-based web servers [should][1] [avoid][2] dynamic directory listing, to avoid accidentally leaking a file that a user drops into the served filesystem.  It seems like an unlikely vector for the downloads container, where nobody outside of our script is likely to be dropping files.  But it is easy enough to fix by filling in `index.html` files throughout, which preempt `SimpleHTTPRequestHandler`'s [directory][3] [listing][4].

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=1859331
[2]: https://cwe.mitre.org/data/definitions/548.html
[3]: https://docs.python.org/2.7/library/simplehttpserver.html#SimpleHTTPServer.SimpleHTTPRequestHandler.do_GET
[4]: https://github.com/python/cpython/blob/e7c98f08e228e9f6e139d61e3e5d0a5018a38f0b/Lib/http/server.py#L757-L758