### PR TITLE
Export project access details to console-config ConfigMap

### DIFF
--- a/pkg/console/subresource/configmap/configmap.go
+++ b/pkg/console/subresource/configmap/configmap.go
@@ -74,6 +74,7 @@ func DefaultConfigMap(
 		CustomLogoFile(operatorConfig.Spec.Customization.CustomLogoFile.Key).
 		CustomProductName(operatorConfig.Spec.Customization.CustomProductName).
 		CustomDeveloperCatalog(operatorConfig.Spec.Customization.DeveloperCatalog).
+		ProjectAccess(operatorConfig.Spec.Customization.ProjectAccess).
 		CustomHostnameRedirectPort(routesub.IsCustomRouteSet(operatorConfig)).
 		StatusPageID(statusPageId(operatorConfig)).
 		InactivityTimeout(inactivityTimeoutSeconds).

--- a/pkg/console/subresource/consoleserver/config_builder.go
+++ b/pkg/console/subresource/consoleserver/config_builder.go
@@ -39,6 +39,7 @@ type ConsoleServerCLIConfigBuilder struct {
 	statusPageID               string
 	customProductName          string
 	devCatalogCustomization    operatorv1.DeveloperConsoleCatalogCustomization
+	projectAccess              operatorv1.ProjectAccess
 	customLogoFile             string
 	CAFile                     string
 	monitoring                 map[string]string
@@ -73,6 +74,10 @@ func (b *ConsoleServerCLIConfigBuilder) CustomProductName(customProductName stri
 }
 func (b *ConsoleServerCLIConfigBuilder) CustomDeveloperCatalog(devCatalogCustomization operatorv1.DeveloperConsoleCatalogCustomization) *ConsoleServerCLIConfigBuilder {
 	b.devCatalogCustomization = devCatalogCustomization
+	return b
+}
+func (b *ConsoleServerCLIConfigBuilder) ProjectAccess(projectAccess operatorv1.ProjectAccess) *ConsoleServerCLIConfigBuilder {
+	b.projectAccess = projectAccess
 	return b
 }
 func (b *ConsoleServerCLIConfigBuilder) CustomLogoFile(customLogoFile string) *ConsoleServerCLIConfigBuilder {
@@ -260,6 +265,12 @@ func (b *ConsoleServerCLIConfigBuilder) customization() Customization {
 
 		conf.DeveloperCatalog = &DeveloperConsoleCatalogCustomization{
 			Categories: &categories,
+		}
+	}
+
+	if len(b.projectAccess.AvailableClusterRoles) > 0 {
+		conf.ProjectAccess = ProjectAccess{
+			AvailableClusterRoles: b.projectAccess.AvailableClusterRoles,
 		}
 	}
 	return conf

--- a/pkg/console/subresource/consoleserver/config_builder_test.go
+++ b/pkg/console/subresource/consoleserver/config_builder_test.go
@@ -289,6 +289,39 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 			},
 		},
 		{
+			name: "Config builder should handle project access options",
+			input: func() Config {
+				b := &ConsoleServerCLIConfigBuilder{}
+				b.ProjectAccess(v1.ProjectAccess{
+					AvailableClusterRoles: []string{"View", "Edit", "Admin"},
+				})
+				return b.Config()
+			},
+			output: Config{
+				Kind:       "ConsoleConfig",
+				APIVersion: "console.openshift.io/v1",
+				ServingInfo: ServingInfo{
+					BindAddress: "https://[::]:8443",
+					CertFile:    certFilePath,
+					KeyFile:     keyFilePath,
+				},
+				ClusterInfo: ClusterInfo{
+					ConsoleBasePath: "",
+				},
+				Auth: Auth{
+					ClientID:            api.OpenShiftConsoleName,
+					ClientSecretFile:    clientSecretFilePath,
+					OAuthEndpointCAFile: oauthEndpointCAFilePath,
+				},
+				Customization: Customization{
+					ProjectAccess: ProjectAccess{
+						AvailableClusterRoles: []string{"View", "Edit", "Admin"},
+					},
+				},
+				Providers: Providers{},
+			},
+		},
+		{
 			name: "Config builder should handle all inputs",
 			input: func() Config {
 				b := &ConsoleServerCLIConfigBuilder{}

--- a/pkg/console/subresource/consoleserver/types.go
+++ b/pkg/console/subresource/consoleserver/types.go
@@ -72,6 +72,12 @@ type Customization struct {
 	CustomLogoFile       string `yaml:"customLogoFile,omitempty"`
 	// developerCatalog allows to configure the shown developer catalog categories.
 	DeveloperCatalog *DeveloperConsoleCatalogCustomization `yaml:"developerCatalog,omitempty"`
+	ProjectAccess    ProjectAccess                         `yaml:"projectAccess,omitempty"`
+}
+
+// ProjectAccess contains options for project access roles
+type ProjectAccess struct {
+	AvailableClusterRoles []string `yaml:"availableClusterRoles,omitempty"`
 }
 
 // DeveloperConsoleCatalogCustomization allow cluster admin to configure developer catalog.


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/ODC-5447

Add project access customization details to console-config ConfigMap.

Based on enhancement proposal https://github.com/openshift/enhancements/pull/668
Depends on https://github.com/openshift/console-operator/pull/519 to get update from https://github.com/openshift/api/pull/857