### PR TITLE
Add in get subscriptions to console service account

### DIFF
--- a/manifests/03-rbac-role-cluster.yaml
+++ b/manifests/03-rbac-role-cluster.yaml
@@ -105,6 +105,14 @@ rules:
   - validatingwebhookconfigurations
   verbs:
   - get
+- apiGroups:
+  - operators.coreos.com
+  resources:
+  - subscriptions
+  resourceNames:
+  - web-terminal
+  verbs:
+  - get
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
This PR adds in additional permissions that are needed for https://github.com/openshift/console/pull/8342. We are using it to check if the web-terminal operator is installed on the cluster.

Related issue: https://issues.redhat.com/browse/WTO-20

Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>