### PR TITLE
Bug 1948524: Update operator's status with downloads deployment generation && pull route health check into a standalone controller

### DIFF
--- a/pkg/console/controllers/clidownloads/controller.go
+++ b/pkg/console/controllers/clidownloads/controller.go
@@ -4,7 +4,6 @@ import (
 	// standard lib
 	"context"
 	"fmt"
-	"time"
 
 	// kube
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -85,7 +84,7 @@ func NewCLIDownloadsSyncController(
 		routeInformer.Informer(),
 	).WithInformers(
 		consoleCLIDownloadsInformers.Informer(),
-	).ResyncEvery(time.Minute).WithSync(ctrl.Sync).
+	).WithSync(ctrl.Sync).
 		ToController("ConsoleCLIDownloadsController", recorder.WithComponentSuffix("console-cli-downloads-controller"))
 }
 

--- a/pkg/console/controllers/healthcheck/controller.go
+++ b/pkg/console/controllers/healthcheck/controller.go
@@ -1,0 +1,198 @@
+package healthcheck
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"net/http"
+	"time"
+
+	// k8s
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	coreinformersv1 "k8s.io/client-go/informers/core/v1"
+	coreclientv1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/klog/v2"
+
+	// openshift
+	operatorsv1 "github.com/openshift/api/operator/v1"
+	routev1 "github.com/openshift/api/route/v1"
+	configclientv1 "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
+	operatorclientv1 "github.com/openshift/client-go/operator/clientset/versioned/typed/operator/v1"
+	v1 "github.com/openshift/client-go/operator/informers/externalversions/operator/v1"
+	routeclientv1 "github.com/openshift/client-go/route/clientset/versioned/typed/route/v1"
+	routesinformersv1 "github.com/openshift/client-go/route/informers/externalversions/route/v1"
+	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/resourcesynccontroller"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+
+	// console-operator
+	"github.com/openshift/console-operator/pkg/api"
+	"github.com/openshift/console-operator/pkg/console/controllers/util"
+	"github.com/openshift/console-operator/pkg/console/status"
+	routesub "github.com/openshift/console-operator/pkg/console/subresource/route"
+)
+
+type HealthCheckController struct {
+	// clients
+	operatorClient       v1helpers.OperatorClient
+	operatorConfigClient operatorclientv1.ConsoleInterface
+	ingressClient        configclientv1.IngressInterface
+	routeClient          routeclientv1.RoutesGetter
+	configMapClient      coreclientv1.ConfigMapsGetter
+	// events
+	resourceSyncer resourcesynccontroller.ResourceSyncer
+}
+
+func NewHealthCheckController(
+	// top level config
+	configClient configclientv1.ConfigV1Interface,
+	// clients
+	operatorClient v1helpers.OperatorClient,
+	operatorConfigClient operatorclientv1.ConsoleInterface,
+	routev1Client routeclientv1.RoutesGetter,
+	configMapClient coreclientv1.ConfigMapsGetter,
+	// informers
+	operatorConfigInformer v1.ConsoleInformer,
+	coreInformer coreinformersv1.Interface,
+	routeInformer routesinformersv1.RouteInformer,
+	// events
+	recorder events.Recorder,
+	resourceSyncer resourcesynccontroller.ResourceSyncer,
+) factory.Controller {
+	ctrl := &HealthCheckController{
+		operatorClient:       operatorClient,
+		operatorConfigClient: operatorConfigClient,
+		ingressClient:        configClient.Ingresses(),
+		routeClient:          routev1Client,
+		configMapClient:      configMapClient,
+		// events
+		resourceSyncer: resourceSyncer,
+	}
+
+	configMapInformer := coreInformer.ConfigMaps()
+
+	return factory.New().
+		WithFilteredEventsInformers( // service
+			util.NamesFilter(api.TrustedCAConfigMapName, api.DefaultIngressCertConfigMapName),
+			configMapInformer.Informer(),
+		).WithFilteredEventsInformers( // route
+		util.NamesFilter(api.OpenShiftConsoleRouteName, api.OpenshiftConsoleCustomRouteName),
+		routeInformer.Informer(),
+	).ResyncEvery(time.Minute).WithSync(ctrl.Sync).
+		ToController("HealthCheckController", recorder.WithComponentSuffix("health-check-controller"))
+}
+
+func (c *HealthCheckController) Sync(ctx context.Context, controllerContext factory.SyncContext) error {
+	operatorConfig, err := c.operatorConfigClient.Get(ctx, api.ConfigResourceName, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	updatedOperatorConfig := operatorConfig.DeepCopy()
+
+	switch updatedOperatorConfig.Spec.ManagementState {
+	case operatorsv1.Managed:
+		klog.V(4).Infoln("console-operator is in a managed state: starting health checks")
+	case operatorsv1.Unmanaged:
+		klog.V(4).Infoln("console-operator is in an unmanaged state: skipping health checks")
+		return nil
+	case operatorsv1.Removed:
+		klog.V(4).Infoln("console-operator is in a removed state: skipping health checks")
+		return nil
+	default:
+		return fmt.Errorf("unknown state: %v", updatedOperatorConfig.Spec.ManagementState)
+	}
+
+	statusHandler := status.NewStatusHandler(c.operatorClient)
+
+	ingressConfig, err := c.ingressClient.Get(ctx, api.ConfigResourceName, metav1.GetOptions{})
+	if err != nil {
+		return statusHandler.FlushAndReturn(err)
+	}
+
+	activeRouteName := api.OpenShiftConsoleRouteName
+	routeConfig := routesub.NewRouteConfig(updatedOperatorConfig, ingressConfig, activeRouteName)
+	if routeConfig.IsCustomHostnameSet() {
+		activeRouteName = api.OpenshiftConsoleCustomRouteName
+	}
+
+	activeRoute, activeRouteErr := c.routeClient.Routes(api.OpenShiftConsoleNamespace).Get(ctx, activeRouteName, metav1.GetOptions{})
+	statusHandler.AddConditions(status.HandleProgressingOrDegraded("RouteHealth", "FailedRouteGet", activeRouteErr))
+	if activeRouteErr != nil {
+		statusHandler.FlushAndReturn(activeRouteErr)
+	}
+
+	routeHealthCheckErrReason, routeHealthCheckErr := c.CheckRouteHealth(ctx, updatedOperatorConfig, activeRoute)
+	statusHandler.AddCondition(status.HandleDegraded("RouteHealth", routeHealthCheckErrReason, routeHealthCheckErr))
+
+	return statusHandler.FlushAndReturn(routeHealthCheckErr)
+}
+
+func (c *HealthCheckController) CheckRouteHealth(ctx context.Context, operatorConfig *operatorsv1.Console, route *routev1.Route) (string, error) {
+	if !routesub.IsAdmitted(route) {
+		return "RouteNotAdmitted", fmt.Errorf("console route is not admitted")
+	}
+
+	caPool, err := c.getCA(ctx, route.Spec.TLS)
+	if err != nil {
+		return "FailedLoadCA", fmt.Errorf("failed to read CA to check route health: %v", err)
+	}
+	client := clientWithCA(caPool)
+
+	if len(route.Spec.Host) == 0 {
+		return "RouteHostError", fmt.Errorf("route does not have host specified")
+	}
+	url := "https://" + route.Spec.Host + "/health"
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return "FailedRequest", fmt.Errorf("failed to build request to route (%s): %v", url, err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "FailedGet", fmt.Errorf("failed to GET route (%s): %v", url, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "StatusError", fmt.Errorf("route not yet available, %s returns '%s'", url, resp.Status)
+	}
+
+	return "", nil
+}
+
+func (c *HealthCheckController) getCA(ctx context.Context, tls *routev1.TLSConfig) (*x509.CertPool, error) {
+	caCertPool := x509.NewCertPool()
+
+	if tls != nil && len(tls.Certificate) != 0 {
+		if ok := caCertPool.AppendCertsFromPEM([]byte(tls.Certificate)); !ok {
+			klog.V(4).Infof("failed to parse custom tls.crt")
+		}
+	}
+
+	for _, cmName := range []string{api.TrustedCAConfigMapName, api.DefaultIngressCertConfigMapName} {
+		cm, err := c.configMapClient.ConfigMaps(api.OpenShiftConsoleNamespace).Get(ctx, cmName, metav1.GetOptions{})
+		if err != nil {
+			klog.V(4).Infof("failed to GET configmap %s / %s ", api.OpenShiftConsoleNamespace, cmName)
+			return nil, err
+		}
+		if ok := caCertPool.AppendCertsFromPEM([]byte(cm.Data["ca-bundle.crt"])); !ok {
+			klog.V(4).Infof("failed to parse %s ca-bundle.crt", cmName)
+		}
+	}
+
+	return caCertPool, nil
+}
+
+func clientWithCA(caPool *x509.CertPool) *http.Client {
+	return &http.Client{
+		Timeout: 5 * time.Second,
+		Transport: &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
+			TLSClientConfig: &tls.Config{
+				RootCAs: caPool,
+			},
+		},
+	}
+}

--- a/pkg/console/controllers/service/controller.go
+++ b/pkg/console/controllers/service/controller.go
@@ -3,8 +3,6 @@ package service
 import (
 	"context"
 	"fmt"
-	"strings"
-	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -83,8 +81,8 @@ func NewServiceSyncController(
 		).WithFilteredEventsInformers( // console resources
 		util.NamesFilter(serviceName, ctrl.getRedirectServiceName()),
 		serviceInformer.Informer(),
-	).ResyncEvery(time.Minute).WithSync(ctrl.Sync).
-		ToController(fmt.Sprintf("%sServiceController", strings.Title(serviceName)), recorder.WithComponentSuffix(fmt.Sprintf("%s-service-controller", serviceName)))
+	).WithSync(ctrl.Sync).
+		ToController("ConsoleServiceController", recorder.WithComponentSuffix("console-service-controller"))
 }
 
 func (c *ServiceSyncController) Sync(ctx context.Context, controllerContext factory.SyncContext) error {

--- a/pkg/console/operator/operator.go
+++ b/pkg/console/operator/operator.go
@@ -11,7 +11,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	corev1 "k8s.io/client-go/informers/core/v1"
-	appsv1 "k8s.io/client-go/kubernetes/typed/apps/v1"
+	appsclientv1 "k8s.io/client-go/kubernetes/typed/apps/v1"
 	coreclientv1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/klog/v2"
 
@@ -58,7 +58,7 @@ type consoleOperator struct {
 	secretsClient    coreclientv1.SecretsGetter
 	configMapClient  coreclientv1.ConfigMapsGetter
 	serviceClient    coreclientv1.ServicesGetter
-	deploymentClient appsv1.DeploymentsGetter
+	deploymentClient appsclientv1.DeploymentsGetter
 	// openshift
 	routeClient   routeclientv1.RoutesGetter
 	oauthClient   oauthclientv1.OAuthClientsGetter
@@ -81,7 +81,7 @@ func NewConsoleOperator(
 	corev1Client coreclientv1.CoreV1Interface,
 	coreV1 corev1.Interface,
 	// deployments
-	deploymentClient appsv1.DeploymentsGetter,
+	deploymentClient appsclientv1.DeploymentsGetter,
 	deploymentInformer appsinformersv1.DeploymentInformer,
 	// routes
 	routev1Client routeclientv1.RoutesGetter,

--- a/pkg/console/subresource/deployment/deployment.go
+++ b/pkg/console/subresource/deployment/deployment.go
@@ -77,6 +77,7 @@ func DefaultDeployment(operatorConfig *operatorv1.Console, cm *corev1.ConfigMap,
 		secretResourceVersionAnnotation:                      sec.GetResourceVersion(),
 		consoleImageAnnotation:                               util.GetImageEnv("CONSOLE_IMAGE"),
 	}
+
 	// Set any annotations as needed so that `ApplyDeployment` rolls out a
 	// new version when they change.
 	meta.Annotations = deploymentAnnotations
@@ -145,7 +146,7 @@ func DefaultDownloadsDeployment(operatorConfig *operatorv1.Console, infrastructu
 	meta.Name = api.OpenShiftConsoleDownloadsDeploymentName
 	replicas := Replicas(infrastructureConfig)
 	affinity := downloadsPodAffinity(infrastructureConfig)
-	gracePeriod := int64(1)
+	gracePeriod := int64(0)
 
 	downloadsDeployment := &appsv1.Deployment{
 		ObjectMeta: meta,

--- a/pkg/console/subresource/deployment/deployment_test.go
+++ b/pkg/console/subresource/deployment/deployment_test.go
@@ -372,7 +372,7 @@ func TestDefaultDownloadsDeployment(t *testing.T) {
 		defaultReplicaCount    int32 = DefaultConsoleReplicas
 		singleNodeReplicaCount int32 = SingleNodeConsoleReplicas
 		labels                       = util.LabelsForDownloads()
-		gracePeriod            int64 = 1
+		gracePeriod            int64 = 0
 	)
 
 	type args struct {


### PR DESCRIPTION
Remove the `ResyncEvery(time.Minute)` from most of the controllers, so unnecessary sync loops are not triggered. Instead I've created a `HealthCheckController` that should contain all the health check that we have (currently only for `console` route), and will add in the future. This controller sync is triggered periodically, every minute.

/assign @spadgett    