### PR TITLE
Fix user settings role definition for console service account

### DIFF
--- a/manifests/03-rbac-role-ns-openshift-console-user-settings.yaml
+++ b/manifests/03-rbac-role-ns-openshift-console-user-settings.yaml
@@ -7,7 +7,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
 rules:
 - apiGroups:
-  - rbac.authorization.k8s.io/v1
+  - rbac.authorization.k8s.io
   resources:
   - roles
   - rolebindings
@@ -18,7 +18,7 @@ rules:
   - create
   - update
   - delete
-  - watch
+  - patch
 - apiGroups:
   - ""
   resources:
@@ -30,7 +30,7 @@ rules:
   - create
   - update
   - delete
-  - watch
+  - patch
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-4755

**Analysis / Root cause**:
Get an forbidden error on a shared cluster with new user settings api.

**Solution Description**: 
* Removed version suffix of Role `rules.apiGroups to fix

`Failed to create user settings: roles.rbac.authorization.k8s.io is forbidden: User "system:serviceaccount:openshift-console:console" cannot create resource "roles" in API group "rbac.authorization.k8s.io" in the namespace "openshift-console-user-settings"`
* Fixed typo in verbs, we have two times watch instead of watch and patch. Doh! :facepalm: 

`Failed to create user settings: roles.rbac.authorization.k8s.io "user-settings-kubeadmin-role" is forbidden: user "system:serviceaccount:openshift-console:console" (groups=["system:serviceaccounts" "system:serviceaccounts:openshift-console" "system:authenticated"]) is attempting to grant RBAC permissions not currently held:\n{APIGroups:[""], Resources:["configmaps"], ResourceNames:["user-settings-kubeadmin"], Verbs:["patch"]}`


/bug
/assign @jhadvig 