### PR TITLE
Add management workload annotations

### DIFF
--- a/manifests/02-namespace.yaml
+++ b/manifests/02-namespace.yaml
@@ -7,6 +7,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     openshift.io/node-selector: ""
+    workload.openshift.io/allowed: "management"
 ---
 apiVersion: v1
 kind: Namespace
@@ -17,6 +18,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     openshift.io/node-selector: ""
+    workload.openshift.io/allowed: "management"
   labels:
     openshift.io/cluster-monitoring: "true"
 ---
@@ -29,3 +31,4 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     openshift.io/node-selector: ""
+    workload.openshift.io/allowed: "management"

--- a/manifests/07-operator-ibm-cloud-managed.yaml
+++ b/manifests/07-operator-ibm-cloud-managed.yaml
@@ -13,6 +13,8 @@ spec:
       name: console-operator
   template:
     metadata:
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         name: console-operator
     spec:

--- a/manifests/07-operator.yaml
+++ b/manifests/07-operator.yaml
@@ -14,6 +14,8 @@ spec:
       name: console-operator
   template:
     metadata:
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         name: console-operator
     spec:

--- a/pkg/console/subresource/deployment/deployment_test.go
+++ b/pkg/console/subresource/deployment/deployment_test.go
@@ -126,6 +126,7 @@ func TestDefaultDeployment(t *testing.T) {
 		proxyConfigResourceVersionAnnotation:                 "",
 		infrastructureConfigResourceVersionAnnotation:        "",
 		consoleImageAnnotation:                               "",
+		workloadManagementAnnotation:                         workloadManagementAnnotationValue,
 	}
 
 	consoleDeploymentAffinity := &corev1.Affinity{
@@ -434,6 +435,9 @@ func TestDefaultDownloadsDeployment(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Name:   api.OpenShiftConsoleDownloadsDeploymentName,
 							Labels: labels,
+							Annotations: map[string]string{
+								workloadManagementAnnotation: workloadManagementAnnotationValue,
+							},
 						},
 						Spec: corev1.PodSpec{
 							NodeSelector: map[string]string{
@@ -489,6 +493,9 @@ func TestDefaultDownloadsDeployment(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Name:   api.OpenShiftConsoleDownloadsDeploymentName,
 							Labels: labels,
+							Annotations: map[string]string{
+								workloadManagementAnnotation: workloadManagementAnnotationValue,
+							},
 						},
 						Spec: corev1.PodSpec{
 							NodeSelector: map[string]string{


### PR DESCRIPTION
In support of the workload partitioning feature
(openshift/enhancements#703), we need to add
annotations to all management pods and namespaces so they can be
properly identified and assigned to segregated management cores on
clusters configured to do so.

Signed-off-by: Artyom Lukianov <alukiano@redhat.com>