### PR TITLE
Bug 1896645: Bump DEFAULT_DOC_URL for ocp 4.7

### DIFF
--- a/pkg/console/subresource/configmap/brand_ocp.go
+++ b/pkg/console/subresource/configmap/brand_ocp.go
@@ -4,5 +4,5 @@ package configmap
 
 const (
 	DEFAULT_BRAND   = "ocp"
-	DEFAULT_DOC_URL = "https://docs.openshift.com/container-platform/4.6/"
+	DEFAULT_DOC_URL = "https://docs.openshift.com/container-platform/4.7/"
 )


### PR DESCRIPTION
Bump DEFAULT_DOC_URL for 4.7 then documentationBaseURL will point to correct link https://docs.openshift.com/container-platform/4.7/