### PR TITLE
Bug 1862377: Notify user that the CLI binaries downloaded from console might be in different version then the server version

### DIFF
--- a/pkg/console/controllers/clidownloads/controller.go
+++ b/pkg/console/controllers/clidownloads/controller.go
@@ -199,6 +199,8 @@ func PlatformBasedOCConsoleCLIDownloads(host, cliDownloadsName string) *v1.Conso
 			Description: `With the OpenShift command line interface, you can create applications and manage OpenShift projects from a terminal.
 
 The oc binary offers the same capabilities as the kubectl binary, but it is further extended to natively support OpenShift Container Platform features.
+
+Note: The downloaded binary will report a different version based on the source code revision system rather than the server version.
 `,
 			DisplayName: "oc - OpenShift Command Line Interface (CLI)",
 			Links:       links,

--- a/pkg/console/controllers/clidownloads/controller_test.go
+++ b/pkg/console/controllers/clidownloads/controller_test.go
@@ -108,6 +108,8 @@ func TestPlatformBasedOCConsoleCLIDownloads(t *testing.T) {
 					Description: `With the OpenShift command line interface, you can create applications and manage OpenShift projects from a terminal.
 
 The oc binary offers the same capabilities as the kubectl binary, but it is further extended to natively support OpenShift Container Platform features.
+
+Note: The downloaded binary will report a different version based on the source code revision system rather than the server version.
 `,
 					DisplayName: "oc - OpenShift Command Line Interface (CLI)",
 					Links: []v1.CLIDownloadLink{


### PR DESCRIPTION
Making this change as a suggested solution of this issue, based on https://bugzilla.redhat.com/show_bug.cgi?id=1862377#c7

/assign @spadgett 