### PR TITLE
Bump polling interval when checking for resource unavailability

### DIFF
--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -257,7 +257,7 @@ func LoopResources(client *ClientSet, inner func(errChan chan error, client *Cli
 func IsResourceUnavailable(errChan chan error, client *ClientSet, resource TestingResource) {
 	counter := 0
 	maxCount := 15
-	err := wait.Poll(1*time.Second, AsyncOperationTimeout, func() (stop bool, err error) {
+	err := wait.Poll(5*time.Second, AsyncOperationTimeout, func() (stop bool, err error) {
 
 		obtainedResource, err := GetResource(client, resource)
 		if err == nil {


### PR DESCRIPTION
Due to the small polling interval the `RemovedTest` has been flaking, since we didnt get all the operator sync loop enough between testing if all the resources are removed and not recreated.

/assign @spadgett 