### PR TITLE
Rename workload annotations

### DIFF
--- a/manifests/07-operator-ibm-cloud-managed.yaml
+++ b/manifests/07-operator-ibm-cloud-managed.yaml
@@ -14,7 +14,7 @@ spec:
   template:
     metadata:
       annotations:
-        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         name: console-operator
     spec:

--- a/manifests/07-operator.yaml
+++ b/manifests/07-operator.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         name: console-operator
     spec:

--- a/pkg/console/subresource/deployment/deployment.go
+++ b/pkg/console/subresource/deployment/deployment.go
@@ -35,7 +35,7 @@ const (
 	trustedCAConfigMapResourceVersionAnnotation          = "console.openshift.io/trusted-ca-config-version"
 	secretResourceVersionAnnotation                      = "console.openshift.io/oauth-secret-version"
 	consoleImageAnnotation                               = "console.openshift.io/image"
-	workloadManagementAnnotation                         = "workload.openshift.io/management"
+	workloadManagementAnnotation                         = "target.workload.openshift.io/management"
 	workloadManagementAnnotationValue                    = `{"effect": "PreferredDuringScheduling"}`
 )
 


### PR DESCRIPTION
As per openshift/enhancements#739, the workload annotations names are changing.

Signed-off-by: Artyom Lukianov <alukiano@redhat.com>

/hold
Hold until after openshift/kubernetes#632 is merged