### PR TITLE
Bug 1894216: Improve OpenShift Console availability

### DIFF
--- a/pkg/console/subresource/deployment/deployment.go
+++ b/pkg/console/subresource/deployment/deployment.go
@@ -115,7 +115,7 @@ func DefaultDeployment(operatorConfig *operatorv1.Console, cm *corev1.ConfigMap,
 									LabelSelector: &metav1.LabelSelector{
 										MatchLabels: util.SharedLabels(),
 									},
-									TopologyKey: "kubernetes.io/hostname",
+									TopologyKey: "topology.kubernetes.io/zone",
 								},
 							}},
 						},

--- a/pkg/console/subresource/deployment/deployment_test.go
+++ b/pkg/console/subresource/deployment/deployment_test.go
@@ -132,7 +132,7 @@ func TestDefaultDeployment(t *testing.T) {
 					LabelSelector: &metav1.LabelSelector{
 						MatchLabels: util.SharedLabels(),
 					},
-					TopologyKey: "kubernetes.io/hostname",
+					TopologyKey: "topology.kubernetes.io/zone",
 				},
 			}},
 		},


### PR DESCRIPTION
Based on the bug description, we should avoid several minute outage in case of node failure pods are rescheduled to a healthy zone. For that reason we should use `RequiredDuringSchedulingIgnoredDuringExecution`, due to the [docs](https://kubernetes.io/docs/tutorials/stateful-application/zookeeper/#tolerating-node-failure).
Also 3 console replicas are recommended, although not sure if that's necessary.

/assign @spadgett 