### PR TITLE
Add namespace and role resources for user settings

### DIFF
--- a/manifests/02-namespace.yaml
+++ b/manifests/02-namespace.yaml
@@ -17,3 +17,11 @@ metadata:
     openshift.io/node-selector: ""
   labels:
     openshift.io/cluster-monitoring: "true"
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-console-user-settings
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+    openshift.io/node-selector: ""

--- a/manifests/03-rbac-role-ns-openshift-console-user-settings.yaml
+++ b/manifests/03-rbac-role-ns-openshift-console-user-settings.yaml
@@ -1,0 +1,49 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: console-user-settings-admin
+  namespace: openshift-console-user-settings
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+rules:
+- apiGroups:
+  - rbac.authorization.k8s.io/v1
+  resources:
+  - roles
+  - rolebindings
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
+  - watch
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: console-user-settings-admin
+  namespace: openshift-console-user-settings
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+roleRef:
+  kind: Role
+  name: console-user-settings-admin
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: console
+    namespace: openshift-console


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-4755

**Analysis / Root cause**:
Based on the [User Settings for OpenShift Console enhancement proposal](https://github.com/openshift/enhancements/blob/master/enhancements/console/user-settings.md) we want to create a `ConfigMap` for each individual user in the namespace `openshift-console-user-settings`

We create a `ConfigMap` with a service account from the console bridge, see PR https://github.com/openshift/console/pull/7095. For this we need that the namespace, role and rolebinding which is added in this PR.

**Solution Description**: 
* Add Namespace `openshift-console-user-settings`
* Add Role and RoleBinding `console-user-settings-role-operator` to allow the ServiceAccount to get, list, create, update and delete Role, RoleBinding and ConfigMap in this new namespace.