### PR TITLE
Bug 1906798: Export operator dev catalog customization to console-config ConfigMap

### DIFF
--- a/pkg/console/subresource/configmap/configmap.go
+++ b/pkg/console/subresource/configmap/configmap.go
@@ -67,6 +67,7 @@ func DefaultConfigMap(
 		Monitoring(monitoringSharedConfig).
 		CustomLogoFile(operatorConfig.Spec.Customization.CustomLogoFile.Key).
 		CustomProductName(operatorConfig.Spec.Customization.CustomProductName).
+		CustomDeveloperCatalog(operatorConfig.Spec.Customization.DeveloperCatalog).
 		CustomHostnameRedirectPort(routesub.IsCustomRouteSet(operatorConfig)).
 		StatusPageID(statusPageId(operatorConfig)).
 		InactivityTimeout(inactivityTimeoutSeconds).

--- a/pkg/console/subresource/consoleserver/types.go
+++ b/pkg/console/subresource/consoleserver/types.go
@@ -1,7 +1,7 @@
 package consoleserver
 
 // This file is a copy of the struct within the console itself:
-//   https://github.com/openshift/console/blob/master/cmd/bridge/config.go
+//   https://github.com/openshift/console/blob/master/pkg/serverconfig/types.go
 // These structs need to remain in sync.
 //
 // `yaml:",omitempty"` has not been applied to any of the properties currently
@@ -69,6 +69,34 @@ type Customization struct {
 	DocumentationBaseURL string `yaml:"documentationBaseURL,omitempty"`
 	CustomProductName    string `yaml:"customProductName,omitempty"`
 	CustomLogoFile       string `yaml:"customLogoFile,omitempty"`
+	// developerCatalog allows to configure the shown developer catalog categories.
+	DeveloperCatalog *DeveloperConsoleCatalogCustomization `yaml:"developerCatalog,omitempty"`
+}
+
+// DeveloperConsoleCatalogCustomization allow cluster admin to configure developer catalog.
+type DeveloperConsoleCatalogCustomization struct {
+	// categories which are shown the in developer catalog.
+	Categories *[]DeveloperConsoleCatalogCategory `yaml:"categories"`
+}
+
+// DeveloperConsoleCatalogCategoryMeta are the key identifiers of a developer catalog category.
+type DeveloperConsoleCatalogCategoryMeta struct {
+	// ID is an identifier used in the URL to enable deep linking in console.
+	// ID is required and must have 1-32 URL safe (A-Z, a-z, 0-9, - and _) characters.
+	ID string `yaml:"id"`
+	// label defines a category display label. It is required and must have 1-64 characters.
+	Label string `yaml:"label"`
+	// tags is a list of strings that will match the category. A selected category
+	// show all items which has at least one overlapping tag between category and item.
+	Tags []string `yaml:"tags,omitempty"`
+}
+
+// DeveloperConsoleCatalogCategory for the developer console catalog.
+type DeveloperConsoleCatalogCategory struct {
+	// defines top level category ID, label and filter tags.
+	DeveloperConsoleCatalogCategoryMeta `yaml:",inline"`
+	// subcategories defines a list of child categories.
+	Subcategories []DeveloperConsoleCatalogCategoryMeta `yaml:"subcategories,omitempty"`
 }
 
 type Providers struct {


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/ODC-5238
https://bugzilla.redhat.com/show_bug.cgi?id=1906798

**Analysis / Root cause**:
With the changes in https://github.com/openshift/api/pull/763, https://github.com/openshift/console-operator/pull/484 and https://github.com/openshift/console/pull/7196 we prepared that the developer catalog categories could be customized by the admin.

But changes to the Console (operator.openshift.io/v1) resource "cluster"  was not transferred to the ConfigMap "console-config" (in namespace "openshift-console") data entry `console-config.yaml`. This config entry was used as mounted console-config.yaml when starting a bridge.

**Solution Description**: 
The Console "cluster" customization data was not copied 1:1 to the ConfigMap "console-config". So it was required to extend config_builder.go similar to other customization options.

This PR adds the types for dev console catalog customization and map all categories from "operatorv1.DeveloperConsoleCatalogCustomization" to "consoleserer.DeveloperConsoleCatalogCustomization".

:warning: The copied type differs from the API type by using a pointer to a categories array.

```diff
// DeveloperConsoleCatalogCustomization allow cluster admin to configure developer catalog.
type DeveloperConsoleCatalogCustomization struct {
	// categories which are shown the in developer catalog.
- 	Categories []DeveloperConsoleCatalogCategory `yaml:"categories"`
+ 	Categories *[]DeveloperConsoleCatalogCategory `yaml:"categories"`
}
```

This was required to create different YAML output for "no categories" and "zero categories".

**Unit tests**
Extended the `config_builder_test.go` with new use cases for
* no custom categories configuration => will show the default categories in frontend
* zero custom categories => will hide all categories in frontend
* some custom categories (with subcategories) => will show this categories in frontend

**Manual tests on a cluster**
Started with `launch openshift/console-operator#495`

Links an on cluster:
* `Console` "cluster": `..../k8s/cluster/operator.openshift.io~v1~Console/cluster/yaml`
* `ConfigMap` "console-config"": `...../k8s/ns/openshift-console/configmaps/console-config/yaml`

#### Testcase 0: The initial data on a cluster was

```yaml
apiVersion: operator.openshift.io/v1
kind: Console
metadata:
  name: cluster
  ...
spec:
  logLevel: Normal
  managementState: Managed
  operatorLogLevel: Normal
status:
  ...
```

```yaml
kind: ConfigMap
apiVersion: v1
metadata:
  name: console-config
  namespace: openshift-console
  ...
data:
  console-config.yaml: |
    kind: ConsoleConfig
    apiVersion: console.openshift.io/v1
    customization:
      branding: ocp
      documentationBaseURL: https://docs.openshift.com/container-platform/4.7/
    ...
```

```tsx
SERVER_FLAGS = {..., "developerCatalogCategories":""}
```

* No default customization :heavy_check_mark: 
* Frontend shows the default (hard coded) categories :heavy_check_mark: 

#### Testcase 1: Adding customization and developerCatalog section without categories

```diff
kind: Console
spec:
  logLevel: Normal
  managementState: Managed
  operatorLogLevel: Normal
+   customization:
+     developerCatalog: {}
```

* ConfigMap does not changes (because of the omitempty attributes) :heavy_check_mark: 
* Does not trigger any new Pod. :heavy_check_mark: 
* SERVER_FLAGS developerCatalogCategories is still ""  :heavy_check_mark: 

#### Testcase 2: Change to an empty categories array

```diff
kind: Console
spec:
  logLevel: Normal
  managementState: Managed
  operatorLogLevel: Normal
  customization:
-     developerCatalog: {}
+     developerCatalog:
+       categories: []
```

ConfigMap was automatically changed to:

```diff
kind: ConfigMap
data:
  console-config.yaml: |
    apiVersion: console.openshift.io/v1
    customization:
      branding: ocp
+       developerCatalog:
+         categories: []
      documentationBaseURL: https://docs.openshift.com/container-platform/4.7/
```

* ConfigMap changed :heavy_check_mark: 
* New pods are started. :heavy_check_mark: 
* SERVER_FLAGS developerCatalogCategories is now "[]"  :heavy_check_mark: 
* Frontend shows no categories :heavy_check_mark: 

:warning: The frontend needs a manual refresh to shot the latest categories.

![image](https://user-images.githubusercontent.com/139310/101770724-2bb4eb00-3ae9-11eb-9c34-f5db0c6bb208.png)

#### Testcase 3: Change to some real categories

```diff
kind: Console
spec:
  logLevel: Normal
  managementState: Managed
  operatorLogLevel: Normal
  customization:
     developerCatalog:
-       categories: []
+       categories:
+         - id: java
+           label: Java
+           subcategories:
+             - id: javaonly
+               label: Java Only
+               tags:
+                 - java
+             - id: quarkus
+               label: Quarkus Only
+               tags:
+                 - quarkus
+           tags:
+             - jvm
+             - java
+             - quarkus
```

ConfigMap was changed to:

```diff
kind: ConfigMap
data:
  console-config.yaml: |
    apiVersion: console.openshift.io/v1
    customization:
      branding: ocp
      developerCatalog:
        categories:
+         - id: java
+           label: Java
+           subcategories:
+           - id: javaonly
+             label: Java Only
+             tags:
+             - java
+           - id: quarkus
+             label: Quarkus Only
+             tags:
+             - quarkus
+           tags:
+           - jvm
+           - java
+           - quarkus
      documentationBaseURL: https://docs.openshift.com/container-platform/4.7/
```

* ConfigMap changed :heavy_check_mark: 
* New pods are started. :heavy_check_mark: 
* SERVER_FLAGS developerCatalogCategories is now "[{\"id\":\"java\",\"label\":\"Java\",\"tags\":[\"jvm\",\"java\",\"quarkus\"],\"subcategories\":[{\"id\":\"javaonly\",\"label\":\"Java Only\",\"tags\":[\"java\"]},{\"id\":\"quarkus\",\"label\":\"Quarkus Only\",\"tags\":[\"quarkus\"]}]}]"  :heavy_check_mark: 
* Frontend shows no categories :heavy_check_mark: 

:warning: The frontend needs a manual refresh to shot the latest categories.
:warning: Categories without matching items are not shown in the sidebar.

![Peek 2020-12-10 13-20](https://user-images.githubusercontent.com/139310/101771647-8dc22000-3aea-11eb-97a7-a571891cbb3a.gif)
