### PR TITLE
Bug 1906713: Logged user should be able to get consolequickstarts

### DIFF
--- a/manifests/03-rbac-role-cluster-extensions.yaml
+++ b/manifests/03-rbac-role-cluster-extensions.yaml
@@ -17,6 +17,7 @@ rules:
   - consoleexternalloglinks
   - consoleclidownloads
   - consoleyamlsamples
+  - consolequickstarts
   verbs:
   - get
   - list


### PR DESCRIPTION
/assign @spadgett 