### PR TITLE
IBM Cloud manifest profile patch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ include $(addprefix ./vendor/github.com/openshift/build-machinery-go/make/, \
     targets/openshift/deps-gomod.mk \
     targets/openshift/images.mk \
     targets/openshift/bindata.mk \
+    targets/openshift/operator/profile-manifests.mk \
 )
 
 # Run core verification and all self contained tests.
@@ -26,6 +27,14 @@ IMAGE_REGISTRY?=registry.svc.ci.openshift.org
 # $4 - context directory for image build
 # It will generate target "image-$(1)" for building the image and binding it as a prerequisite to target "images".
 $(call build-image,ocp-console-operator,$(IMAGE_REGISTRY)/ocp/4.5:console-operator,./Dockerfile.rhel7,.)
+
+# This will include additional actions on the update and verify targets to ensure that profile patches are applied
+# to manifest files
+# $0 - macro name
+# $1 - target name
+# $2 - profile patches directory
+# $3 - manifests directory
+$(call add-profile-manifests,manifests,./profile-patches,./manifests)
 
 GO_TEST_PACKAGES :=./pkg/... ./cmd/...
 

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/go-test/deep v1.0.5
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/openshift/api v0.0.0-20210331155327-945e812e9d2c
-	github.com/openshift/build-machinery-go v0.0.0-20200917070002-f171684f77ab
+	github.com/openshift/build-machinery-go v0.0.0-20210209125900-0da259a2c359
 	github.com/openshift/client-go v0.0.0-20210112160336-8889f8b15bd6
 	github.com/openshift/library-go v0.0.0-20201123212217-43f358922ea0
 	github.com/pkg/profile v1.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -419,8 +419,9 @@ github.com/openshift/api v0.0.0-20201019163320-c6a5ec25f267/go.mod h1:RDvBcRQMGL
 github.com/openshift/api v0.0.0-20210105115604-44119421ec6b/go.mod h1:aqU5Cq+kqKKPbDMqxo9FojgDeSpNJI7iuskjXjtojDg=
 github.com/openshift/api v0.0.0-20210331155327-945e812e9d2c h1:03oCl2A0bjf/8rJzopmeJ4JTTEXHSfv/sx+21QopTps=
 github.com/openshift/api v0.0.0-20210331155327-945e812e9d2c/go.mod h1:aqU5Cq+kqKKPbDMqxo9FojgDeSpNJI7iuskjXjtojDg=
-github.com/openshift/build-machinery-go v0.0.0-20200917070002-f171684f77ab h1:lBrojddP6C9C2p67EMs2vcdpC8eF+H0DDom+fgI2IF0=
 github.com/openshift/build-machinery-go v0.0.0-20200917070002-f171684f77ab/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
+github.com/openshift/build-machinery-go v0.0.0-20210209125900-0da259a2c359 h1:ehSDsWQiUVzJZrSEXMC7ceV9JIPEyTYqrpqu3m4Wa08=
+github.com/openshift/build-machinery-go v0.0.0-20210209125900-0da259a2c359/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20201020074620-f8fd44879f7c/go.mod h1:yZ3u8vgWC19I9gbDMRk8//9JwG/0Sth6v7C+m6R8HXs=
 github.com/openshift/client-go v0.0.0-20210112160336-8889f8b15bd6 h1:nT3OoJhg9EO/sATO6oJFZkDmkNAq1ox4GJSp/rDcIqM=
 github.com/openshift/client-go v0.0.0-20210112160336-8889f8b15bd6/go.mod h1:u7NRAjtYVAKokiI9LouzTv4mhds8P4S1TwdVAfbjKSk=

--- a/manifests/07-operator-ibm-cloud-managed.yaml
+++ b/manifests/07-operator-ibm-cloud-managed.yaml
@@ -1,0 +1,86 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    config.openshift.io/inject-proxy: console-operator
+    include.release.openshift.io/ibm-cloud-managed: "true"
+  name: console-operator
+  namespace: openshift-console-operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: console-operator
+  template:
+    metadata:
+      labels:
+        name: console-operator
+    spec:
+      containers:
+      - args:
+        - -v=2
+        - --config=/var/run/configmaps/config/controller-config.yaml
+        command:
+        - console
+        - operator
+        env:
+        - name: CONSOLE_IMAGE
+          value: registry.svc.ci.openshift.org/openshift:console
+        - name: DOWNLOADS_IMAGE
+          value: registry.svc.ci.openshift.org/openshift:cli-artifacts
+        - name: RELEASE_VERSION
+          value: 0.0.1-snapshot
+        - name: OPERATOR_NAME
+          value: console-operator
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        image: registry.svc.ci.openshift.org/openshift:console-operator
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8443
+            scheme: HTTPS
+        name: console-operator
+        ports:
+        - containerPort: 60000
+          name: metrics
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8443
+            scheme: HTTPS
+        resources:
+          requests:
+            cpu: 10m
+            memory: 100Mi
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /var/run/configmaps/config
+          name: config
+        - mountPath: /var/run/secrets/serving-cert
+          name: serving-cert
+      priorityClassName: system-cluster-critical
+      serviceAccountName: console-operator
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+        operator: Exists
+      - effect: NoExecute
+        key: node.kubernetes.io/unreachable
+        operator: Exists
+        tolerationSeconds: 120
+      - effect: NoExecute
+        key: node.kubernetes.io/not-ready
+        operator: Exists
+        tolerationSeconds: 120
+      volumes:
+      - configMap:
+          name: console-operator-config
+        name: config
+      - name: serving-cert
+        secret:
+          optional: true
+          secretName: serving-cert

