### PR TITLE
Bug 1880307: Fix inconsistent vendoring in vendor/modules.txt

### DIFF
--- a/vendor/github.com/openshift/api/config/v1/0000_10_config-operator_01_oauth.crd.yaml
+++ b/vendor/github.com/openshift/api/config/v1/0000_10_config-operator_01_oauth.crd.yaml
@@ -637,17 +637,8 @@ spec:
               type: object
               properties:
                 accessTokenInactivityTimeoutSeconds:
-                  description: 'accessTokenInactivityTimeoutSeconds defines the default
-                    token inactivity timeout for tokens granted by any client. The
-                    value represents the maximum amount of time that can occur between
-                    consecutive uses of the token. Tokens become invalid if they are
-                    not used within this temporal window. The user will need to acquire
-                    a new token to regain access once a token times out. Valid values
-                    are integer values:   x < 0  Tokens time out is enabled but tokens
-                    never timeout unless configured per client (e.g. `-1`)   x = 0  Tokens
-                    time out is disabled (default)   x > 0  Tokens time out if there
-                    is no activity for x seconds The current minimum allowed value
-                    for X is 300 (5 minutes)'
+                  description: 'accessTokenInactivityTimeoutSeconds - DEPRECATED:
+                    setting this field has no effect.'
                   type: integer
                   format: int32
                 accessTokenMaxAgeSeconds:

--- a/vendor/github.com/openshift/api/config/v1/types_oauth.go
+++ b/vendor/github.com/openshift/api/config/v1/types_oauth.go
@@ -47,17 +47,7 @@ type TokenConfig struct {
 	// accessTokenMaxAgeSeconds defines the maximum age of access tokens
 	AccessTokenMaxAgeSeconds int32 `json:"accessTokenMaxAgeSeconds"`
 
-	// accessTokenInactivityTimeoutSeconds defines the default token
-	// inactivity timeout for tokens granted by any client.
-	// The value represents the maximum amount of time that can occur between
-	// consecutive uses of the token. Tokens become invalid if they are not
-	// used within this temporal window. The user will need to acquire a new
-	// token to regain access once a token times out.
-	// Valid values are integer values:
-	//   x < 0  Tokens time out is enabled but tokens never timeout unless configured per client (e.g. `-1`)
-	//   x = 0  Tokens time out is disabled (default)
-	//   x > 0  Tokens time out if there is no activity for x seconds
-	// The current minimum allowed value for X is 300 (5 minutes)
+	// accessTokenInactivityTimeoutSeconds - DEPRECATED: setting this field has no effect.
 	// +optional
 	AccessTokenInactivityTimeoutSeconds int32 `json:"accessTokenInactivityTimeoutSeconds,omitempty"`
 }

--- a/vendor/github.com/openshift/api/config/v1/zz_generated.swagger_doc_generated.go
+++ b/vendor/github.com/openshift/api/config/v1/zz_generated.swagger_doc_generated.go
@@ -1208,7 +1208,7 @@ func (RequestHeaderIdentityProvider) SwaggerDoc() map[string]string {
 var map_TokenConfig = map[string]string{
 	"":                                    "TokenConfig holds the necessary configuration options for authorization and access tokens",
 	"accessTokenMaxAgeSeconds":            "accessTokenMaxAgeSeconds defines the maximum age of access tokens",
-	"accessTokenInactivityTimeoutSeconds": "accessTokenInactivityTimeoutSeconds defines the default token inactivity timeout for tokens granted by any client. The value represents the maximum amount of time that can occur between consecutive uses of the token. Tokens become invalid if they are not used within this temporal window. The user will need to acquire a new token to regain access once a token times out. Valid values are integer values:\n  x < 0  Tokens time out is enabled but tokens never timeout unless configured per client (e.g. `-1`)\n  x = 0  Tokens time out is disabled (default)\n  x > 0  Tokens time out if there is no activity for x seconds\nThe current minimum allowed value for X is 300 (5 minutes)",
+	"accessTokenInactivityTimeoutSeconds": "accessTokenInactivityTimeoutSeconds - DEPRECATED: setting this field has no effect.",
 }
 
 func (TokenConfig) SwaggerDoc() map[string]string {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -88,7 +88,7 @@ github.com/modern-go/concurrent
 github.com/modern-go/reflect2
 # github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
 github.com/munnerz/goautoneg
-# github.com/openshift/api v0.0.0-20200424083944-0422dc17083e
+# github.com/openshift/api v0.0.0-20200429152225-b98a784d8e6d
 github.com/openshift/api
 github.com/openshift/api/apps
 github.com/openshift/api/apps/v1
@@ -145,7 +145,7 @@ github.com/openshift/build-machinery-go/make/targets/golang
 github.com/openshift/build-machinery-go/make/targets/openshift
 github.com/openshift/build-machinery-go/make/targets/openshift/operator
 github.com/openshift/build-machinery-go/scripts
-# github.com/openshift/client-go v0.0.0-20200326155132-2a6cd50aedd0
+# github.com/openshift/client-go v0.0.0-20200422192633-6f6c07fc2a70
 github.com/openshift/client-go/config/clientset/versioned
 github.com/openshift/client-go/config/clientset/versioned/scheme
 github.com/openshift/client-go/config/clientset/versioned/typed/config/v1


### PR DESCRIPTION
Need to fix this inconsistency due to the failures https://github.com/openshift/release/pull/12006

```
2020/09/18 14:52:20 Executing test unit
go test  -race ./pkg/... ./cmd/...
go: inconsistent vendoring in /go/src/github.com/openshift/console-operator:
	github.com/openshift/api@v0.0.0-20200429152225-b98a784d8e6d: is explicitly required in go.mod, but vendor/modules.txt indicates github.com/openshift/api@v0.0.0-20200424083944-0422dc17083e
	github.com/openshift/client-go@v0.0.0-20200422192633-6f6c07fc2a70: is explicitly required in go.mod, but vendor/modules.txt indicates github.com/openshift/client-go@v0.0.0-20200326155132-2a6cd50aedd0
```

/assign @spadgett 