### PR TITLE
New 4.7 Quick Starts focusing on the developer experience

### DIFF
--- a/quickstarts/manage-helm-repos.yaml
+++ b/quickstarts/manage-helm-repos.yaml
@@ -1,0 +1,78 @@
+apiVersion: console.openshift.io/v1
+kind: ConsoleQuickStart
+metadata:
+  name: manage-helm-repos
+spec:
+  description: Manage available content in the Helm Chart Catalog by adding a Helm Chart Repository.
+  displayName: Manage available content in the Helm Chart Catalog
+  durationMinutes: 5
+  accessReviewResources:
+    - group: helm.openshift.io
+      resource: helmchartrepositories
+      verb: create
+  icon: >-
+    data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHJvbGU9ImltZyIgdmlld0JveD0iLTYuNDkgLTYuNzQgMzE2LjQ5IDM2My43NCI+PG1hc2sgaWQ9ImEiIGZpbGw9IiNmZmYiPjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgZD0ibTAgMGgzMTMuMzAzMTU1djE1OS44NjQ4NjVoLTMxMy4zMDMxNTV6Ii8+PC9tYXNrPjxtYXNrIGlkPSJiIiBmaWxsPSIjZmZmIj48cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGQ9Im0wIDBoMzEzLjMwMzE1NXYxNTkuODY0ODY1aC0zMTMuMzAzMTU1eiIvPjwvbWFzaz48ZyBmaWxsPSJub25lIiBmaWxsLXJ1bGU9ImV2ZW5vZGQiPjxwYXRoIGZpbGw9IiMwMDAiIGQ9Im0xMS42Nzg1NzE0IDE4OWgxOS43ODU4MzU3djI2Ljc4OWgyMy45MDM3di0yNi43ODloMTkuNzg1ODM1OHY3NS4yNWgtMTkuNzg1ODM1OHYtMjguNjk1MzMzaC0yMy45MDM3djI4LjY5NTMzM2gtMTkuNzg1ODM1N3ptODYuMTczODQyOSA3NS4yNXYtNzUuMjVoNDYuODAzMDQyN3YxNi4zNTQzMzNoLTI3LjAxNzIwN3YxMi4yNDA2NjdoMjMuOTAzN3YxNi42NTUzMzNoLTIzLjkwMzd2MTMuODQ2aDI3LjAxNzIwN3YxNi4xNTM2Njd6bTY4LjQ5NzE1NjcgMHYtNzUuMjVoMTkuNzg1ODM2djU1LjM4NGgyNy4xMTc2NDN2MTkuODY2em03Ny41MzYzNzItNzUuMjUgMzAuNzMzMzI4IDI3Ljg5MjY2NyAzMC42MzI4OTMtMjcuODkyNjY3aDguOTM4Nzc5djc1LjI1aC0xOS44ODYyNzJ2LTM4LjYyODMzM2wtMTkuNjg1NCAxNy45NTk2NjYtMTkuNzg1ODM1LTE3Ljg1OTMzM3YzOC41MjhoLTE5Ljg4NjI3MnYtNzUuMjV6IiB0cmFuc2Zvcm09InRyYW5zbGF0ZSgtMTEgLTUxKSIvPjxnPjxnIGZpbGw9IiMwMDAiIG1hc2s9InVybCgjYSkiIHRyYW5zZm9ybT0ibWF0cml4KDEgMCAwIC0xIC45NTggNDA0KSI+PHBhdGggZD0ibTIwMy40NjA2NzYgOTUuNjg3NTQyNWM2LjkzNjMxIDAgMTIuNTU5MzAxLTE0LjgwOTIxOTQgMTIuNTU5MzAxLTMzLjA3NzMxNzJzLTUuNjIyOTkxLTMzLjA3NzMxNzItMTIuNTU5MzAxLTMzLjA3NzMxNzJjLTYuOTM2MzExIDAtMTIuNTU5MzAxIDE0LjgwOTIxOTQtMTIuNTU5MzAxIDMzLjA3NzMxNzJzNS42MjI5OSAzMy4wNzczMTcyIDEyLjU1OTMwMSAzMy4wNzczMTcyeiIgdHJhbnNmb3JtPSJyb3RhdGUoMzUgMTM3LjkzMSAxNTEuNTUpIi8+PHBhdGggZD0ibTMwLjE0MjMyMjMgOTUuNjg3NTQyNWM2LjkzNjMxMDQgMCAxMi41NTkzMDEtMTQuODA5MjE5NCAxMi41NTkzMDEtMzMuMDc3MzE3MnMtNS42MjI5OTA2LTMzLjA3NzMxNzItMTIuNTU5MzAxLTMzLjA3NzMxNzItMTIuNTU5MzAwOSAxNC44MDkyMTk0LTEyLjU1OTMwMDkgMzMuMDc3MzE3MiA1LjYyMjk5MDUgMzMuMDc3MzE3MiAxMi41NTkzMDA5IDMzLjA3NzMxNzJ6IiB0cmFuc2Zvcm09InNjYWxlKC0xIDEpIHJvdGF0ZSgzNSAtMTA0LjY5MiAtNjguMjU4KSIvPjxwYXRoIGQ9Im0xMTYuNzMyODE1IDY2LjI3NTI2NzZjNi45MzYzMTEgMCAxMi41NTkzMDEtMTQuODA5MjE5MyAxMi41NTkzMDEtMzMuMDc3MzE3MiAwLTE4LjI2ODA5NzgtNS42MjI5OS0zMy4wNzczMTcxMy0xMi41NTkzMDEtMzMuMDc3MzE3MTMtNi45MzYzMSAwLTEyLjU1OTMwMSAxNC44MDkyMTkzMy0xMi41NTkzMDEgMzMuMDc3MzE3MTMgMCAxOC4yNjgwOTc5IDUuNjIyOTkxIDMzLjA3NzMxNzIgMTIuNTU5MzAxIDMzLjA3NzMxNzJ6IiB0cmFuc2Zvcm09Im1hdHJpeCgtMSAwIDAgMSAyNzIuNjI5IDUzLjY3KSIvPjwvZz48cGF0aCBzdHJva2U9IiMwMDAiIHN0cm9rZS13aWR0aD0iMjAiIGQ9Im0yNTEuNDY3MDA2IDE3My4wOTk4NDljLTIwLjIzMDA3Ni0zMy42MDk5NjktNTYuODg5NTY1LTU2LjA2NzkwOC05OC43NTU3NzYtNTYuMDY3OTA4LTQwLjcyMDc5OCAwLTc2LjUxNTg3NjYgMjEuMjQ1OTAxLTk3LjA1ODY5NTkgNTMuMzM0NTg4bTIuMTk4MTEwNyAxMjkuMTY5NTM0YzIwLjg0MDMwMzYgMzAuMjMyNzAxIDU1LjU1NTkwNDIgNTAuMDI2NTkxIDk0Ljg2MDU4NTIgNTAuMDI2NTkxIDM5LjM3NjA5OSAwIDc0LjE0NjQyNC0xOS44NjU4ODcgOTQuOTc0MDQ5LTUwLjE5MTQ5NSIgbWFzaz0idXJsKCNhKSIgdHJhbnNmb3JtPSJtYXRyaXgoMSAwIDAgLTEgLjk1OCA0MDQpIi8+PC9nPjxnPjxnIGZpbGw9IiMwMDAiIG1hc2s9InVybCgjYikiIHRyYW5zZm9ybT0idHJhbnNsYXRlKC45NTggLTUxKSI+PHBhdGggZD0ibTIwMy40NjA2NzYgOTUuNjg3NTQyNWM2LjkzNjMxIDAgMTIuNTU5MzAxLTE0LjgwOTIxOTQgMTIuNTU5MzAxLTMzLjA3NzMxNzJzLTUuNjIyOTkxLTMzLjA3NzMxNzItMTIuNTU5MzAxLTMzLjA3NzMxNzJjLTYuOTM2MzExIDAtMTIuNTU5MzAxIDE0LjgwOTIxOTQtMTIuNTU5MzAxIDMzLjA3NzMxNzJzNS42MjI5OSAzMy4wNzczMTcyIDEyLjU1OTMwMSAzMy4wNzczMTcyeiIgdHJhbnNmb3JtPSJyb3RhdGUoMzUgMTQxLjgzMSAxNTAuMzIpIi8+PHBhdGggZD0ibTMwLjE0MjMyMjMgOTUuNjg3NTQyNWM2LjkzNjMxMDQgMCAxMi41NTkzMDEtMTQuODA5MjE5NCAxMi41NTkzMDEtMzMuMDc3MzE3MnMtNS42MjI5OTA2LTMzLjA3NzMxNzItMTIuNTU5MzAxLTMzLjA3NzMxNzItMTIuNTU5MzAwOSAxNC44MDkyMTk0LTEyLjU1OTMwMDkgMzMuMDc3MzE3MiA1LjYyMjk5MDUgMzMuMDc3MzE3MiAxMi41NTkzMDA5IDMzLjA3NzMxNzJ6IiB0cmFuc2Zvcm09InNjYWxlKC0xIDEpIHJvdGF0ZSgzNSAtMTAwLjc5MiAtNjkuNDg4KSIvPjxwYXRoIGQ9Im0xMTYuNzMyODE1IDY2LjI3NTI2NzZjNi45MzYzMTEgMCAxMi41NTkzMDEtMTQuODA5MjE5MyAxMi41NTkzMDEtMzMuMDc3MzE3MiAwLTE4LjI2ODA5NzgtNS42MjI5OS0zMy4wNzczMTcxMy0xMi41NTkzMDEtMzMuMDc3MzE3MTMtNi45MzYzMSAwLTEyLjU1OTMwMSAxNC44MDkyMTkzMy0xMi41NTkzMDEgMzMuMDc3MzE3MTMgMCAxOC4yNjgwOTc5IDUuNjIyOTkxIDMzLjA3NzMxNzIgMTIuNTU5MzAxIDMzLjA3NzMxNzJ6IiB0cmFuc2Zvcm09Im1hdHJpeCgtMSAwIDAgMSAyNzIuNjI5IDUxLjIxMSkiLz48L2c+PHBhdGggc3Ryb2tlPSIjMDAwIiBzdHJva2Utd2lkdGg9IjIwIiBkPSJtMjUxLjQ2NzAwNiAxNzAuNjQwMzljLTIwLjIzMDA3Ni0zMy42MDk5NjktNTYuODg5NTY1LTU2LjA2NzkwOC05OC43NTU3NzYtNTYuMDY3OTA4LTQwLjcyMDc5OCAwLTc2LjUxNTg3NjYgMjEuMjQ1OS05Ny4wNTg2OTU5IDUzLjMzNDU4N20yLjE5ODExMDcgMTI5LjE2OTUzNGMyMC44NDAzMDM2IDMwLjIzMjcwMiA1NS41NTU5MDQyIDUwLjAyNjU5MSA5NC44NjA1ODUyIDUwLjAyNjU5MSAzOS4zNzYwOTkgMCA3NC4xNDY0MjQtMTkuODY1ODg2IDk0Ljk3NDA0OS01MC4xOTE0OTQiIG1hc2s9InVybCgjYikiIHRyYW5zZm9ybT0idHJhbnNsYXRlKC45NTggLTUxKSIvPjwvZz48L2c+PC9zdmc+Cg==
+  introduction: >-
+    Content in the Helm Chart Catalog is defined by HelmChartRepository (HCR) CRs.
+    The HelmChartRepository (HCR) provides a URL, the Helm Catalog is populated
+    by pulling available Helm Charts from each of the HCR URLs.
+    
+    - HCRs are cluster scoped. 
+    
+    - A default HelmChartRepository (HCR) is provided, called the **redhat-helm-repo**.
+    
+    - An administrator can add additional HCRs to provide additional Helm Charts.
+  tags:
+    - helm
+  tasks:
+    - description: >-
+        Follow these steps to create a HelmChartRepository CR:
+
+        1. Click on the [perspective switcher]{{highlight qs-perspective-switcher}} at the top of the navigation, and select **Administrator**.
+        
+        1. In the navigation menu, click [Home]{{highlight qs-nav-home}}.
+        
+        1. In the [Home navigation section]{{highlight qs-nav-home}}, click **Search**.
+        
+        1. Click the **Resources dropdown** menu and select **HelmChartRepository**.
+        
+        1. Click **Create HelmChartRepository** to bring up the YAML editor.
+        
+        1. Replace the contents of the YAML editor with:
+
+            ```
+            apiVersion: helm.openshift.io/v1beta1
+            kind: HelmChartRepository
+
+            metadata:
+              name: azure-sample-repo
+
+            spec:
+              name: azure-sample-repo
+
+              connectionConfig:
+                url: https://raw.githubusercontent.com/Azure-Samples/helm-charts/master/docs
+            ```
+
+        1. Click **Create**.
+
+      review:
+        failedTaskHelp: This task isn’t verified yet. Try the task again.
+        instructions: >-
+          Verify that the HelmChartRepository was successfully installed:
+
+          1. Click on the [perspective switcher]{{highlight qs-perspective-switcher}} at the top of the navigation, and select **Developer**.
+
+          1. In the navigation menu, click [Add]{{highlight qs-nav-add}}.
+          
+          1. On the **+Add** page, click **Helm Chart**. 
+          
+          1. Confirm that the **azure-sample-repo** is an available catalog.
+
+          1. In the **Chart Repositories** filter, do you see **azure-sample-repo**?
+
+      summary:
+        failed: Try the steps again.
+        success: >-
+          Charts from the **azure-sample-repo** repository are now available.
+      title: Create a HelmChartRepository CR

