### PR TITLE
add 'single-node-production-edge' annotations to CVO manifests.

### DIFF
--- a/manifests/0000_90_console-operator_01_prometheusrbac.yaml
+++ b/manifests/0000_90_console-operator_01_prometheusrbac.yaml
@@ -8,6 +8,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 rules:
   - apiGroups:
       - ""
@@ -30,6 +31,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/manifests/0000_90_console-operator_02_servicemonitor.yaml
+++ b/manifests/0000_90_console-operator_02_servicemonitor.yaml
@@ -8,6 +8,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   endpoints:
     - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token

--- a/manifests/01-helm.yaml
+++ b/manifests/01-helm.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     release.openshift.io/create-only: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
   name: redhat-helm-repo
 spec:
   name: Red Hat Helm Charts

--- a/manifests/01-oauth.yaml
+++ b/manifests/01-oauth.yaml
@@ -7,5 +7,6 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     release.openshift.io/create-only: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 grantMethod: auto
 respondWithChallenges: false

--- a/manifests/01-operator-config.yaml
+++ b/manifests/01-operator-config.yaml
@@ -7,5 +7,6 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     release.openshift.io/create-only: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   managementState: Managed

--- a/manifests/02-namespace.yaml
+++ b/manifests/02-namespace.yaml
@@ -7,6 +7,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     openshift.io/node-selector: ""
+    include.release.openshift.io/single-node-production-edge: "true"
 ---
 apiVersion: v1
 kind: Namespace
@@ -17,6 +18,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     openshift.io/node-selector: ""
+    include.release.openshift.io/single-node-production-edge: "true"
   labels:
     openshift.io/cluster-monitoring: "true"
 ---
@@ -29,3 +31,4 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     openshift.io/node-selector: ""
+    include.release.openshift.io/single-node-production-edge: "true"

--- a/manifests/03-rbac-role-cluster-extensions.yaml
+++ b/manifests/03-rbac-role-cluster-extensions.yaml
@@ -8,6 +8,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 rules:
 - apiGroups:
   - console.openshift.io

--- a/manifests/03-rbac-role-cluster.yaml
+++ b/manifests/03-rbac-role-cluster.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 rules:
 - apiGroups:
   - oauth.openshift.io
@@ -89,6 +90,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 rules:
 - apiGroups:
   - apiextensions.k8s.io
@@ -114,6 +116,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 rules:
   - apiGroups:
       - helm.openshift.io

--- a/manifests/03-rbac-role-ns-console.yaml
+++ b/manifests/03-rbac-role-ns-console.yaml
@@ -7,6 +7,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 rules:
 # TODO: delete is needed for ownerRefs on older clusters
 # should remove in the future.

--- a/manifests/03-rbac-role-ns-openshift-config-managed.yaml
+++ b/manifests/03-rbac-role-ns-openshift-config-managed.yaml
@@ -7,6 +7,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 rules:
 - apiGroups:
   - ""
@@ -34,6 +35,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 rules:
 - apiGroups:
   - ""
@@ -53,6 +55,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 rules:
 - apiGroups:
   - ""

--- a/manifests/03-rbac-role-ns-openshift-config.yaml
+++ b/manifests/03-rbac-role-ns-openshift-config.yaml
@@ -7,6 +7,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 rules:
   - apiGroups:
       - ""

--- a/manifests/03-rbac-role-ns-openshift-console-user-settings.yaml
+++ b/manifests/03-rbac-role-ns-openshift-console-user-settings.yaml
@@ -7,6 +7,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 rules:
 - apiGroups:
   - rbac.authorization.k8s.io
@@ -43,6 +44,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 roleRef:
   kind: Role
   name: console-user-settings-admin

--- a/manifests/03-rbac-role-ns-operator.yaml
+++ b/manifests/03-rbac-role-ns-operator.yaml
@@ -7,6 +7,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 rules:
 - apiGroups:
   - ""

--- a/manifests/04-rbac-rolebinding-cluster.yaml
+++ b/manifests/04-rbac-rolebinding-cluster.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -23,6 +24,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 roleRef:
   kind: ClusterRole
   name: console-extensions-reader
@@ -40,6 +42,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 roleRef:
   # for protected endpoints like /metrics, the operator must perform
   # authentication (tokenreview) & authorization (subjectaccessreview)
@@ -60,6 +63,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 roleRef:
   # CRD lists are protected from unpriviledged users, access is
   # granted to Service Account by this ClusterRole
@@ -79,6 +83,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
   name: helm-chartrepos-view
 subjects:
   - kind: Group

