### PR TITLE
Bug 1948524: Remove ResyncEvery method from the operator sync loop

### DIFF
--- a/pkg/console/operator/operator.go
+++ b/pkg/console/operator/operator.go
@@ -154,7 +154,7 @@ func NewConsoleOperator(
 	).WithFilteredEventsInformers(
 		util.NamesFilter(deployment.ConsoleOauthConfigName),
 		secretsInformer.Informer(),
-	).ResyncEvery(time.Minute).WithSync(c.Sync).
+	).WithSync(c.Sync).
 		ToController("ConsoleOperator", recorder.WithComponentSuffix("console-operator"))
 }
 


### PR DESCRIPTION
Removing the `ResyncEvery()` method from the operator sync loop. The issue is that the operator sync loop is syncing multiple resources, not just the deployment, which was causing re-deployment. For that reason we cant resync periodically this controller.
The periodical redepoyment was causing also panic in the `k8s.io/apiserver/pkg/server/filters.(*timeoutHandler).ServeHTTP.func1.1` 

```
2021-04-09T15:31:25.666699821Z I0409 15:31:25.666622       1 event.go:282] Event(v1.ObjectReference{Kind:"Deployment", Namespace:"openshift-console-operator", Name:"console-operator", UID:"efb36fcc-940d-4563-a9bc-54c14ea1ac29", APIVersion:"apps/v1", ResourceVersion:"", FieldPath:""}): type: 'Normal' reason: 'DeploymentUpdated' Updated Deployment.apps/downloads -n openshift-console because it changed
2021-04-09T15:31:27.045895966Z I0409 15:31:27.045793       1 event.go:282] Event(v1.ObjectReference{Kind:"Deployment", Namespace:"openshift-console-operator", Name:"console-operator", UID:"efb36fcc-940d-4563-a9bc-54c14ea1ac29", APIVersion:"apps/v1", ResourceVersion:"", FieldPath:""}): type: 'Normal' reason: 'DeploymentUpdated' Updated Deployment.apps/downloads -n openshift-console because it changed
2021-04-09T15:31:27.378385258Z E0409 15:31:27.359578       1 runtime.go:76] Observed a panic: runtime error: invalid memory address or nil pointer dereference
2021-04-09T15:31:27.378385258Z goroutine 15637 [running]:
2021-04-09T15:31:27.378385258Z k8s.io/apiserver/pkg/server/filters.(*timeoutHandler).ServeHTTP.func1.1(0xc001d80ae0)
2021-04-09T15:31:27.378385258Z 	/go/src/github.com/openshift/console-operator/vendor/k8s.io/apiserver/pkg/server/filters/timeout.go:106 +0x125
2021-04-09T15:31:27.378385258Z panic(0x1ffe920, 0x35c9ae0)
2021-04-09T15:31:27.378385258Z 	/usr/lib/golang/src/runtime/panic.go:965 +0x1b9
2021-04-09T15:31:27.378385258Z k8s.io/apiserver/plugin/pkg/authorizer/webhook.(*WebhookAuthorizer).Authorize(0xc00081c600, 0x268cb78, 0xc001f41f20, 0x26ab8a8, 0xc001d121e0, 0xc00221ad20, 0xf3c6ef, 0x268d080, 0xc001f4d700, 0xc001e04fda)
2021-04-09T15:31:27.378385258Z 	/go/src/github.com/openshift/console-operator/vendor/k8s.io/apiserver/plugin/pkg/authorizer/webhook/webhook.go:208 +0x8b3
2021-04-09T15:31:27.378385258Z k8s.io/apiserver/pkg/authorization/union.unionAuthzHandler.Authorize(0xc000d8e460, 0x1, 0x1, 0x268cb78, 0xc001f41f20, 0x26ab8a8, 0xc001d121e0, 0x0, 0x1, 0x23123de, ...)
2021-04-09T15:31:27.378385258Z 	/go/src/github.com/openshift/console-operator/vendor/k8s.io/apiserver/pkg/authorization/union/union.go:52 +0xfe
2021-04-09T15:31:27.378385258Z k8s.io/apiserver/pkg/authorization/union.unionAuthzHandler.Authorize(0xc000d99660, 0x2, 0x2, 0x268cb78, 0xc001f41f20, 0x26ab8a8, 0xc001d121e0, 0x2615450, 0x1ecf260, 0xc00200e6e0, ...)
2021-04-09T15:31:27.378385258Z 	/go/src/github.com/openshift/console-operator/vendor/k8s.io/apiserver/pkg/authorization/union/union.go:52 +0xfe
2021-04-09T15:31:27.378385258Z k8s.io/apiserver/pkg/endpoints/filters.WithAuthorization.func1(0x7f80903fbcf8, 0xc0004357c0, 0xc001f5fd00)
2021-04-09T15:31:27.378385258Z 	/go/src/github.com/openshift/console-operator/vendor/k8s.io/apiserver/pkg/endpoints/filters/authorization.go:59 +0x164
2021-04-09T15:31:27.378385258Z net/http.HandlerFunc.ServeHTTP(0xc000e0ec40, 0x7f80903fbcf8, 0xc0004357c0, 0xc001f5fd00)
2021-04-09T15:31:27.378385258Z 	/usr/lib/golang/src/net/http/server.go:2069 +0x44
2021-04-09T15:31:27.378385258Z k8s.io/apiserver/pkg/endpoints/filterlatency.trackStarted.func1(0x7f80903fbcf8, 0xc0004357c0, 0xc001f5fd00)
2021-04-09T15:31:27.378385258Z 	/go/src/github.com/openshift/console-operator/vendor/k8s.io/apiserver/pkg/endpoints/filterlatency/filterlatency.go:71 +0x186
```

As a short term fix we will just remove the `ResyncEvery()` method. Long term would be good to refactor and decouple these resources from the operator sync loop into their own sync loops.

/assign @spadgett 