### PR TITLE
Annotate manifests for single-node-developer cluster profile

### DIFF
--- a/manifests/0000_90_console-operator_01_prometheusrbac.yaml
+++ b/manifests/0000_90_console-operator_01_prometheusrbac.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 rules:
   - apiGroups:
       - ""
@@ -28,6 +29,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/manifests/0000_90_console-operator_02_servicemonitor.yaml
+++ b/manifests/0000_90_console-operator_02_servicemonitor.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 spec:
   endpoints:
     - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token

--- a/manifests/01-helm.yaml
+++ b/manifests/01-helm.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
     release.openshift.io/create-only: "true"
   name: redhat-helm-repo
 spec:

--- a/manifests/01-oauth.yaml
+++ b/manifests/01-oauth.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
     release.openshift.io/create-only: "true"
 grantMethod: auto
 respondWithChallenges: false

--- a/manifests/01-operator-config.yaml
+++ b/manifests/01-operator-config.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
     release.openshift.io/create-only: "true"
 spec:
   managementState: Managed

--- a/manifests/02-namespace.yaml
+++ b/manifests/02-namespace.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
     openshift.io/node-selector: ""
 ---
 apiVersion: v1
@@ -14,6 +15,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
     openshift.io/node-selector: ""
   labels:
     openshift.io/cluster-monitoring: "true"
@@ -24,4 +26,5 @@ metadata:
   name: openshift-console-user-settings
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
     openshift.io/node-selector: ""

--- a/manifests/03-rbac-role-cluster-extensions.yaml
+++ b/manifests/03-rbac-role-cluster-extensions.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 rules:
 - apiGroups:
   - console.openshift.io

--- a/manifests/03-rbac-role-cluster.yaml
+++ b/manifests/03-rbac-role-cluster.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 rules:
 - apiGroups:
   - oauth.openshift.io
@@ -87,6 +88,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 rules:
 - apiGroups:
   - apiextensions.k8s.io
@@ -111,6 +113,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 rules:
   - apiGroups:
       - helm.openshift.io

--- a/manifests/03-rbac-role-ns-console.yaml
+++ b/manifests/03-rbac-role-ns-console.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 rules:
 # TODO: delete is needed for ownerRefs on older clusters
 # should remove in the future.

--- a/manifests/03-rbac-role-ns-openshift-config-managed.yaml
+++ b/manifests/03-rbac-role-ns-openshift-config-managed.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 rules:
 - apiGroups:
   - ""
@@ -32,6 +33,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 rules:
 - apiGroups:
   - ""
@@ -50,6 +52,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 rules:
 - apiGroups:
   - ""

--- a/manifests/03-rbac-role-ns-openshift-config.yaml
+++ b/manifests/03-rbac-role-ns-openshift-config.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 rules:
   - apiGroups:
       - ""

--- a/manifests/03-rbac-role-ns-openshift-console-user-settings.yaml
+++ b/manifests/03-rbac-role-ns-openshift-console-user-settings.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: openshift-console-user-settings
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 rules:
 - apiGroups:
   - rbac.authorization.k8s.io
@@ -39,6 +40,7 @@ metadata:
   namespace: openshift-console-user-settings
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 roleRef:
   kind: Role
   name: console-user-settings-admin

--- a/manifests/03-rbac-role-ns-operator.yaml
+++ b/manifests/03-rbac-role-ns-operator.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 rules:
 - apiGroups:
   - ""

--- a/manifests/04-rbac-rolebinding-cluster.yaml
+++ b/manifests/04-rbac-rolebinding-cluster.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -21,6 +22,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 roleRef:
   kind: ClusterRole
   name: console-extensions-reader
@@ -37,6 +39,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 roleRef:
   # for protected endpoints like /metrics, the operator must perform
   # authentication (tokenreview) & authorization (subjectaccessreview)
@@ -56,6 +59,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 roleRef:
   # CRD lists are protected from unpriviledged users, access is
   # granted to Service Account by this ClusterRole
@@ -74,6 +78,7 @@ metadata:
     "release.openshift.io/create-only": "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
   name: helm-chartrepos-view
 subjects:
   - kind: Group

--- a/manifests/04-rbac-rolebinding.yaml
+++ b/manifests/04-rbac-rolebinding.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 roleRef:
   kind: Role
   name: console-operator
@@ -23,6 +24,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 roleRef:
   kind: Role
   name: console-operator
@@ -39,6 +41,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 roleRef:
   kind: Role
   name: console-operator
@@ -56,6 +59,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 roleRef:
   kind: Role
   name: console-public
@@ -73,6 +77,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 roleRef:
   kind: Role
   name: console-operator
@@ -90,6 +95,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 roleRef:
   kind: Role
   name: extension-apiserver-authentication-reader
@@ -107,6 +113,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 roleRef:
   kind: Role
   name: console-configmap-reader

--- a/manifests/05-config-public.yaml
+++ b/manifests/05-config-public.yaml
@@ -6,4 +6,5 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
     release.openshift.io/create-only: "true"

--- a/manifests/05-config.yaml
+++ b/manifests/05-config.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 data:
   controller-config.yaml: |
     apiVersion: operator.openshift.io/v1alpha1

--- a/manifests/05-service.yaml
+++ b/manifests/05-service.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
     service.alpha.openshift.io/serving-cert-secret-name: serving-cert
   labels:
     name: console-operator

--- a/manifests/06-sa.yaml
+++ b/manifests/06-sa.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -15,3 +16,4 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"

--- a/manifests/07-downloads-deployment.yaml
+++ b/manifests/07-downloads-deployment.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 spec:
   replicas: 2
   selector:

--- a/manifests/07-downloads-helm.yaml
+++ b/manifests/07-downloads-helm.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 spec:
   description: |
     Helm 3 is a package manager for Kubernetes applications which enables defining,

--- a/manifests/07-downloads-route.yaml
+++ b/manifests/07-downloads-route.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 spec:
   tls:
     termination: edge

--- a/manifests/07-downloads-service.yaml
+++ b/manifests/07-downloads-service.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 spec:
   ports:
   - name: http

--- a/manifests/07-operator.yaml
+++ b/manifests/07-operator.yaml
@@ -7,6 +7,7 @@ metadata:
     config.openshift.io/inject-proxy: console-operator
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 spec:
   replicas: 1
   selector:

--- a/manifests/08-clusteroperator.yaml
+++ b/manifests/08-clusteroperator.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 spec: {}
 status:
   versions:

--- a/manifests/09-console-link-openshift-blog.yaml
+++ b/manifests/09-console-link-openshift-blog.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 spec:
   href: 'https://blog.openshift.com'
   location: HelpMenu

--- a/manifests/09-console-link-openshift-learning-portal.yaml
+++ b/manifests/09-console-link-openshift-learning-portal.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 spec:
   href: 'https://learn.openshift.com/?ref=webconsole'
   location: HelpMenu


### PR DESCRIPTION
This partially implements phase 1 of https://github.com/openshift/enhancements#482
and does not change behavior. Initially, all console-operator
manifests are included in the single-node-developer cluster profile.
Follow-on PRs may exclude any of these that are not needed in the
profile.