### PR TITLE
Add e2e test to check correct deployment replicas, based on the Infrastructure config TopologyMode

### DIFF
--- a/pkg/console/subresource/deployment/deployment.go
+++ b/pkg/console/subresource/deployment/deployment.go
@@ -78,7 +78,7 @@ func DefaultDeployment(operatorConfig *operatorv1.Console, cm *corev1.ConfigMap,
 	// Set any annotations as needed so that `ApplyDeployment` rolls out a
 	// new version when they change.
 	meta.Annotations = annotations
-	replicas := replicas(infrastructureConfig)
+	replicas := Replicas(infrastructureConfig)
 	affinity := consolePodAffinity(infrastructureConfig)
 	gracePeriod := int64(40)
 	volumeConfig := defaultVolumeConfig()
@@ -135,7 +135,7 @@ func DefaultDownloadsDeployment(operatorConfig *operatorv1.Console, infrastructu
 	meta := util.SharedMeta()
 	meta.Labels = labels
 	meta.Name = api.OpenShiftConsoleDownloadsDeploymentName
-	replicas := replicas(infrastructureConfig)
+	replicas := Replicas(infrastructureConfig)
 	affinity := downloadsPodAffinity(infrastructureConfig)
 	gracePeriod := int64(1)
 
@@ -277,7 +277,7 @@ func downloadsPodAffinity(infrastructureConfig *configv1.Infrastructure) *corev1
 	}
 }
 
-func replicas(infrastructureConfig *configv1.Infrastructure) int32 {
+func Replicas(infrastructureConfig *configv1.Infrastructure) int32 {
 	if infrastructureConfig.Status.InfrastructureTopology == configv1.SingleReplicaTopologyMode {
 		return int32(SingleNodeConsoleReplicas)
 	}

--- a/pkg/console/subresource/deployment/deployment_test.go
+++ b/pkg/console/subresource/deployment/deployment_test.go
@@ -554,7 +554,7 @@ func TestReplicas(t *testing.T) {
 			want: 1,
 		},
 		{
-			name: "Test Replica Count For Single Node Cluster Infrastructure Config",
+			name: "Test Replica Count For Multi Node Cluster Infrastructure Config",
 			infraConfig: &configv1.Infrastructure{
 				TypeMeta:   metav1.TypeMeta{},
 				ObjectMeta: metav1.ObjectMeta{},
@@ -566,8 +566,9 @@ func TestReplicas(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			if diff := deep.Equal(replicas(tt.infraConfig), tt.want); diff != nil {
+			if diff := deep.Equal(Replicas(tt.infraConfig), tt.want); diff != nil {
 				t.Error(diff)
 			}
 		})

--- a/test/e2e/deployment_replicas_test.go
+++ b/test/e2e/deployment_replicas_test.go
@@ -1,0 +1,52 @@
+package e2e
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+
+	operatorsv1 "github.com/openshift/api/operator/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openshift/console-operator/pkg/api"
+	deploymentsub "github.com/openshift/console-operator/pkg/console/subresource/deployment"
+	"github.com/openshift/console-operator/test/e2e/framework"
+)
+
+func setupDeploymentsReplicasTestCase(t *testing.T) (*framework.ClientSet, *operatorsv1.Console) {
+	return framework.StandardSetup(t)
+}
+
+func cleanupDeploymentsReplicasTestCase(t *testing.T, client *framework.ClientSet) {
+	framework.StandardCleanup(t, client)
+}
+
+func TestDeploymentsReplicas(t *testing.T) {
+	client, _ := setupDeploymentsReplicasTestCase(t)
+	defer cleanupDeploymentsReplicasTestCase(t, client)
+
+	infrastructureConfig, err := client.Infrastructure.Infrastructures().Get(context.TODO(), api.ConfigResourceName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("error: %s", err)
+	}
+	expectedReplicas := deploymentsub.Replicas(infrastructureConfig)
+
+	consoleDeployment, err := framework.GetConsoleDeployment(client)
+	if err != nil {
+		t.Fatalf("error: %s", err)
+	}
+
+	downloadsDeployment, err := framework.GetDownloadsDeployment(client)
+	if err != nil {
+		t.Fatalf("error: %s", err)
+	}
+
+	for _, deployment := range []*appsv1.Deployment{consoleDeployment, downloadsDeployment} {
+		if !reflect.DeepEqual(*deployment.Spec.Replicas, expectedReplicas) {
+			t.Fatalf("error: expected %d replicas for %q deployment but has %d", expectedReplicas, deployment.ObjectMeta.Name, *deployment.Spec.Replicas)
+		}
+	}
+
+}

--- a/test/e2e/framework/clientset.go
+++ b/test/e2e/framework/clientset.go
@@ -31,6 +31,7 @@ type ClientSet struct {
 	Console                configv1.ConsolesGetter
 	ClusterOperator        configv1.ClusterOperatorsGetter
 	Proxy                  configv1.ProxiesGetter
+	Infrastructure         configv1.InfrastructuresGetter
 }
 
 // NewClientset creates a set of Kubernetes clients. The default kubeconfig is
@@ -69,6 +70,7 @@ func NewClientset(kubeconfig *restclient.Config) (*ClientSet, error) {
 	}
 	clientset.Console = configClient
 	clientset.Proxy = configClient
+	clientset.Infrastructure = configClient
 	clientset.ClusterOperator = configClient
 
 	consoleClient, err := consoleclientv1.NewForConfig(kubeconfig)

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -124,6 +124,10 @@ func GetConsoleDeployment(client *ClientSet) (*appv1.Deployment, error) {
 	return client.Apps.Deployments(consoleapi.OpenShiftConsoleNamespace).Get(context.TODO(), consoleapi.OpenShiftConsoleDeploymentName, metav1.GetOptions{})
 }
 
+func GetDownloadsDeployment(client *ClientSet) (*appv1.Deployment, error) {
+	return client.Apps.Deployments(consoleapi.OpenShiftConsoleNamespace).Get(context.TODO(), consoleapi.OpenShiftConsoleDownloadsDeploymentName, metav1.GetOptions{})
+}
+
 func GetConsoleCLIDownloads(client *ClientSet, consoleCLIDownloadName string) (*consolev1.ConsoleCLIDownload, error) {
 	return client.ConsoleCliDownloads.Get(context.TODO(), consoleCLIDownloadName, metav1.GetOptions{})
 }

--- a/test/e2e/plugins_test.go
+++ b/test/e2e/plugins_test.go
@@ -30,8 +30,6 @@ func setupPluginsTestCase(t *testing.T) (*framework.ClientSet, *operatorsv1.Cons
 }
 
 func cleanupPluginsTestCase(t *testing.T, client *framework.ClientSet) {
-	framework.StandardCleanup(t, client)
-
 	err := client.ConsolePlugin.Delete(context.TODO(), availablePluginName, metav1.DeleteOptions{})
 	if err != nil && !apiErrors.IsNotFound(err) {
 		t.Fatalf("could not delete cleanup %q plugin, %v", availablePluginName, err)


### PR DESCRIPTION
adding e2e test to check the `console` && `downloads` deployments replicas, based on the Infrastructure config, since the release team will by adding and enabling single-node cluster prow job to this repo.

/assign @spadgett 