### PR TITLE
Bug 1917759: Dont panic after setting plugin that does not exists to the console-operator config

### DIFF
--- a/pkg/console/operator/sync_v400.go
+++ b/pkg/console/operator/sync_v400.go
@@ -510,7 +510,8 @@ func (co *consoleOperator) GetPluginsEndpointMap(enabledPluginsNames []string) m
 	for _, pluginName := range enabledPluginsNames {
 		plugin, err := co.consolePluginLister.Get(pluginName)
 		if err != nil {
-			klog.Errorf("failed to set service endpoint for %q plugin: %v", pluginName, err)
+			klog.Errorf("failed to get %q plugin: %v", pluginName, err)
+			continue
 		}
 		pluginsEndpointMap[pluginName] = getServiceHostname(plugin)
 	}


### PR DESCRIPTION
When we fail to fetch any of the set plugins in the console-operator config, dont set an endpoint for it and just skip it.
If the plugins will be created additionally, informer will trigger a next sync loop.


also update e2e test for adding available and unavailable plugin names to the console-operator config

/assign @spadgett 