--- a/manifests/07-operator.yaml
+++ b/manifests/07-operator.yaml
@@ -5,7 +5,6 @@ metadata:
   namespace: openshift-console-operator
   annotations:
     config.openshift.io/inject-proxy: console-operator
-    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
 spec:

--- a/profile-patches/ibm-cloud-managed/07-operator.yaml-patch
+++ b/profile-patches/ibm-cloud-managed/07-operator.yaml-patch
@@ -1,0 +1,7 @@
+- op: replace
+  path: /metadata/annotations
+  value:
+    config.openshift.io/inject-proxy: console-operator
+    include.release.openshift.io/ibm-cloud-managed: "true"
+- op: remove
+  path: /spec/template/spec/nodeSelector

--- a/vendor/github.com/openshift/build-machinery-go/OWNERS
+++ b/vendor/github.com/openshift/build-machinery-go/OWNERS
@@ -1,10 +1,8 @@
 reviewers:
-  - tnozicka
   - sttts
   - mfojtik
   - soltysh
 approvers:
-  - tnozicka
   - sttts
   - mfojtik
   - soltysh

--- a/vendor/github.com/openshift/build-machinery-go/README.md
+++ b/vendor/github.com/openshift/build-machinery-go/README.md
@@ -35,3 +35,10 @@ Extends [#Default]().
 
 ## Scripts
 `scripts` contain more complicated logic that is used in some make targets.
+
+## Contributing
+### Updating generated files
+We track the log output from the makefile tests to make sure any change is visible and can be audited. Unfortunately due to subtle linux tooling differences in distributions and versions, `make update` may not get you the exact output as the CI. To avoid it, just run the command in the same container as CI:   
+```
+podman run -it --rm --pull=always -v $( pwd ):/go/src/$( go list -m ) --workdir=/go/src/$( go list -m ) registry.svc.ci.openshift.org/openshift/release:rhel-8-release-golang-1.15-openshift-4.7 make update
+```

--- a/vendor/github.com/openshift/build-machinery-go/make/operator.example.mk.help.log
+++ b/vendor/github.com/openshift/build-machinery-go/make/operator.example.mk.help.log
@@ -3,6 +3,10 @@ all
 build
 clean
 clean-binaries
+clean-yaml-patch
+clean-yq
+ensure-yaml-patch
+ensure-yq
 help
 image-ocp-openshift-apiserver-operator
 images
@@ -15,6 +19,7 @@ update-codegen
 update-deps-overrides
 update-generated
 update-gofmt
+update-profile-manifests
 verify
 verify-bindata
 verify-codegen
@@ -23,3 +28,4 @@ verify-generated
 verify-gofmt
 verify-golint
 verify-govet
+verify-profile-manifests

--- a/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/operator/profile-manifests.mk
+++ b/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/operator/profile-manifests.mk
@@ -1,0 +1,84 @@
+self_dir :=$(dir $(lastword $(MAKEFILE_LIST)))
+
+# Merge yaml patch using mikefarah/yq
+# $1 - patch file
+# $2 - manifest file
+# $3 - output file
+define patch-manifest-yq
+	$(YQ) m -x '$(2)' '$(1)' > '$(3)'
+
+endef
+
+# Apply yaml-patch using krishicks/yaml-patch
+# $1 - patch file
+# $2 - manifest file
+# $3 - output file
+define patch-manifest-yaml-patch
+	$(YAML_PATCH) -o '$(1)' < '$(2)' > '$(3)'
+
+endef
+
+profile-yaml-patches = $(sort $(shell find $(1) -type f -name '*.yaml-patch'))
+profile-yaml-merge-patches = $(sort $(shell find $(1) -type f -name '*.yaml-merge-patch'))
+
+# Apply profile patches to manifests
+# $1 - patch dir
+# $2 - manifests dir
+define apply-profile-manifest-patches
+	$$(foreach p,$$(call profile-yaml-patches,$(1)),$$(call patch-manifest-yaml-patch,$$(p),$$(realpath $(2))/$$(basename $$(notdir $$(p))).yaml,$$(realpath $(2))/$$(basename $$(notdir $$(p)))-$$(notdir $$(realpath $$(dir $$(p)))).yaml))
+	$$(foreach p,$$(call profile-yaml-merge-patches,$(1)),$$(call patch-manifest-yq,$$(p),$$(realpath $(2))/$$(basename $$(notdir $$(p))).yaml,$$(realpath $(2))/$$(basename $$(notdir $$(p)))-$$(notdir $$(realpath $$(dir $$(p)))).yaml))
+endef
+
+# $1 - target name
+# $2 - patch dir
+# $3 - manifest dir
+define add-profile-manifests-internal
+
+update-profile-manifests-$(1): ensure-yq ensure-yaml-patch
+	$(call apply-profile-manifest-patches,$(2),$(3))
+.PHONY: update-profile-manifests-$(1)
+
+update-profile-manifests: update-profile-manifests-$(1)
+.PHONY: update-profile-manifests
+
+verify-profile-manifests-$(1): VERIFY_PROFILE_MANIFESTS_TMP_DIR:=$$(shell mktemp -d)
+verify-profile-manifests-$(1): ensure-yq ensure-yaml-patch
+	cp -R $(3)/* $$(VERIFY_PROFILE_MANIFESTS_TMP_DIR)/
+	$(call apply-profile-manifest-patches,$(2),$$(VERIFY_PROFILE_MANIFESTS_TMP_DIR))
+	diff -Naup $(3) $$(VERIFY_PROFILE_MANIFESTS_TMP_DIR)
+.PHONY: verify-profile-manifests-$(1)
+
+verify-profile-manifests: verify-profile-manifests-$(1)
+.PHONY: verify-profile-manifests
+
+update-generated: update-profile-manifests
+.PHONY: update-generated
+
+update: update-generated
+.PHONY: update
+
+verify-generated: verify-profile-manifests
+.PHONY: verify-generated
+
+verify: verify-generated
+.PHONY: verify
+
+endef
+
+
+# $1 - target name
+# $2 - profile patches dir
+# $3 - manifests dir
+define add-profile-manifests
+$(eval $(call add-profile-manifests-internal,$(1),$(2),$(3)))
+endef
+
+
+# We need to be careful to expand all the paths before any include is done
+# or self_dir could be modified for the next include by the included file.
+# Also doing this at the end of the file allows us to use self_dir before it could be modified.
+include $(addprefix $(self_dir), \
+	../../../lib/tmp.mk \
+	../yq.mk \
+	../yaml-patch.mk \
+)

--- a/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/yaml-patch.mk
+++ b/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/yaml-patch.mk
@@ -1,3 +1,5 @@
+ifndef _YAML_PATCH_MK_
+_YAML_PATCH_MK_ := defined
 self_dir :=$(dir $(lastword $(MAKEFILE_LIST)))
 
 YAML_PATCH ?=$(PERMANENT_TMP_GOPATH)/bin/yaml-patch
@@ -30,3 +32,4 @@ include $(addprefix $(self_dir), \
 	../../lib/golang.mk \
 	../../lib/tmp.mk \
 )
+endif

--- a/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/yq.mk
+++ b/vendor/github.com/openshift/build-machinery-go/make/targets/openshift/yq.mk
@@ -1,3 +1,5 @@
+ifndef _YQ_MK_
+_YQ_MK_ := defined
 self_dir :=$(dir $(lastword $(MAKEFILE_LIST)))
 
 YQ ?=$(PERMANENT_TMP_GOPATH)/bin/yq
@@ -30,3 +32,4 @@ include $(addprefix $(self_dir), \
 	../../lib/golang.mk \
 	../../lib/tmp.mk \
 )
+endif

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -156,7 +156,7 @@ github.com/openshift/api/template
 github.com/openshift/api/template/v1
 github.com/openshift/api/user
 github.com/openshift/api/user/v1
-# github.com/openshift/build-machinery-go v0.0.0-20200917070002-f171684f77ab
+# github.com/openshift/build-machinery-go v0.0.0-20210209125900-0da259a2c359
 ## explicit
 github.com/openshift/build-machinery-go
 github.com/openshift/build-machinery-go/make


### PR DESCRIPTION
Bumps build-machinery-go to latest
Adds patch specific to ibm-cloud-managed profile that generates a manifest that removes node selector for operator deployment
`make verify` verifies that the generated manifest is up to date
`make update` updates the manifest by applying the ibm-cloud-managed patch to the original deployment manifest