--- a/manifests/04-rbac-rolebinding.yaml
+++ b/manifests/04-rbac-rolebinding.yaml
@@ -7,6 +7,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 roleRef:
   kind: Role
   name: console-operator
@@ -25,6 +26,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 roleRef:
   kind: Role
   name: console-operator
@@ -42,6 +44,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 roleRef:
   kind: Role
   name: console-operator
@@ -60,6 +63,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 roleRef:
   kind: Role
   name: console-public
@@ -78,6 +82,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 roleRef:
   kind: Role
   name: console-operator
@@ -96,6 +101,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 roleRef:
   kind: Role
   name: extension-apiserver-authentication-reader
@@ -114,6 +120,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 roleRef:
   kind: Role
   name: console-configmap-reader

--- a/manifests/05-config-public.yaml
+++ b/manifests/05-config-public.yaml
@@ -8,3 +8,4 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     release.openshift.io/create-only: "true"
+    include.release.openshift.io/single-node-production-edge: "true"

--- a/manifests/05-config.yaml
+++ b/manifests/05-config.yaml
@@ -7,6 +7,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 data:
   controller-config.yaml: |
     apiVersion: operator.openshift.io/v1alpha1

--- a/manifests/05-service.yaml
+++ b/manifests/05-service.yaml
@@ -7,6 +7,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     service.alpha.openshift.io/serving-cert-secret-name: serving-cert
+    include.release.openshift.io/single-node-production-edge: "true"
   labels:
     name: console-operator
   name: metrics

--- a/manifests/06-sa.yaml
+++ b/manifests/06-sa.yaml
@@ -7,6 +7,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -17,3 +18,4 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"

--- a/manifests/07-downloads-deployment.yaml
+++ b/manifests/07-downloads-deployment.yaml
@@ -7,6 +7,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   replicas: 2
   selector:

--- a/manifests/07-downloads-helm.yaml
+++ b/manifests/07-downloads-helm.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   description: |
     Helm 3 is a package manager for Kubernetes applications which enables defining,

--- a/manifests/07-downloads-route.yaml
+++ b/manifests/07-downloads-route.yaml
@@ -7,6 +7,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   tls:
     termination: edge

--- a/manifests/07-downloads-service.yaml
+++ b/manifests/07-downloads-service.yaml
@@ -7,6 +7,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   ports:
   - name: http

--- a/manifests/07-operator.yaml
+++ b/manifests/07-operator.yaml
@@ -8,6 +8,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   replicas: 1
   selector:

--- a/manifests/08-clusteroperator.yaml
+++ b/manifests/08-clusteroperator.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec: {}
 status:
   versions:

--- a/manifests/09-console-link-openshift-blog.yaml
+++ b/manifests/09-console-link-openshift-blog.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   href: 'https://blog.openshift.com'
   location: HelpMenu

--- a/manifests/09-console-link-openshift-learning-portal.yaml
+++ b/manifests/09-console-link-openshift-learning-portal.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   href: 'https://learn.openshift.com/?ref=webconsole'
   location: HelpMenu

--- a/quickstarts/README.md
+++ b/quickstarts/README.md
@@ -25,6 +25,7 @@ cluster profile annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 ```
 
 See the

--- a/quickstarts/add-healthchecks-quickstart.yaml
+++ b/quickstarts/add-healthchecks-quickstart.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   version: 4.7
   displayName: Adding health checks to your sample application

--- a/quickstarts/explore-pipeline-quickstart.yaml
+++ b/quickstarts/explore-pipeline-quickstart.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   version: 4.7
   displayName: Installing the Pipelines Operator

--- a/quickstarts/explore-serverless-quickstart.yaml
+++ b/quickstarts/explore-serverless-quickstart.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   version: 4.7
   displayName: Setting up Serverless

--- a/quickstarts/monitor-sampleapp-quickstart.yaml
+++ b/quickstarts/monitor-sampleapp-quickstart.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   version: 4.7
   displayName: Monitoring your sample application

--- a/quickstarts/sample-application-quickstart.yaml
+++ b/quickstarts/sample-application-quickstart.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   version: 4.7
   displayName: Getting started with a sample


### PR DESCRIPTION
This adds annotations for the single-node-production-edge cluster profile. There's a growing requirement from several customers to enable creation of single-node (not high-available) Openshift clusters.
In stage one (following openshift/enhancements#504) there should be no implication on components logic.
In the next stage, the component's behavior will match a non high-availability profile if the customer is specifically interested in one.
This PR is separate from the 'single-node-developer' work, which will implement a different behavior and is currently on another stage of implementation.

For more info, please refer to the enhancement link and participate in the discussion.