--- a/quickstarts/node-with-s2i.yaml
+++ b/quickstarts/node-with-s2i.yaml
@@ -1,0 +1,152 @@
+﻿apiVersion: console.openshift.io/v1
+kind: ConsoleQuickStart
+metadata:
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: 'true'
+    include.release.openshift.io/self-managed-high-availability: 'true'
+    include.release.openshift.io/single-node-developer: 'true'
+  name: node-with-s2i
+spec:
+  description: 'Import a Node Application from git, build, and deploy it onto OpenShift.'
+  displayName: Get started with Node
+  durationMinutes: 10
+  icon: >-
+    data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDIwLjEuMCwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPgo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCAzMiAzMiIgc3R5bGU9ImVuYWJsZS1iYWNrZ3JvdW5kOm5ldyAwIDAgMzIgMzI7IiB4bWw6c3BhY2U9InByZXNlcnZlIj4KPHN0eWxlIHR5cGU9InRleHQvY3NzIj4KCS5zdDB7ZmlsbDojNjk5RjYzO30KCS5zdDF7ZmlsbC1ydWxlOmV2ZW5vZGQ7Y2xpcC1ydWxlOmV2ZW5vZGQ7ZmlsbDojMzMzMzMzO30KCS5zdDJ7ZmlsbC1ydWxlOmV2ZW5vZGQ7Y2xpcC1ydWxlOmV2ZW5vZGQ7ZmlsbDojNjk5RjYzO30KCS5zdDN7Y2xpcC1wYXRoOnVybCgjWE1MSURfNV8pO30KCS5zdDR7ZmlsbDpub25lO30KCS5zdDV7ZmlsbDp1cmwoI1NWR0lEXzFfKTt9Cgkuc3Q2e2ZpbGw6dXJsKCNTVkdJRF8yXyk7fQoJLnN0N3tmaWxsOnVybCgjU1ZHSURfM18pO30KCS5zdDh7ZmlsbDp1cmwoI1NWR0lEXzRfKTt9Cgkuc3Q5e2ZpbGw6dXJsKCNTVkdJRF81Xyk7fQoJLnN0MTB7ZmlsbDp1cmwoI1NWR0lEXzZfKTt9Cjwvc3R5bGU+CjxnPgoJPGc+CgkJPHBhdGggY2xhc3M9InN0MCIgZD0iTTE1LjgyLDI1LjY1Yy0wLjExLDAtMC4yMS0wLjAzLTAuMy0wLjA4TDE0LjU1LDI1Yy0wLjE0LTAuMDgtMC4wNy0wLjExLTAuMDMtMC4xMwoJCQljMC4xOS0wLjA3LDAuMjMtMC4wOCwwLjQ0LTAuMmMwLjAyLTAuMDEsMC4wNS0wLjAxLDAuMDcsMC4wMWwwLjc0LDAuNDRjMC4wMywwLjAxLDAuMDYsMC4wMSwwLjA5LDBsMi44OS0xLjY3CgkJCWMwLjAzLTAuMDIsMC4wNC0wLjA1LDAuMDQtMC4wOHYtMy4zNGMwLTAuMDMtMC4wMi0wLjA2LTAuMDQtMC4wOGwtMi44OS0xLjY3Yy0wLjAzLTAuMDItMC4wNi0wLjAyLTAuMDksMGwtMi44OSwxLjY3CgkJCWMtMC4wMywwLjAyLTAuMDUsMC4wNS0wLjA1LDAuMDh2My4zNGMwLDAuMDMsMC4wMiwwLjA2LDAuMDUsMC4wOGwwLjc5LDAuNDZjMC40MywwLjIxLDAuNjktMC4wNCwwLjY5LTAuMjl2LTMuMjkKCQkJYzAtMC4wNSwwLjA0LTAuMDgsMC4wOC0wLjA4aDAuMzdjMC4wNSwwLDAuMDgsMC4wNCwwLjA4LDAuMDh2My4yOWMwLDAuNTctMC4zMSwwLjktMC44NiwwLjljLTAuMTcsMC0wLjMsMC0wLjY3LTAuMThsLTAuNzYtMC40NAoJCQljLTAuMTktMC4xMS0wLjMtMC4zMS0wLjMtMC41M3YtMy4zNGMwLTAuMjIsMC4xMi0wLjQyLDAuMy0wLjUzbDIuODktMS42N2MwLjE4LTAuMSwwLjQzLTAuMSwwLjYxLDBsMi44OSwxLjY3CgkJCWMwLjE5LDAuMTEsMC4zLDAuMzEsMC4zLDAuNTN2My4zNGMwLDAuMjItMC4xMiwwLjQyLTAuMywwLjUzbC0yLjg5LDEuNjdDMTYuMDMsMjUuNjIsMTUuOTIsMjUuNjUsMTUuODIsMjUuNjV6Ii8+CgkJPHBhdGggY2xhc3M9InN0MCIgZD0iTTE2LjcxLDIzLjM1Yy0xLjI2LDAtMS41My0wLjU4LTEuNTMtMS4wN2MwLTAuMDUsMC4wNC0wLjA4LDAuMDgtMC4wOGgwLjM3YzAuMDQsMCwwLjA4LDAuMDMsMC4wOCwwLjA3CgkJCWMwLjA2LDAuMzgsMC4yMiwwLjU3LDAuOTksMC41N2MwLjYxLDAsMC44Ny0wLjE0LDAuODctMC40NmMwLTAuMTktMC4wNy0wLjMyLTEuMDItMC40MmMtMC43OS0wLjA4LTEuMjgtMC4yNS0xLjI4LTAuODkKCQkJYzAtMC41OCwwLjQ5LTAuOTMsMS4zMi0wLjkzYzAuOTMsMCwxLjM4LDAuMzIsMS40NCwxLjAxYzAsMC4wMi0wLjAxLDAuMDUtMC4wMiwwLjA2Yy0wLjAyLDAuMDItMC4wNCwwLjAzLTAuMDYsMC4wM2gtMC4zOAoJCQljLTAuMDQsMC0wLjA3LTAuMDMtMC4wOC0wLjA3Yy0wLjA5LTAuNC0wLjMxLTAuNTMtMC45LTAuNTNjLTAuNjYsMC0wLjc0LDAuMjMtMC43NCwwLjQxYzAsMC4yMSwwLjA5LDAuMjcsMC45OSwwLjM5CgkJCWMwLjg5LDAuMTIsMS4zMSwwLjI4LDEuMzEsMC45MUMxOC4xNSwyMi45OSwxNy42MiwyMy4zNSwxNi43MSwyMy4zNXoiLz4KCTwvZz4KCTxnPgoJCTxwYXRoIGNsYXNzPSJzdDAiIGQ9Ik0yMC44OCwxOS44NmMwLDAuMzEtMC4yNSwwLjU2LTAuNTYsMC41NmMtMC4zLDAtMC41Ni0wLjI1LTAuNTYtMC41NmMwLTAuMzIsMC4yNi0wLjU2LDAuNTYtMC41NgoJCQlDMjAuNjIsMTkuMywyMC44OCwxOS41NCwyMC44OCwxOS44NnogTTE5Ljg1LDE5Ljg2YzAsMC4yNiwwLjIxLDAuNDcsMC40NywwLjQ3YzAuMjYsMCwwLjQ3LTAuMjEsMC40Ny0wLjQ3CgkJCWMwLTAuMjYtMC4yMS0wLjQ3LTAuNDctMC40N0MyMC4wNiwxOS4zOSwxOS44NSwxOS41OSwxOS44NSwxOS44NnogTTIwLjExLDE5LjU0aDAuMjJjMC4wNywwLDAuMjIsMCwwLjIyLDAuMTcKCQkJYzAsMC4xMS0wLjA3LDAuMTQtMC4xMiwwLjE1YzAuMDksMC4wMSwwLjA5LDAuMDYsMC4xLDAuMTRjMC4wMSwwLjA1LDAuMDEsMC4xNCwwLjAzLDAuMTZoLTAuMTNjMC0wLjAzLTAuMDItMC4xOS0wLjAyLTAuMgoJCQljLTAuMDEtMC4wNC0wLjAyLTAuMDUtMC4wNi0wLjA1aC0wLjExdjAuMjVoLTAuMTJWMTkuNTR6IE0yMC4yMywxOS44MmgwLjFjMC4wOCwwLDAuMDktMC4wNiwwLjA5LTAuMDkKCQkJYzAtMC4wOS0wLjA2LTAuMDktMC4wOS0wLjA5aC0wLjFWMTkuODJ6Ii8+Cgk8L2c+Cgk8cGF0aCBjbGFzcz0ic3QxIiBkPSJNNi44NywxMi42YzAtMC4xMy0wLjA3LTAuMjYtMC4xOS0wLjMybC0zLjA2LTEuNzZjLTAuMDUtMC4wMy0wLjExLTAuMDUtMC4xNy0wLjA1Yy0wLjAxLDAtMC4wMywwLTAuMDMsMAoJCWMtMC4wNiwwLTAuMTIsMC4wMi0wLjE3LDAuMDVsLTMuMDYsMS43NkMwLjA3LDEyLjM1LDAsMTIuNDcsMCwxMi42bDAuMDEsNC43NWMwLDAuMDcsMC4wMywwLjEzLDAuMDksMC4xNgoJCWMwLjA2LDAuMDMsMC4xMywwLjAzLDAuMTgsMGwxLjgyLTEuMDRjMC4xMi0wLjA3LDAuMTktMC4xOSwwLjE5LTAuMzJ2LTIuMjJjMC0wLjEzLDAuMDctMC4yNSwwLjE4LTAuMzJsMC43OC0wLjQ1CgkJYzAuMDYtMC4wMywwLjEyLTAuMDUsMC4xOS0wLjA1YzAuMDYsMCwwLjEzLDAuMDIsMC4xOCwwLjA1bDAuNzgsMC40NWMwLjExLDAuMDcsMC4xOSwwLjE5LDAuMTksMC4zMnYyLjIyCgkJYzAsMC4xMywwLjA3LDAuMjUsMC4xOSwwLjMybDEuODIsMS4wNGMwLjA2LDAuMDMsMC4xMywwLjAzLDAuMTksMGMwLjA2LTAuMDMsMC4wOS0wLjA5LDAuMDktMC4xNkw2Ljg3LDEyLjZ6Ii8+Cgk8cGF0aCBjbGFzcz0ic3QxIiBkPSJNMjEuNjEsNi4wOGMtMC4wNi0wLjAzLTAuMTMtMC4wMy0wLjE4LDBjLTAuMDYsMC4wMy0wLjA5LDAuMDktMC4wOSwwLjE2djQuN2MwLDAuMDUtMC4wMiwwLjA5LTAuMDYsMC4xMQoJCWMtMC4wNCwwLjAyLTAuMDksMC4wMi0wLjEzLDBsLTAuNzctMC40NGMtMC4xMS0wLjA3LTAuMjYtMC4wNy0wLjM3LDBsLTMuMDcsMS43N2MtMC4xMSwwLjA3LTAuMTksMC4xOS0wLjE5LDAuMzJ2My41NAoJCWMwLDAuMTMsMC4wNywwLjI1LDAuMTksMC4zMkwyMCwxOC4zM2MwLjExLDAuMDcsMC4yNiwwLjA3LDAuMzcsMGwzLjA3LTEuNzdjMC4xMS0wLjA3LDAuMTktMC4xOSwwLjE5LTAuMzJWNy40MgoJCWMwLTAuMTMtMC4wNy0wLjI2LTAuMTktMC4zMkwyMS42MSw2LjA4eiBNMjEuMzMsMTUuMDhjMCwwLjAzLTAuMDIsMC4wNi0wLjA1LDAuMDhsLTEuMDUsMC42MWMtMC4wMywwLjAyLTAuMDYsMC4wMi0wLjA5LDAKCQlsLTEuMDUtMC42MWMtMC4wMy0wLjAyLTAuMDUtMC4wNS0wLjA1LTAuMDh2LTEuMjJjMC0wLjAzLDAuMDItMC4wNiwwLjA1LTAuMDhsMS4wNS0wLjYxYzAuMDMtMC4wMiwwLjA2LTAuMDIsMC4wOSwwbDEuMDUsMC42MQoJCWMwLjAzLDAuMDIsMC4wNSwwLjA1LDAuMDUsMC4wOFYxNS4wOHoiLz4KCTxnPgoJCTxwYXRoIGNsYXNzPSJzdDEiIGQ9Ik0zMS44MiwxMy44M2MwLjExLTAuMDcsMC4xOC0wLjE5LDAuMTgtMC4zMnYtMC44NmMwLTAuMTMtMC4wNy0wLjI1LTAuMTgtMC4zMmwtMy4wNS0xLjc3CgkJCWMtMC4xMS0wLjA3LTAuMjYtMC4wNy0wLjM3LDBsLTMuMDYsMS43N2MtMC4xMSwwLjA3LTAuMTksMC4xOS0wLjE5LDAuMzJ2My41NGMwLDAuMTMsMC4wNywwLjI2LDAuMTksMC4zMmwzLjA0LDEuNzQKCQkJYzAuMTEsMC4wNiwwLjI1LDAuMDYsMC4zNiwwbDEuODQtMS4wMmMwLjA2LTAuMDMsMC4wOS0wLjA5LDAuMS0wLjE2YzAtMC4wNy0wLjA0LTAuMTMtMC4wOS0wLjE2bC0zLjA4LTEuNzcKCQkJYy0wLjA2LTAuMDMtMC4wOS0wLjA5LTAuMDktMC4xNnYtMS4xMWMwLTAuMDcsMC4wNC0wLjEzLDAuMDktMC4xNmwwLjk2LTAuNTVjMC4wNi0wLjAzLDAuMTMtMC4wMywwLjE4LDBsMC45NiwwLjU1CgkJCWMwLjA2LDAuMDMsMC4wOSwwLjA5LDAuMDksMC4xNnYwLjg3YzAsMC4wNywwLjA0LDAuMTMsMC4wOSwwLjE2YzAuMDYsMC4wMywwLjEzLDAuMDMsMC4xOSwwTDMxLjgyLDEzLjgzeiIvPgoJCTxwYXRoIGNsYXNzPSJzdDIiIGQ9Ik0yOC41NCwxMy42NmMwLjAyLTAuMDEsMC4wNS0wLjAxLDAuMDcsMEwyOS4yLDE0YzAuMDIsMC4wMSwwLjA0LDAuMDQsMC4wNCwwLjA2djAuNjgKCQkJYzAsMC4wMy0wLjAxLDAuMDUtMC4wNCwwLjA2bC0wLjU5LDAuMzRjLTAuMDIsMC4wMS0wLjA1LDAuMDEtMC4wNywwbC0wLjU5LTAuMzRjLTAuMDItMC4wMS0wLjA0LTAuMDQtMC4wNC0wLjA2di0wLjY4CgkJCWMwLTAuMDMsMC4wMS0wLjA1LDAuMDQtMC4wNkwyOC41NCwxMy42NnoiLz4KCTwvZz4KCTxnPgoJCTxkZWZzPgoJCQk8cGF0aCBpZD0iWE1MSURfMTQzXyIgZD0iTTExLjk5LDEwLjU4Yy0wLjExLTAuMDctMC4yNS0wLjA3LTAuMzcsMGwtMy4wNSwxLjc2Yy0wLjExLDAuMDctMC4xOCwwLjE5LTAuMTgsMC4zMnYzLjUyCgkJCQljMCwwLjEzLDAuMDcsMC4yNSwwLjE4LDAuMzJsMy4wNSwxLjc2YzAuMTEsMC4wNywwLjI1LDAuMDcsMC4zNywwbDMuMDUtMS43NmMwLjExLTAuMDcsMC4xOC0wLjE5LDAuMTgtMC4zMnYtMy41MgoJCQkJYzAtMC4xMy0wLjA3LTAuMjUtMC4xOC0wLjMyTDExLjk5LDEwLjU4eiIvPgoJCTwvZGVmcz4KCQk8bGluZWFyR3JhZGllbnQgaWQ9IlhNTElEXzRfIiBncmFkaWVudFVuaXRzPSJ1c2VyU3BhY2VPblVzZSIgeDE9IjEzLjA0OTQiIHkxPSIxMS44OTE3IiB4Mj0iMTAuMjk1OSIgeTI9IjE3LjUwODkiPgoJCQk8c3RvcCAgb2Zmc2V0PSIwIiBzdHlsZT0ic3RvcC1jb2xvcjojNDE4NzNGIi8+CgkJCTxzdG9wICBvZmZzZXQ9IjAuMzI4OCIgc3R5bGU9InN0b3AtY29sb3I6IzQxOEIzRCIvPgoJCQk8c3RvcCAgb2Zmc2V0PSIwLjYzNTIiIHN0eWxlPSJzdG9wLWNvbG9yOiM0MTk2MzciLz4KCQkJPHN0b3AgIG9mZnNldD0iMC45MzE5IiBzdHlsZT0ic3RvcC1jb2xvcjojM0ZBOTJEIi8+CgkJCTxzdG9wICBvZmZzZXQ9IjEiIHN0eWxlPSJzdG9wLWNvbG9yOiMzRkFFMkEiLz4KCQk8L2xpbmVhckdyYWRpZW50PgoJCTx1c2UgeGxpbms6aHJlZj0iI1hNTElEXzE0M18iICBzdHlsZT0ib3ZlcmZsb3c6dmlzaWJsZTtmaWxsLXJ1bGU6ZXZlbm9kZDtjbGlwLXJ1bGU6ZXZlbm9kZDtmaWxsOnVybCgjWE1MSURfNF8pOyIvPgoJCTxjbGlwUGF0aCBpZD0iWE1MSURfNV8iPgoJCQk8dXNlIHhsaW5rOmhyZWY9IiNYTUxJRF8xNDNfIiAgc3R5bGU9Im92ZXJmbG93OnZpc2libGU7Ii8+CgkJPC9jbGlwUGF0aD4KCQk8ZyBjbGFzcz0ic3QzIj4KCQkJPHBhdGggY2xhc3M9InN0NCIgZD0iTTExLjYyLDEwLjU4bC0zLjI0LDEuNzZDOC4yNywxMi40MSw4LDEyLjUzLDgsMTIuNjZ2My41MmMwLDAuMDksMC4yMiwwLjE3LDAuMjgsMC4yM2wzLjUyLTUuODcKCQkJCUMxMS43MSwxMC41MiwxMS43LDEwLjUzLDExLjYyLDEwLjU4eiIvPgoJCQk8cGF0aCBjbGFzcz0ic3Q0IiBkPSJNMTEuOTEsMTguMjljMC4wMy0wLjAxLDAuMDYtMC4wMiwwLjA5LTAuMDRsMy40My0xLjc2YzAuMTEtMC4wNywwLjU3LTAuMTksMC41Ny0wLjMydi0zLjUyCgkJCQljMC0wLjEtMC40Mi0wLjE5LTAuNDktMC4yNkwxMS45MSwxOC4yOXoiLz4KCQkJPGxpbmVhckdyYWRpZW50IGlkPSJTVkdJRF8xXyIgZ3JhZGllbnRVbml0cz0idXNlclNwYWNlT25Vc2UiIHgxPSIxMS4zNDYzIiB5MT0iMTQuODMxNCIgeDI9IjE5LjA3MjQiIHkyPSI5LjEyMjkiPgoJCQkJPHN0b3AgIG9mZnNldD0iMC4xMzc2IiBzdHlsZT0ic3RvcC1jb2xvcjojNDE4NzNGIi8+CgkJCQk8c3RvcCAgb2Zmc2V0PSIwLjQwMzIiIHN0eWxlPSJzdG9wLWNvbG9yOiM1NEEwNDQiLz4KCQkJCTxzdG9wICBvZmZzZXQ9IjAuNzEzNiIgc3R5bGU9InN0b3AtY29sb3I6IzY2Qjg0OCIvPgoJCQkJPHN0b3AgIG9mZnNldD0iMC45MDgxIiBzdHlsZT0ic3RvcC1jb2xvcjojNkNDMDRBIi8+CgkJCTwvbGluZWFyR3JhZGllbnQ+CgkJCTxwYXRoIGNsYXNzPSJzdDUiIGQ9Ik0xNS4wNSwxMi4zNGwtMy4wNi0xLjc2Yy0wLjAzLTAuMDItMC4wNi0wLjAzLTAuMS0wLjA0bC0zLjQzLDUuODdjMC4wMywwLjAzLDAuMDYsMC4wNiwwLjEsMC4wOGwzLjA2LDEuNzYKCQkJCWMwLjA5LDAuMDUsMC4xOSwwLjA2LDAuMjgsMC4wNGwzLjIyLTUuODlDMTUuMTEsMTIuMzgsMTUuMDgsMTIuMzYsMTUuMDUsMTIuMzR6Ii8+CgkJPC9nPgoJCTxnIGNsYXNzPSJzdDMiPgoJCQk8cGF0aCBjbGFzcz0ic3Q0IiBkPSJNMTYsMTYuMTh2LTMuNTJjMC0wLjEzLTAuNDYtMC4yNS0wLjU3LTAuMzJsLTMuMjUtMS43NmMtMC4wNC0wLjAyLTAuMTctMC4wMy0wLjIxLTAuMDRsMy42OCw1LjcyCgkJCQlDMTUuNjYsMTYuMjQsMTYsMTYuMjEsMTYsMTYuMTh6Ii8+CgkJCTxwYXRoIGNsYXNzPSJzdDQiIGQ9Ik04LjM4LDEyLjM0QzguMjcsMTIuNDEsOCwxMi41Myw4LDEyLjY2djMuNTJjMCwwLjEzLDAuMjcsMC4yNSwwLjM4LDAuMzJsMy4xNSwxLjc2CgkJCQljMC4wNywwLjA0LDAuMiwwLjA2LDAuMjgsMC4wNWwtMy4zNS01Ljk3TDguMzgsMTIuMzR6Ii8+CgkJCTxsaW5lYXJHcmFkaWVudCBpZD0iU1ZHSURfMl8iIGdyYWRpZW50VW5pdHM9InVzZXJTcGFjZU9uVXNlIiB4MT0iOC4yODY3IiB5MT0iOS45NDczIiB4Mj0iMTUuMzMzNiIgeTI9IjkuOTQ3MyI+CgkJCQk8c3RvcCAgb2Zmc2V0PSIwLjA5MTkiIHN0eWxlPSJzdG9wLWNvbG9yOiM2Q0MwNEEiLz4KCQkJCTxzdG9wICBvZmZzZXQ9IjAuMjg2NCIgc3R5bGU9InN0b3AtY29sb3I6IzY2Qjg0OCIvPgoJCQkJPHN0b3AgIG9mZnNldD0iMC41OTY4IiBzdHlsZT0ic3RvcC1jb2xvcjojNTRBMDQ0Ii8+CgkJCQk8c3RvcCAgb2Zmc2V0PSIwLjg2MjQiIHN0eWxlPSJzdG9wLWNvbG9yOiM0MTg3M0YiLz4KCQkJPC9saW5lYXJHcmFkaWVudD4KCQkJPHBvbHlnb24gY2xhc3M9InN0NiIgcG9pbnRzPSIxMS41Miw5Ljk0IDExLjQ4LDkuOTYgMTEuNTQsOS45NiAJCQkiLz4KCQkJPGxpbmVhckdyYWRpZW50IGlkPSJTVkdJRF8zXyIgZ3JhZGllbnRVbml0cz0idXNlclNwYWNlT25Vc2UiIHgxPSI4LjI4NjciIHkxPSIxNC40MTkiIHgyPSIxNS4zMzM2IiB5Mj0iMTQuNDE5Ij4KCQkJCTxzdG9wICBvZmZzZXQ9IjAuMDkxOSIgc3R5bGU9InN0b3AtY29sb3I6IzZDQzA0QSIvPgoJCQkJPHN0b3AgIG9mZnNldD0iMC4yODY0IiBzdHlsZT0ic3RvcC1jb2xvcjojNjZCODQ4Ii8+CgkJCQk8c3RvcCAgb2Zmc2V0PSIwLjU5NjgiIHN0eWxlPSJzdG9wLWNvbG9yOiM1NEEwNDQiLz4KCQkJCTxzdG9wICBvZmZzZXQ9IjAuODYyNCIgc3R5bGU9InN0b3AtY29sb3I6IzQxODczRiIvPgoJCQk8L2xpbmVhckdyYWRpZW50PgoJCQk8cGF0aCBjbGFzcz0ic3Q3IiBkPSJNMTUuMDUsMTYuNWMwLjA5LTAuMDUsMC4xNi0wLjE0LDAuMTgtMC4yM2wtMy4zNS01LjcyYy0wLjA5LTAuMDItMC4xOCwwLTAuMjYsMC4wNGwtMy4wNCwxLjc1bDMuMjgsNS45NwoJCQkJYzAuMDUtMC4wMSwwLjA5LTAuMDIsMC4xMy0wLjA1TDE1LjA1LDE2LjV6Ii8+CgkJCTxsaW5lYXJHcmFkaWVudCBpZD0iU1ZHSURfNF8iIGdyYWRpZW50VW5pdHM9InVzZXJTcGFjZU9uVXNlIiB4MT0iOC4yODY3IiB5MT0iMTYuNDMwNyIgeDI9IjE1LjMzMzYiIHkyPSIxNi40MzA3Ij4KCQkJCTxzdG9wICBvZmZzZXQ9IjAuMDkxOSIgc3R5bGU9InN0b3AtY29sb3I6IzZDQzA0QSIvPgoJCQkJPHN0b3AgIG9mZnNldD0iMC4yODY0IiBzdHlsZT0ic3RvcC1jb2xvcjojNjZCODQ4Ii8+CgkJCQk8c3RvcCAgb2Zmc2V0PSIwLjU5NjgiIHN0eWxlPSJzdG9wLWNvbG9yOiM1NEEwNDQiLz4KCQkJCTxzdG9wICBvZmZzZXQ9IjAuODYyNCIgc3R5bGU9InN0b3AtY29sb3I6IzQxODczRiIvPgoJCQk8L2xpbmVhckdyYWRpZW50PgoJCQk8cG9seWdvbiBjbGFzcz0ic3Q4IiBwb2ludHM9IjE1LjMzLDE2LjQ0IDE1LjMxLDE2LjQxIDE1LjMxLDE2LjQ1IAkJCSIvPgoJCQk8bGluZWFyR3JhZGllbnQgaWQ9IlNWR0lEXzVfIiBncmFkaWVudFVuaXRzPSJ1c2VyU3BhY2VPblVzZSIgeDE9IjcuNTc0NyIgeTE9IjE3LjM0IiB4Mj0iMTYuMDI0MiIgeTI9IjE3LjM0Ij4KCQkJCTxzdG9wICBvZmZzZXQ9IjAuMDkxOSIgc3R5bGU9InN0b3AtY29sb3I6IzZDQzA0QSIvPgoJCQkJPHN0b3AgIG9mZnNldD0iMC4yODY0IiBzdHlsZT0ic3RvcC1jb2xvcjojNjZCODQ4Ii8+CgkJCQk8c3RvcCAgb2Zmc2V0PSIwLjU5NjgiIHN0eWxlPSJzdG9wLWNvbG9yOiM1NEEwNDQiLz4KCQkJCTxzdG9wICBvZmZzZXQ9IjAuODYyNCIgc3R5bGU9InN0b3AtY29sb3I6IzQxODczRiIvPgoJCQk8L2xpbmVhckdyYWRpZW50PgoJCQk8cGF0aCBjbGFzcz0ic3Q5IiBkPSJNMTUuMDUsMTYuNUwxMiwxOC4yNmMtMC4wNCwwLjAyLTAuMDksMC4wNC0wLjEzLDAuMDVsMC40LDAuMTFMMTYsMTYuNDV2LTAuMDVsLTAuNDMtMC4xNAoJCQkJQzE1LjU1LDE2LjM2LDE1LjE0LDE2LjQ1LDE1LjA1LDE2LjV6Ii8+CgkJCTxsaW5lYXJHcmFkaWVudCBpZD0iU1ZHSURfNl8iIGdyYWRpZW50VW5pdHM9InVzZXJTcGFjZU9uVXNlIiB4MT0iMTYuODExNyIgeTE9IjExLjUwNDUiIHgyPSIxMi4yODg2IiB5Mj0iMjAuNzMxNiI+CgkJCQk8c3RvcCAgb2Zmc2V0PSIwIiBzdHlsZT0ic3RvcC1jb2xvcjojNDE4NzNGIi8+CgkJCQk8c3RvcCAgb2Zmc2V0PSIwLjMyODgiIHN0eWxlPSJzdG9wLWNvbG9yOiM0MThCM0QiLz4KCQkJCTxzdG9wICBvZmZzZXQ9IjAuNjM1MiIgc3R5bGU9InN0b3AtY29sb3I6IzQxOTYzNyIvPgoJCQkJPHN0b3AgIG9mZnNldD0iMC45MzE5IiBzdHlsZT0ic3RvcC1jb2xvcjojM0ZBOTJEIi8+CgkJCQk8c3RvcCAgb2Zmc2V0PSIxIiBzdHlsZT0ic3RvcC1jb2xvcjojM0ZBRTJBIi8+CgkJCTwvbGluZWFyR3JhZGllbnQ+CgkJCTxwYXRoIGNsYXNzPSJzdDEwIiBkPSJNMTUuMDUsMTYuNUwxMiwxOC4yNmMtMC4wNCwwLjAyLTAuMDksMC4wNC0wLjEzLDAuMDVsMC40LDAuMTFMMTYsMTYuNDV2LTAuMDVsLTAuNDMtMC4xNAoJCQkJQzE1LjU1LDE2LjM2LDE1LjE0LDE2LjQ1LDE1LjA1LDE2LjV6Ii8+CgkJPC9nPgoJPC9nPgo8L2c+Cjwvc3ZnPg==
+  introduction: >-
+    **Node.js** is based on the V8 JavaScript engine and allows you to write server-side JavaScript applications. It provides an I/O model based on events and non-blocking operations that enables you to write efficient applications.
+    
+    - The Node.js runtime enables you to run Node.js applications and services on OpenShift while providing all the advantages and conveniences of the OpenShift platform such as:
+    
+      - Rolling updates
+    
+      - Continuous delivery pipelines
+      
+      - Service discovery
+    
+      - Externalized configuration
+    
+      - Load balancing
+    
+    OpenShift also makes it easier for your applications to implement common microservice patterns such as externalized configuration, health check, circuit breaker, and failover.
+
+  tasks:
+    - description: >-
+        To create a Node application:
+        
+        1. Click on the [perspective switcher]{{highlight qs-perspective-switcher}} at the top of the navigation, and select **Developer**.
+        
+        1. In the navigation menu, click [Add]{{highlight qs-nav-add}}.
+        
+        1. Click the **Project** dropdown menu and select **Create Project** to create a project for your Node application.
+
+        1. In the **Name** field, enter a name for your new project. Then click **Create**.
+        
+        1. On the **+Add page**, click **From Git**. 
+        
+        1. In the **Git Repo URL** field, add 
+        
+          ```
+            https://github.com/nodeshift-starters/nodejs-rest-http-redhat
+          ``` 
+        
+        1. At the end of the form, click **Create**. 
+
+      review:
+        failedTaskHelp: This task isn’t verified yet. Try the task again.
+        instructions: |-
+          The application is represented by the light grey area with the white border.  The deployment is a white circle.  Verify that the application was successfully created:
+          
+          - Can you identify a **nodejs-rest-http-redhat-app** application?
+          
+          - Can you identify a **nodejs-rest-http-redhat** deployment?
+
+      summary:
+        failed: Try the steps again.
+        success: Your Node application has been deployed onto OpenShift.
+      title: Create a Node application
+    - description: >-
+        To view the build status of your Node application:
+        
+        1. To view build status in a tooltip, hover over the status icon on the bottom left quadrant of the **nodejs-rest-http-redhat** deployment.
+        
+        1. Click on the icon for quick access to the build log.  
+        
+            - You should be able to see the log stream of the **nodejs-rest-http-redhat-1** build on the **Build Details** page.
+          
+            - The application and its dependencies will be built into a container image and pushed to the OpenShift container registry.
+
+      review:
+        failedTaskHelp: This task isn’t verified yet. Try the task again.
+        instructions: >-
+          Verify the build is complete:
+
+          - This build may take a few minutes. When it's finished, a **Complete** badge will surface on the page header beside build name **nodejsrest-http-redhat-1**. Did this badge appear?
+
+      summary:
+        failed: Try the steps again.
+        success: Your build is complete.
+      title: View the build status
+    - description: >-
+        To view the associated code:
+        
+        1. In the navigation menu, click [Topology]{{highlight qs-nav-topology}}.
+        
+        1. The icon on the bottom right quadrant of the **nodejs-rest-http-redhat** deployment represents the Git repository of the associated code.  
+        
+            - The icon shown can be for Bitbucket, GitHub, GitLab or generic Git.  
+          
+        1. Click on the icon to navigate to the associated Git repository.
+      review:
+        failedTaskHelp: >-
+          This task isn’t verified yet. Try the task again.
+        instructions: |-
+          Verify that you can see the code associated with the sample app:
+          
+          - Was a new browser tab opened with **https://github.com/nodeshift-starters/nodejs-rest-http-redhat** ?
+
+          - Return to the browser tab running OpenShift.  
+
+      summary:
+        failed: Try the steps again.
+        success: You accessed the Git repository associated with your deployment.
+      title: View the associated Git repository
+    - description: >-
+        To view the pod status:
+
+        1. Hover over the pod donut to see the pod status in a tooltip.
+
+             - Notice that the **nodejs-rest-http-redhat** deployment has a pod donut imposed on the circle, representing the pod status (i.e. blue = running).  
+        
+              - The color of the donut indicates the pod status.  
+
+      review:
+        failedTaskHelp: >-
+          This task isn’t verified yet. Try the task again.
+        instructions: |-
+          Verify you see the pod status:
+          
+          - Do you see the number of associated pods and their statuses?
+
+      summary:
+        failed: Try the steps again.
+        success: Your deployment has one running pod.
+      title: View the pod status
+
+    - description: >-
+        The external link icon on the top right quadrant of the **nodejs-rest-http-redhat** deployment represents the route URL.  
+        
+        1. Click the external link icon to open the URL and run the application in a new browser tab.
+      review:
+        failedTaskHelp: >-
+          This task isn’t verified yet. Try the task again.
+        instructions: |-
+          Verify your Node application is running:
+          
+          - Is the new tab titled **API Level 0 Example - Node.js**?
+
+      summary:
+        failed: Try the steps again.
+        success: Your Node application is running.
+      title: Run the Node application
+  conclusion: >-
+    Your Node application is deployed and ready.

