### PR TITLE
Bug 1872375: Add RedHat Helm chart repository as default repo in OCP payload

### DIFF
--- a/manifests/01-helm.yaml
+++ b/manifests/01-helm.yaml
@@ -1,0 +1,10 @@
+apiVersion: helm.openshift.io/v1beta1
+kind: HelmChartRepository
+metadata:
+  annotations:
+    "release.openshift.io/create-only": 'true'
+  name: redhat-helm-repo
+spec:
+  name: Red Hat Helm Charts
+  connectionConfig:
+    url: https://redhat-developer.github.io/redhat-helm-charts

--- a/manifests/03-rbac-role-cluster.yaml
+++ b/manifests/03-rbac-role-cluster.yaml
@@ -97,3 +97,16 @@ rules:
   - validatingwebhookconfigurations
   verbs:
   - get
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: helm-chartrepos-viewer
+rules:
+  - apiGroups:
+      - helm.openshift.io
+    resources:
+      - helmchartrepositories
+    verbs:
+      - get
+      - list

--- a/manifests/04-rbac-rolebinding-cluster.yaml
+++ b/manifests/04-rbac-rolebinding-cluster.yaml
@@ -54,3 +54,18 @@ subjects:
   - kind: ServiceAccount
     name: console
     namespace: openshift-console
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  annotations:
+    "release.openshift.io/create-only": 'true'
+  name: helm-chartrepos-view
+subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: 'system:authenticated'
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: helm-chartrepos-viewer


### PR DESCRIPTION
Although console endpoint `/api/helm/charts/index.yaml` handles the situation
when there is no HelmChartRepository CR present in the cluster, we should align
us to other default cluster settings and provide the default HelmChartRepository CR in the payload

Prior introducing openshift/console#5933 all authenticated users could browse the charts from the chart repo.
This PR restores that functionality by introducing additional `helm-chartrepos-viewer` ClusterRole,
binding it to all authenticated users.