### PR TITLE
Bug 1859331: Fix downloads index

### DIFF
--- a/manifests/07-downloads-deployment.yaml
+++ b/manifests/07-downloads-deployment.yaml
@@ -137,8 +137,9 @@ spec:
                       path=os.path.join(root, directory, 'index.html'),
                       message='<p>Directory listings are disabled.  See <a href="{}">here</a> for available content.</p>'.format(root_link),
                   )
+
           write_index(
-              path=os.path.join(root, 'index.html'),
+              path=os.path.join(temp_dir, 'index.html'),
               message='\n'.join(
                   ['<ul>'] +
                   ['  <li>{}</li>'.format(entry) for entry in content] +


### PR DESCRIPTION
The variable root is left over from the previous for loop, it shouldn't
be used again here.

/assign @wking