--- a/quickstarts/quarkus-with-helm.yaml
+++ b/quickstarts/quarkus-with-helm.yaml
@@ -1,0 +1,132 @@
+﻿apiVersion: console.openshift.io/v1
+kind: ConsoleQuickStart
+metadata:
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: 'true'
+    include.release.openshift.io/self-managed-high-availability: 'true'
+    include.release.openshift.io/single-node-developer: 'true'
+  name: quarkus-with-helm
+spec:
+  description: 'Deploy a Quarkus application using a Helm Chart.'
+  displayName: Get started with Quarkus using a Helm Chart
+  durationMinutes: 10
+  icon: >-
+    data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGlkPSJMYXllcl8xIiBkYXRhLW5hbWU9IkxheWVyIDEiIHZpZXdCb3g9IjAgMCAxMDI0IDEwMjQiPjxkZWZzPjxzdHlsZT4uY2xzLTF7ZmlsbDojNDY5NWViO30uY2xzLTJ7ZmlsbDojZmYwMDRhO30uY2xzLTN7ZmlsbDojZmZmO308L3N0eWxlPjwvZGVmcz48dGl0bGU+cXVhcmt1c19pY29uX3JnYl8xMDI0cHhfcmV2ZXJzZTwvdGl0bGU+PHBvbHlnb24gY2xhc3M9ImNscy0xIiBwb2ludHM9IjY2OS4zNCAxODAuNTcgNTEyIDI3MS40MSA2NjkuMzQgMzYyLjI1IDY2OS4zNCAxODAuNTciLz48cG9seWdvbiBjbGFzcz0iY2xzLTIiIHBvaW50cz0iMzU0LjY2IDE4MC41NyAzNTQuNjYgMzYyLjI1IDUxMiAyNzEuNDEgMzU0LjY2IDE4MC41NyIvPjxwb2x5Z29uIGNsYXNzPSJjbHMtMyIgcG9pbnRzPSI2NjkuMzQgMzYyLjI1IDUxMiAyNzEuNDEgMzU0LjY2IDM2Mi4yNSA1MTIgNDUzLjA5IDY2OS4zNCAzNjIuMjUiLz48cG9seWdvbiBjbGFzcz0iY2xzLTEiIHBvaW50cz0iMTg4Ljc2IDQ2Ny45MyAzNDYuMSA1NTguNzYgMzQ2LjEgMzc3LjA5IDE4OC43NiA0NjcuOTMiLz48cG9seWdvbiBjbGFzcz0iY2xzLTIiIHBvaW50cz0iMzQ2LjEgNzQwLjQ0IDUwMy40MyA2NDkuNiAzNDYuMSA1NTguNzYgMzQ2LjEgNzQwLjQ0Ii8+PHBvbHlnb24gY2xhc3M9ImNscy0zIiBwb2ludHM9IjM0Ni4xIDM3Ny4wOSAzNDYuMSA1NTguNzYgNTAzLjQzIDY0OS42IDUwMy40MyA0NjcuOTMgMzQ2LjEgMzc3LjA5Ii8+PHBvbHlnb24gY2xhc3M9ImNscy0xIiBwb2ludHM9IjY3Ny45IDc0MC40NCA2NzcuOSA1NTguNzYgNTIwLjU3IDY0OS42IDY3Ny45IDc0MC40NCIvPjxwb2x5Z29uIGNsYXNzPSJjbHMtMiIgcG9pbnRzPSI4MzUuMjQgNDY3LjkzIDY3Ny45IDM3Ny4wOSA2NzcuOSA1NTguNzYgODM1LjI0IDQ2Ny45MyIvPjxwb2x5Z29uIGNsYXNzPSJjbHMtMyIgcG9pbnRzPSI1MjAuNTcgNjQ5LjYgNjc3LjkgNTU4Ljc2IDY3Ny45IDM3Ny4wOSA1MjAuNTcgNDY3LjkzIDUyMC41NyA2NDkuNiIvPjxwYXRoIGNsYXNzPSJjbHMtMSIgZD0iTTg1My40NywxSDE3MC41M0M3Ny4yOSwxLDEsNzcuMjksMSwxNzAuNTNWODUzLjQ3QzEsOTQ2LjcxLDc3LjI5LDEwMjMsMTcwLjUzLDEwMjNoNDY3LjdMNTEyLDcxNi4zOSw0MjAuNDIsOTEwSDE3MC41M0MxMzkuOSw5MTAsMTE0LDg4NC4xLDExNCw4NTMuNDdWMTcwLjUzQzExNCwxMzkuOSwxMzkuOSwxMTQsMTcwLjUzLDExNEg4NTMuNDdDODg0LjEsMTE0LDkxMCwxMzkuOSw5MTAsMTcwLjUzVjg1My40N0M5MTAsODg0LjEsODg0LjEsOTEwLDg1My40Nyw5MTBINzA1LjI4bDQ2LjUyLDExM0g4NTMuNDdjOTMuMjQsMCwxNjkuNTMtNzYuMjksMTY5LjUzLTE2OS41M1YxNzAuNTNDMTAyMyw3Ny4yOSw5NDYuNzEsMSw4NTMuNDcsMVoiLz48L3N2Zz4K
+  introduction: >-
+    **Quarkus** is a Cloud Native, (Linux) Container First framework for writing Java applications.
+
+    - **Container First**: Minimal footprint Java applications that are optimal for running in containers.
+
+    - **Cloud Native**: Embraces 12 factor architecture in environments like Kubernetes.
+
+    - **Unify imperative and reactive**: Brings under one programming model non-blocking and imperative styles of development.
+
+    - **Standards-based**: Based on the standards and frameworks you love and use: RESTEasy and JAX-RS, Hibernate ORM and JPA, Netty, Eclipse Vert.x, Eclipse MicroProfile, Apache Camel.
+
+    - **A great choice for microservices and serverless**: Brings lightning fast startup time and code turnaround to Java apps.
+
+    - **Developer Joy**: Development centric experience bringing your amazing apps to life in no time.
+
+  tasks:
+    - description: >-
+        To create a Quarkus application:
+        
+        1. Click on the [perspective switcher]{{highlight qs-perspective-switcher}} at the top of the navigation, and select **Developer**.
+        
+        1. In the navigation menu, click [Add]{{highlight qs-nav-add}}.
+                
+        1. Click the **Project** dropdown menu and select **Create Project** to create a project for your Quarkus application.
+
+        1. In the **Name** field, enter a name for your new project. Then click **Create**.
+        
+        1. On the **+Add** page, click **Helm Chart**. 
+        
+        1. In the Helm Chart catalog, click the **Quarkus** tile.
+        
+            - The side panel displays information about the Quarkus chart
+        
+        1. Click **Install Helm Chart**
+        
+            - Some form sections are collapsed by default. No changes to these sections are needed to proceed. Click the accordion above a collapsed section to expand and view its content.
+        
+        1. At the bottom of the form, click **Install** to create the Quarkus application using the Helm Chart.
+      review:
+        failedTaskHelp: This task isn’t verified yet. Try the task again.
+        instructions: |-
+          The Helm Release is represented by the light grey shape with a darker grey dashed border.  The deployment is a white circle containing the Quarkus logo.  Verify the application was successfully created:
+          
+          - Do you see a **quarkus** Helm Release?
+          
+          - Do you see a **quarkus** deployment?
+
+      summary:
+        failed: Try the steps again.
+        success: Your Quarkus application has been deployed onto OpenShift.
+      title: Create a Quarkus application from a Helm Chart
+
+    - description: >-
+        To view the build status of the Quarkus application:
+        
+        1. Hover over the icon on the bottom left quadrant of the **quarkus** deployment to see the build status in a tooltip.
+        
+        1. Click on the icon for quick access to the build log.  
+        
+            - The log stream of the **quarkus-1** build is shown on the **Build Details** page.
+        
+            - The application and its dependencies will be built into a container image and pushed to the OpenShift container registry.
+      review:
+        failedTaskHelp: This task isn’t verified yet. Try the task again.
+        instructions: >-
+          Verify the build is complete:
+
+          - This build may take a few minutes. When it's finished, a **Complete** badge will surface on the page header beside build name **quarkus-1**. Did this badge appear?
+
+      summary:
+        failed: Try the steps again.
+        success: Your build is complete.
+      title: View the build status
+    - description: >-
+        To view the pod status:
+
+        1. In the navigation menu, click [Topology]{{highlight qs-nav-topology}}.
+        
+        1. Hover over the pod donut to see the pod status in a tooltip.
+
+              - Notice that the **quarkus** deployment has a pod donut imposed on the circle, representing the pod status (i.e. blue = running).  
+
+              - The color of the donut indicates the pod status.  
+
+      review:
+        failedTaskHelp: >-
+          This task isn’t verified yet. Try the task again.
+        instructions: |-
+          Verify you see the pod status:
+          
+          - Do you see the number of associated pods and their statuses?
+
+      summary:
+        failed: Try the steps again.
+        success: Your deployment has one running pod.
+      title: View the pod status
+    - description: >-
+
+        The external link icon on the top right quadrant of the **quarkus** deployment represents the route URL.  
+        
+        1. Click on the external link icon to open the URL and run the application in a new browser tab.
+
+        1. Learn more about deploying Quarkus applications on OpenShift at
+         [quarkus.io](https://quarkus.io).
+
+      review:
+        failedTaskHelp: This task isn’t verified yet. Try the task again.
+        instructions: >-
+          Verify your Quarkus application is running:
+
+          - Is the new tab titled **Your new
+          Cloud-Native application is ready!**?
+      summary:
+        failed: Try the steps again.
+        success: Your Quarkus application is running.
+      title: Run the Quarkus application
+  conclusion: >-
+    Your Quarkus application is deployed and ready.

--- a/quickstarts/quarkus-with-s2i.yaml
+++ b/quickstarts/quarkus-with-s2i.yaml
@@ -1,0 +1,209 @@
+﻿apiVersion: console.openshift.io/v1
+kind: ConsoleQuickStart
+metadata:
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: 'true'
+    include.release.openshift.io/self-managed-high-availability: 'true'
+    include.release.openshift.io/single-node-developer: 'true'
+  name: quarkus-with-s2i
+spec:
+  description: 'Import a Quarkus Application from git, build, and deploy it onto OpenShift.'
+  displayName: Get started with Quarkus with s2i
+  durationMinutes: 10
+  icon: >-
+    data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGlkPSJMYXllcl8xIiBkYXRhLW5hbWU9IkxheWVyIDEiIHZpZXdCb3g9IjAgMCAxMDI0IDEwMjQiPjxkZWZzPjxzdHlsZT4uY2xzLTF7ZmlsbDojNDY5NWViO30uY2xzLTJ7ZmlsbDojZmYwMDRhO30uY2xzLTN7ZmlsbDojZmZmO308L3N0eWxlPjwvZGVmcz48dGl0bGU+cXVhcmt1c19pY29uX3JnYl8xMDI0cHhfcmV2ZXJzZTwvdGl0bGU+PHBvbHlnb24gY2xhc3M9ImNscy0xIiBwb2ludHM9IjY2OS4zNCAxODAuNTcgNTEyIDI3MS40MSA2NjkuMzQgMzYyLjI1IDY2OS4zNCAxODAuNTciLz48cG9seWdvbiBjbGFzcz0iY2xzLTIiIHBvaW50cz0iMzU0LjY2IDE4MC41NyAzNTQuNjYgMzYyLjI1IDUxMiAyNzEuNDEgMzU0LjY2IDE4MC41NyIvPjxwb2x5Z29uIGNsYXNzPSJjbHMtMyIgcG9pbnRzPSI2NjkuMzQgMzYyLjI1IDUxMiAyNzEuNDEgMzU0LjY2IDM2Mi4yNSA1MTIgNDUzLjA5IDY2OS4zNCAzNjIuMjUiLz48cG9seWdvbiBjbGFzcz0iY2xzLTEiIHBvaW50cz0iMTg4Ljc2IDQ2Ny45MyAzNDYuMSA1NTguNzYgMzQ2LjEgMzc3LjA5IDE4OC43NiA0NjcuOTMiLz48cG9seWdvbiBjbGFzcz0iY2xzLTIiIHBvaW50cz0iMzQ2LjEgNzQwLjQ0IDUwMy40MyA2NDkuNiAzNDYuMSA1NTguNzYgMzQ2LjEgNzQwLjQ0Ii8+PHBvbHlnb24gY2xhc3M9ImNscy0zIiBwb2ludHM9IjM0Ni4xIDM3Ny4wOSAzNDYuMSA1NTguNzYgNTAzLjQzIDY0OS42IDUwMy40MyA0NjcuOTMgMzQ2LjEgMzc3LjA5Ii8+PHBvbHlnb24gY2xhc3M9ImNscy0xIiBwb2ludHM9IjY3Ny45IDc0MC40NCA2NzcuOSA1NTguNzYgNTIwLjU3IDY0OS42IDY3Ny45IDc0MC40NCIvPjxwb2x5Z29uIGNsYXNzPSJjbHMtMiIgcG9pbnRzPSI4MzUuMjQgNDY3LjkzIDY3Ny45IDM3Ny4wOSA2NzcuOSA1NTguNzYgODM1LjI0IDQ2Ny45MyIvPjxwb2x5Z29uIGNsYXNzPSJjbHMtMyIgcG9pbnRzPSI1MjAuNTcgNjQ5LjYgNjc3LjkgNTU4Ljc2IDY3Ny45IDM3Ny4wOSA1MjAuNTcgNDY3LjkzIDUyMC41NyA2NDkuNiIvPjxwYXRoIGNsYXNzPSJjbHMtMSIgZD0iTTg1My40NywxSDE3MC41M0M3Ny4yOSwxLDEsNzcuMjksMSwxNzAuNTNWODUzLjQ3QzEsOTQ2LjcxLDc3LjI5LDEwMjMsMTcwLjUzLDEwMjNoNDY3LjdMNTEyLDcxNi4zOSw0MjAuNDIsOTEwSDE3MC41M0MxMzkuOSw5MTAsMTE0LDg4NC4xLDExNCw4NTMuNDdWMTcwLjUzQzExNCwxMzkuOSwxMzkuOSwxMTQsMTcwLjUzLDExNEg4NTMuNDdDODg0LjEsMTE0LDkxMCwxMzkuOSw5MTAsMTcwLjUzVjg1My40N0M5MTAsODg0LjEsODg0LjEsOTEwLDg1My40Nyw5MTBINzA1LjI4bDQ2LjUyLDExM0g4NTMuNDdjOTMuMjQsMCwxNjkuNTMtNzYuMjksMTY5LjUzLTE2OS41M1YxNzAuNTNDMTAyMyw3Ny4yOSw5NDYuNzEsMSw4NTMuNDcsMVoiLz48L3N2Zz4K
+  introduction: >-
+    #### Quarkus is a Cloud Native, (Linux) Container First framework for
+    writing Java applications.
+
+    - **Container First:** Minimal footprint Java applications that are optimal for
+    running in containers.
+
+    - **Cloud Native:** Embraces 12 factor architecture in environments like
+    Kubernetes.
+
+    - **Unify imperative and reactive**: Brings under one programming model
+    non-blocking and imperative styles of development.
+
+    - **Standards-based**: Based on the standards and frameworks you love and
+    use: RESTEasy and JAX-RS, Hibernate ORM and JPA, Netty, Eclipse Vert.x,
+    Eclipse MicroProfile, Apache Camel.
+
+    - **A great choice for microservices and serverless**: Brings lightning fast startup
+    time and code turnaround to Java apps.
+
+    - **Developer Joy**: Development centric experience bringing your amazing apps to life in no time.
+  tasks:
+    - description: >-
+        To create a Quarkus application:  
+
+        1. Click on the [perspective switcher]{{highlight qs-perspective-switcher}} at the top of the navigation, and select **Developer**.
+        
+        1. In the navigation menu, click [Add]{{highlight qs-nav-add}}.
+        
+        1. Click the **Project** dropdown menu and select **Create Project** to create a project for your Quarkus application.
+
+        1. In the **Name** field, enter a name for your new project. Then click **Create**.
+        
+        1. On the **+Add** page, click **From Git**. 
+        
+        1. In the **Git Repo URL** field, add 
+          
+          ```
+            https://github.com/quarkusio/quarkus-quickstarts
+          ``` 
+          
+        1. Click on **Show advanced Git options**, which will expose additional
+        fields:
+
+        1. Add 
+        
+        ```
+        getting-started
+        ```
+        
+        to the **Context dir** field 
+
+        1. At the end of the form, click **Create**. 
+      review:
+        failedTaskHelp: This task isn’t verified yet. Try the task again.
+        instructions: >-
+          The application is represented by the light grey area with the white
+          border.  The deployment is a white circle.  Verify that the application
+          was successfully created:
+
+          1. Do you see a **quarkus-quickstarts-app** application?
+
+          1. Do you see a **quarkus-quickstarts** deployment?
+      summary:
+        failed: Try the steps again.
+        success: Your Quarkus application has been deployed onto OpenShift.
+      title: Create a Quarkus application
+    - description: >-
+        To view the build status of the Quarkus application:
+
+        1. Hover over the icon on the bottom left quadrant of the
+        **quarkus-quickstarts** deployment to see the build status in a
+        tooltip.  
+
+        1. Click the icon for quick access to the build log.  
+        
+            - You should be able
+        to see the log stream of the **quarkus-quickstarts-1** build on the
+        **Build Details** page. 
+        
+            - The application and its dependencies will be
+        built into a container image and pushed to the OpenShift container
+        registry.
+      review:
+        failedTaskHelp: This task isn’t verified yet. Try the task again.
+        instructions: |-
+          Verify the build is complete:
+          1. This build may take a few minutes. When it's finished, a **Complete** badge will surface on the page header beside build name **quarkus-quickstarts-1**. Did this badge appear?
+       
+      summary:
+        failed: Try the steps again.
+        success: Your build is complete.
+      title: View the build status
+    - description: >-
+        To view the associated code: 
+
+        1. In the navigation menu, click [Topology]{{highlight qs-nav-topology}}.
+        
+        1. The icon on the bottom right
+        quadrant of the **quarkus-quickstarts** deployment represents the Git
+        repository of the associated code.  The icon shown can be for Bitbucket,
+        GitHub, GitLab or generic Git.  
+
+        1. Click on the icon to navigate to the associated Git repository.
+      review:
+        failedTaskHelp: This task isn’t verified yet. Try the task again.
+        instructions: >-
+          Verify that you can see the code associated with the sample app:
+
+          - Was a new browser tab opened with
+          **https://github.com/quarkusio/quarkus-quickstarts**?
+
+          - Return to the browser tab running OpenShift.  
+
+      summary:
+        failed: Try the steps again.
+        success: You accessed the Git repository associated with your deployment.
+      title: View the associated Git repository
+    - description: >-
+
+        To view the pod status:
+                
+        1. Hover over the pod donut to see the pod status in a tooltip.
+
+              - Notice that the **quarkus-quickstarts** deployment has a pod donut imposed on the circle, representing the pod status (i.e. blue = running).  
+
+              - The color of the donut indicates the pod status.  
+
+      review:
+        failedTaskHelp: This task isn’t verified yet. Try the task again.
+        instructions: |-
+          Verify you see the pod status:
+
+          Do you see the number of associated pods and their statuses?
+      summary:
+        failed: Try the steps again.
+        success: Your deployment has one running pod.
+      title: View the pod status
+    - description: >-
+        Since a Java builder image was used during the **Import from Git** flow, a
+        Java icon is used by default in Topology view.  
+        
+          - The displayed icon is determined by the
+        value of the `app.openshift.io/runtime` label.
+        
+          - You can change the icon associated with a deployment to indicate its application type. 
+          
+          To associate a Quarkus icon with the **quarkus-quickstarts** deployment:
+     
+
+        1. Click on the **quarkus-quickstarts** deployment.
+
+        1. In the side panel, click the **Actions** dropdown menu and select **Edit labels**.
+
+        1. Click on the “x” next to the `app.openshift.io/runtime=java` label to
+        remove it from the labels list.
+
+        1. Add an additional label: 
+          ```
+          app.openshift.io/runtime=quarkus
+          ```
+
+        1. Click on **Save** to save the labels.
+      review:
+        failedTaskHelp: This task isn’t verified yet. Try the task again.
+        instructions: >-
+          Verify you have updated the icon :
+
+          -  Do you now see the quarkus icon rather than a java icon in the
+          **quarkus-quickstarts** deployment? 
+      summary:
+        failed: Try the steps again.
+        success: You changed the icon associated with your deployment.
+      title: Change the deployment icon to Quarkus
+
+    - description: >-
+        The external link icon on the top right quadrant of the **quarkus-quickstarts** deployment represents the route URL.  
+        
+        1. Click on the external link icon to open the URL and run the application in a new browser tab.
+
+        1. Learn more about deploying Quarkus applications on OpenShift at
+         [quarkus.io](https://quarkus.io).
+
+      review:
+        failedTaskHelp: This task isn’t verified yet. Try the task again.
+        instructions: >-
+          Verify your Quarkus application is running:
+
+          - Is the new tab titled **Your new
+          Cloud-Native application is ready!**?
+      summary:
+        failed: Try the steps again.
+        success: Your Quarkus application is running.
+      title: Run the Quarkus application
+  conclusion: Your Quarkus application is deployed and ready!

--- a/quickstarts/spring-with-s2i.yaml
+++ b/quickstarts/spring-with-s2i.yaml
@@ -1,0 +1,202 @@
+﻿apiVersion: console.openshift.io/v1
+kind: ConsoleQuickStart
+metadata:
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: 'true'
+    include.release.openshift.io/self-managed-high-availability: 'true'
+    include.release.openshift.io/single-node-developer: 'true'
+  name: spring-with-s2i
+spec:
+  description: 'Import a Spring Application from git, build, and deploy it onto OpenShift.'
+  displayName: Get started with Spring
+  durationMinutes: 10
+  icon: >-
+    data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGlkPSJMYXllcl8xIiBkYXRhLW5hbWU9IkxheWVyIDEiIHZpZXdCb3g9IjAgMCAxMDI0IDEwMjQiPjxkZWZzPjxzdHlsZT4uY2xzLTF7ZmlsbDojMTUzZDNjO30uY2xzLTJ7ZmlsbDojZDhkYTlkO30uY2xzLTN7ZmlsbDojNThjMGE4O30uY2xzLTR7ZmlsbDojZmZmO30uY2xzLTV7ZmlsbDojM2Q5MTkxO308L3N0eWxlPjwvZGVmcz48dGl0bGU+c25vd2Ryb3BfaWNvbl9yZ2JfZGVmYXVsdDwvdGl0bGU+PHBhdGggY2xhc3M9ImNscy0xIiBkPSJNMTAxMi42OSw1OTNjLTExLjEyLTM4LjA3LTMxLTczLTU5LjIxLTEwMy44LTkuNS0xMS4zLTIzLjIxLTI4LjI5LTM5LjA2LTQ3Ljk0QzgzMy41MywzNDEsNzQ1LjM3LDIzNC4xOCw2NzQsMTY4Ljk0Yy01LTUuMjYtMTAuMjYtMTAuMzEtMTUuNjUtMTUuMDdhMjQ2LjQ5LDI0Ni40OSwwLDAsMC0zNi41NS0yNi44LDE4Mi41LDE4Mi41LDAsMCwwLTIwLjMtMTEuNzcsMjAxLjUzLDIwMS41MywwLDAsMC00My4xOS0xNUExNTUuMjQsMTU1LjI0LDAsMCwwLDUyOCw5NS4yYy02Ljc2LS42OC0xMS43NC0uODEtMTQuMzktLjgxaDBsLTEuNjIsMC0xLjYyLDBhMTc3LjMsMTc3LjMsMCwwLDAtMzEuNzcsMy4zNSwyMDguMjMsMjA4LjIzLDAsMCwwLTU2LjEyLDE3LjU2LDE4MSwxODEsMCwwLDAtMjAuMjcsMTEuNzUsMjQ3LjQzLDI0Ny40MywwLDAsMC0zNi41NywyNi44MUMzNjAuMjUsMTU4LjYyLDM1NSwxNjMuNjgsMzUwLDE2OWMtNzEuMzUsNjUuMjUtMTU5LjUsMTcyLTI0MC4zOSwyNzIuMjhDOTMuNzMsNDYwLjg4LDgwLDQ3Ny44Nyw3MC41Miw0ODkuMTcsNDIuMzUsNTIwLDIyLjQzLDU1NC45LDExLjMxLDU5MywuNzIsNjI5LjIyLTEuNzMsNjY3LjY5LDQsNzA3LjMxLDE1LDc4Mi40OSw1NS43OCw4NTkuMTIsMTE4LjkzLDkyMy4wOWEyMiwyMiwwLDAsMCwxNS41OSw2LjUyaDEuODNsMS44Ny0uMzJjODEuMDYtMTMuOTEsMTEwLTc5LjU3LDE0My40OC0xNTUuNiwzLjkxLTguODgsNy45NS0xOC4wNSwxMi4yLTI3LjQzcTUuNDIsOC41NCwxMS4zOSwxNi4yM2MzMS44NSw0MC45MSw3NS4xMiw2NC42NywxMzIuMzIsNzIuNjNsMTguOCwyLjYyLDQuOTUtMTguMzNjMTMuMjYtNDkuMDcsMzUuMy05MC44NSw1MC42NC0xMTYuMTksMTUuMzQsMjUuMzQsMzcuMzgsNjcuMTIsNTAuNjQsMTE2LjE5bDUsMTguMzMsMTguOC0yLjYyYzU3LjItOCwxMDAuNDctMzEuNzIsMTMyLjMyLTcyLjYzcTYtNy42OCwxMS4zOS0xNi4yM2M0LjI1LDkuMzgsOC4yOSwxOC41NSwxMi4yLDI3LjQzLDMzLjQ5LDc2LDYyLjQyLDE0MS42OSwxNDMuNDgsMTU1LjZsMS44MS4zMWgxLjg5YTIyLDIyLDAsMCwwLDE1LjU5LTYuNTJjNjMuMTUtNjQsMTAzLjk1LTE0MC42LDExNC44OS0yMTUuNzhDMTAyNS43Myw2NjcuNjksMTAyMy4yOCw2MjkuMjIsMTAxMi42OSw1OTNaIi8+PHBhdGggY2xhc3M9ImNscy0yIiBkPSJNMzY0LjE1LDE4NS4yM2MxNy44OS0xNi40LDM0LjctMzAuMTUsNDkuNzctNDAuMTFhMjEyLDIxMiwwLDAsMSw2NS45My0yNS43M0ExOTgsMTk4LDAsMCwxLDUxMiwxMTYuMjdhMTk2LjExLDE5Ni4xMSwwLDAsMSwzMiwzLjFjNC41LjkxLDkuMzYsMi4wNiwxNC41MywzLjUyLDYwLjQxLDIwLjQ4LDg0LjkyLDkxLjA1LTQ3LjQ0LDI0OC4wNi0yOC43NSwzNC4xMi0xNDAuNywxOTQuODQtMTg0LjY2LDI2OC40MmE2MzAuODYsNjMwLjg2LDAsMCwwLTMzLjIyLDU4LjMyQzI3Niw2NTUuMzQsMjY1LjQsNTk4LDI2NS40LDUyMC4yOSwyNjUuNCwzNDAuNjEsMzExLjY5LDI0MC43NCwzNjQuMTUsMTg1LjIzWiIvPjxwYXRoIGNsYXNzPSJjbHMtMyIgZD0iTTUyNy41NCwzODQuODNjODQuMDYtOTkuNywxMTYuMDYtMTc3LjI4LDk1LjIyLTIzMC43NCwxMS42Miw4LjY5LDI0LDE5LjIsMzcuMDYsMzEuMTMsNTIuNDgsNTUuNSw5OC43OCwxNTUuMzgsOTguNzgsMzM1LjA3LDAsNzcuNzEtMTAuNiwxMzUuMDUtMjcuNzcsMTc3LjRhNjI4LjczLDYyOC43MywwLDAsMC0zMy4yMy01OC4zMmMtMzktNjUuMjYtMTMxLjQ1LTE5OS0xNzEuOTMtMjUyLjI3QzUyNi4zMywzODYuMjksNTI3LDM4NS41Miw1MjcuNTQsMzg0LjgzWiIvPjxwYXRoIGNsYXNzPSJjbHMtNCIgZD0iTTEzNC41OCw5MDguMDdoLS4wNmEuMzkuMzksMCwwLDEtLjI3LS4xMWMtMTE5LjUyLTEyMS4wNy0xNTUtMjg3LjQtNDcuNTQtNDA0LjU4LDM0LjYzLTQxLjE0LDEyMC0xNTEuNiwyMDIuNzUtMjQyLjE5LTMuMTMsNy02LjEyLDE0LjI1LTguOTIsMjEuNjktMjQuMzQsNjQuNDUtMzYuNjcsMTQ0LjMyLTM2LjY3LDIzNy40MSwwLDU2LjUzLDUuNTgsMTA2LDE2LjU5LDE0Ny4xNEEzMDcuNDksMzA3LjQ5LDAsMCwwLDI4MC45MSw3MjNDMjM3LDgxNi44OCwyMTYuOTMsODkzLjkzLDEzNC41OCw5MDguMDdaIi8+PHBhdGggY2xhc3M9ImNscy01IiBkPSJNNTgzLjQzLDgxMy43OUM1NjAuMTgsNzI3LjcyLDUxMiw2NjQuMTUsNTEyLDY2NC4xNXMtNDguMTcsNjMuNTctNzEuNDMsMTQ5LjY0Yy00OC40NS02Ljc0LTEwMC45MS0yNy41Mi0xMzUuNjYtOTEuMThhNjQ1LjY4LDY0NS42OCwwLDAsMSwzOS41Ny03MS41NGwuMjEtLjMyLjE5LS4zM2MzOC02My42MywxMjYuNC0xOTEuMzcsMTY3LjEyLTI0NS42Niw0MC43MSw1NC4yOCwxMjkuMSwxODIsMTY3LjEyLDI0NS42NmwuMTkuMzMuMjEuMzJhNjQ1LjY4LDY0NS42OCwwLDAsMSwzOS41Nyw3MS41NEM2ODQuMzQsNzg2LjI3LDYzMS44OCw4MDcuMDUsNTgzLjQzLDgxMy43OVoiLz48cGF0aCBjbGFzcz0iY2xzLTQiIGQ9Ik04ODkuNzUsOTA4YS4zOS4zOSwwLDAsMS0uMjcuMTFoLS4wNkM4MDcuMDcsODkzLjkzLDc4Nyw4MTYuODgsNzQzLjA5LDcyM2EzMDcuNDksMzA3LjQ5LDAsMCwwLDIwLjQ1LTU1LjU0YzExLTQxLjExLDE2LjU5LTkwLjYxLDE2LjU5LTE0Ny4xNCwwLTkzLjA4LTEyLjMzLTE3My0zNi42Ni0yMzcuNHEtNC4yMi0xMS4xNi04LjkzLTIxLjdjODIuNzUsOTAuNTksMTY4LjEyLDIwMS4wNSwyMDIuNzUsMjQyLjE5QzEwNDQuNzksNjIwLjU2LDEwMDkuMjcsNzg2Ljg5LDg4OS43NSw5MDhaIi8+PC9zdmc+Cg==
+  introduction: >-
+    **Spring** is a Java framework for building applications based on a distributed microservices architecture. 
+    
+    - Spring enables easy packaging and configuration of Spring applications into a self-contained executable application which can be easily deployed as a container to OpenShift.
+    
+    - Spring applications can integrate OpenShift capabilities to provide a natural "Spring on OpenShift" developer experience for both existing and net-new Spring applications. For example:
+    
+    - Externalized configuration using Kubernetes ConfigMaps and integration with Spring Cloud Kubernetes
+    
+    - Service discovery using Kubernetes Services
+    
+    - Load balancing with Replication Controllers
+    
+    - Kubernetes health probes and integration with Spring Actuator
+    
+    - Metrics: Prometheus, Grafana, and integration with Spring Cloud Sleuth
+    
+    - Distributed tracing with Istio & Jaeger tracing
+    
+    - Developer tooling through Red Hat OpenShift and Red Hat CodeReady developer tooling to quickly scaffold new Spring projects, gain access to familiar Spring APIs in your favorite IDE, and deploy to Red Hat OpenShift
+
+  tasks:
+    - description: >-
+        To create a Spring application:
+        
+        1. Click on the [perspective switcher]{{highlight qs-perspective-switcher}} at the top of the navigation, and select **Developer**.
+        
+        1. In the navigation menu, click [Add]{{highlight qs-nav-add}}.
+        
+        1. Click the **Project** dropdown menu and select **Create Project** to create a project for your Spring application.
+
+        1. In the **Name** field, enter a name for your new project. Then click **Create**.
+        
+        1. On the **+Add** page, click **From Git**. 
+        
+        1. In the **Git Repo URL** field, add 
+          
+          ```
+            https://github.com/snowdrop/rest-http-example
+          ``` 
+        
+        1. Click **Show advanced Git options** to expose additional form fields.
+        
+        1. Add 
+        
+          ```
+          2.3.4-2-redhat
+          ``` 
+        to the **Git reference** field.
+        
+        1. At the end of the form, click **Create**. 
+
+      review:
+        failedTaskHelp: This task isn’t verified yet. Try the task again.
+        instructions: >-
+          The application is represented by the light grey area with the white border.  The deployment is a white circle.  Verify that the application was successfully created:
+          
+          1. Do you see a **rest-http-example-app** application?
+          
+          1. Do you see a **rest-http-example** deployment?
+      summary:
+        failed: Try the steps again.
+        success: Your Spring application has been deployed onto OpenShift.
+      title: Create a Spring application
+    - description: >-
+        To view the build status of the Spring application:
+        
+        1. Hover over the icon on the bottom left quadrant of the **rest-http-example** deployment to see the build status in a tooltip.
+        
+        1. Click on the icon for quick access to the build log.  
+        
+            - You should be able to see the log stream of the **rest-http-example-1** build on the **Build Details** page.
+            
+            - The application and its dependencies will be built into a container image and pushed to the OpenShift container registry.
+
+      review:
+        failedTaskHelp: >-
+          This task isn’t verified yet. Try the task again.
+        instructions: |-
+          Verify the build is complete:
+
+          - This build may take a few minutes. When it's finished, a **Complete** badge will surface on the page header beside build name **rest-http-example**. Did this badge appear?
+
+      summary:
+        failed: Try the steps again.
+        success: Your build is complete.
+      title: View the build status
+    - description: >-
+        To view the associated code:
+        
+        1. In the navigation menu, click [Topology]{{highlight qs-nav-topology}}.
+        
+        1. The icon on the bottom right quadrant of the **rest-http-example** deployment represents the Git repository of the associated code.  
+        
+            - The icon shown can be for Bitbucket, GitHub, GitLab or generic Git.  
+          
+        1. Click on the icon to navigate to the associated Git repository.
+
+      review:
+        failedTaskHelp: >-
+          This task isn’t verified yet. Try the task again.
+        instructions: |-
+          Verify that you can see the code associated with the sample app:
+          
+          - Was a new browser tab opened with https://github.com/snowdrop/rest-http-example ?
+
+          - Return to the browser tab running OpenShift.  
+
+
+      summary:
+        failed: Try the steps again.
+        success: You accessed the Git repository associated with your deployment.
+      title: View the associated Git repository
+    - description: >-
+        To view the pod status:
+        
+        1. To view pod status in a tooltip, hover over the pod donut.
+
+              - Notice that the **rest-http-example** deployment has a pod donut imposed on the circle, representing the pod status (i.e. blue = running).  
+              
+              - The color of the donut indicates the pod status.  
+
+      review:
+        failedTaskHelp: >-
+          This task isn’t verified yet. Try the task again.
+        instructions: |-
+          Verify you see the pod status:
+          
+          - Do you see the number of associated pods and their statuses?
+
+      summary:
+        failed: Try the steps again.
+        success: Your deployment has one running pod.
+      title: View the pod status
+
+    - description: >-
+        Since a Java builder image was used during the **Import from Git** flow, a Java icon is used by default in topology.  
+        
+          - This icon is determined by the value of the `app.openshift.io/runtime` label.
+
+          - Let’s change the icon associated with the **rest-http-example** deployment to indicate that it is a Spring application.
+        
+        1. Click on the **rest-http-example** deployment.
+        
+        1. In the side panel, click on the Actions drop-down and click the **Edit labels** menu item.
+        
+        1. Click on the “x” next to the `app.openshift.io/runtime=java` label to remove the entry
+        
+        1. Add an additional label: 
+
+          ```
+          app.openshift.io/runtime=rh-spring-boot
+          ```
+        
+        1. Click on **Save** to save the labels.
+
+      review:
+        failedTaskHelp: >-
+          This task isn’t verified yet. Try the task again.
+        instructions: |-
+          Verify you have updated the icon:
+          
+          - Has the Spring icon replaced the Java icon in the **rest-http-example** deployment? 
+
+      summary:
+        failed: Try the steps again.
+        success: You changed the icon associated with your deployment.
+      title: Change the deployment icon to Spring
+
+    - description: >-
+        The external link icon on the top right quadrant of the **rest-http-example** deployment represents the route URL.  
+        
+        1. Click on the external link icon to open the URL and run the application in a new browser tab.
+
+      review:
+        failedTaskHelp: >-
+          This task isn’t verified yet. Try the task again.
+        instructions: |-
+          Verify your Spring application is running:
+
+          - Is the new tab titled **HTTP Example**?
+
+      summary:
+        failed: Try the steps again.
+        success: Your Spring application is running.
+      title: Run the Spring application
+  conclusion: >-
+    Your Spring application is deployed and ready. 


### PR DESCRIPTION
Adding five (5) new Quick Starts for 4.7, which focus on the developer experience.

4 of these are available for all users:
- Get started with Node
- Get started with Quarkus with a Helm Chart
- Get started with Quarkus with s2i
- Get started with Spring Boot

1 needs special permissions:
- Manage available content in the Helm Chart Catalog

Note: Each of these have specific icons
I've attached a screenshot of Quick Starts page with them all installed:

<img width="1792" alt="4 7QuickStart-MoreForTheDeveloper" src="https://user-images.githubusercontent.com/12504403/105916665-4858a400-5fff-11eb-9188-58b0845eea6c.png">

Link to videos:

- [Get started with Node](https://drive.google.com/file/d/1FqQHc1yBVdi9inxHm0zfd2-BrHOUnQGb/view?usp=sharing) 
- [Get started with Quarkus using a Helm Chart](https://drive.google.com/file/d/1mhNAxlSSeqDaJWo941lyH3BDjEHJuFKi/view?usp=sharing)
- [Get started with Quarkus with s2i](https://drive.google.com/file/d/1PUtEiMoPuX-z78D11RLB0NIItpTGrux2/view?usp=sharing)
