### PR TITLE
Export quickStarts data to console-config ConfigMap

### DIFF
--- a/pkg/console/subresource/configmap/configmap.go
+++ b/pkg/console/subresource/configmap/configmap.go
@@ -75,6 +75,7 @@ func DefaultConfigMap(
 		CustomProductName(operatorConfig.Spec.Customization.CustomProductName).
 		CustomDeveloperCatalog(operatorConfig.Spec.Customization.DeveloperCatalog).
 		ProjectAccess(operatorConfig.Spec.Customization.ProjectAccess).
+		QuickStarts(operatorConfig.Spec.Customization.QuickStarts).
 		CustomHostnameRedirectPort(routesub.IsCustomRouteSet(operatorConfig)).
 		StatusPageID(statusPageId(operatorConfig)).
 		InactivityTimeout(inactivityTimeoutSeconds).

--- a/pkg/console/subresource/consoleserver/config_builder.go
+++ b/pkg/console/subresource/consoleserver/config_builder.go
@@ -40,6 +40,7 @@ type ConsoleServerCLIConfigBuilder struct {
 	customProductName          string
 	devCatalogCustomization    operatorv1.DeveloperConsoleCatalogCustomization
 	projectAccess              operatorv1.ProjectAccess
+	quickStarts                operatorv1.QuickStarts
 	customLogoFile             string
 	CAFile                     string
 	monitoring                 map[string]string
@@ -78,6 +79,10 @@ func (b *ConsoleServerCLIConfigBuilder) CustomDeveloperCatalog(devCatalogCustomi
 }
 func (b *ConsoleServerCLIConfigBuilder) ProjectAccess(projectAccess operatorv1.ProjectAccess) *ConsoleServerCLIConfigBuilder {
 	b.projectAccess = projectAccess
+	return b
+}
+func (b *ConsoleServerCLIConfigBuilder) QuickStarts(quickStarts operatorv1.QuickStarts) *ConsoleServerCLIConfigBuilder {
+	b.quickStarts = quickStarts
 	return b
 }
 func (b *ConsoleServerCLIConfigBuilder) CustomLogoFile(customLogoFile string) *ConsoleServerCLIConfigBuilder {
@@ -273,6 +278,13 @@ func (b *ConsoleServerCLIConfigBuilder) customization() Customization {
 			AvailableClusterRoles: b.projectAccess.AvailableClusterRoles,
 		}
 	}
+
+	if len(b.quickStarts.Disabled) > 0 {
+		conf.QuickStarts = QuickStarts{
+			Disabled: b.quickStarts.Disabled,
+		}
+	}
+
 	return conf
 
 }

--- a/pkg/console/subresource/consoleserver/config_builder_test.go
+++ b/pkg/console/subresource/consoleserver/config_builder_test.go
@@ -700,6 +700,37 @@ plugins:
   plugin2: plugin2_url
 `,
 		},
+		{
+			name: "Config builder should handle inputs for quick starts options",
+			input: func() ([]byte, error) {
+				b := &ConsoleServerCLIConfigBuilder{}
+				b.QuickStarts(v1.QuickStarts{
+					Disabled: []string{
+						"quickStarts0",
+						"quickStarts1",
+					},
+				})
+				return b.ConfigYAML()
+			},
+			output: `apiVersion: console.openshift.io/v1
+kind: ConsoleConfig
+servingInfo:
+  bindAddress: https://[::]:8443
+  certFile: /var/serving-cert/tls.crt
+  keyFile: /var/serving-cert/tls.key
+clusterInfo: {}
+auth:
+  clientID: console
+  clientSecretFile: /var/oauth-config/clientSecret
+  oauthEndpointCAFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+customization:
+  quickStarts:
+    disabled:
+    - quickStarts0
+    - quickStarts1
+providers: {}
+`,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/console/subresource/consoleserver/config_builder_test.go
+++ b/pkg/console/subresource/consoleserver/config_builder_test.go
@@ -322,6 +322,39 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 			},
 		},
 		{
+			name: "Config builder should handle quick starts options",
+			input: func() Config {
+				b := &ConsoleServerCLIConfigBuilder{}
+				b.QuickStarts(v1.QuickStarts{
+					Disabled: []string{"quick-start0", "quick-start1", "quick-start2"},
+				})
+				return b.Config()
+			},
+			output: Config{
+				Kind:       "ConsoleConfig",
+				APIVersion: "console.openshift.io/v1",
+				ServingInfo: ServingInfo{
+					BindAddress: "https://[::]:8443",
+					CertFile:    certFilePath,
+					KeyFile:     keyFilePath,
+				},
+				ClusterInfo: ClusterInfo{
+					ConsoleBasePath: "",
+				},
+				Auth: Auth{
+					ClientID:            api.OpenShiftConsoleName,
+					ClientSecretFile:    clientSecretFilePath,
+					OAuthEndpointCAFile: oauthEndpointCAFilePath,
+				},
+				Customization: Customization{
+					QuickStarts: QuickStarts{
+						Disabled: []string{"quick-start0", "quick-start1", "quick-start2"},
+					},
+				},
+				Providers: Providers{},
+			},
+		},
+		{
 			name: "Config builder should handle all inputs",
 			input: func() Config {
 				b := &ConsoleServerCLIConfigBuilder{}

--- a/pkg/console/subresource/consoleserver/types.go
+++ b/pkg/console/subresource/consoleserver/types.go
@@ -73,6 +73,12 @@ type Customization struct {
 	// developerCatalog allows to configure the shown developer catalog categories.
 	DeveloperCatalog *DeveloperConsoleCatalogCustomization `yaml:"developerCatalog,omitempty"`
 	ProjectAccess    ProjectAccess                         `yaml:"projectAccess,omitempty"`
+	QuickStarts      QuickStarts                           `yaml:"quickStarts,omitempty"`
+}
+
+// QuickStarts contains options for quick starts
+type QuickStarts struct {
+	Disabled []string `json:"disabled,omitempty"`
 }
 
 // ProjectAccess contains options for project access roles


### PR DESCRIPTION
fixes: https://issues.redhat.com/browse/ODC-5566

Export Quick start disabled data to console config map

Based on the enhancement proposal https://github.com/openshift/enhancements/pull/715