### PR TITLE
reduce initial steps to setup project

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,44 +20,30 @@ work with this repository is to do the following:
 
 ### Cloning the Repo
 
+Rather than ~/go for everything, provide separate gopaths. For this example we will
+use $HOME/gopaths as the root of our projects and consoleoperator as our project directory.
+
+
 ```bash 
-# rather than ~/go for everything, provide separate gopaths
-mkdir $HOME/gopaths
+mkdir -p $HOME/gopaths/consoleoperator
 ``` 
 
-It is fine to have `~/gopaths` next to `~/go` if you have some legacy projects.
-
-Now, create a `dir` under `~gopaths` to hold the project:
+Now get the repository from github.
 
 ```bash 
-mkdir $HOME/gopaths/consoleoperator 
+cd $HOME/gopaths/consoleoperator
+export GOPATH=`pwd`
+go get github.com/openshift/console-operator
 ```
 
-The name of this directory doesn't matter much, but the child directories are 
-important in order to install dependencies and build the project appropriately.
+You may see a message like `package github.com/openshift/console-operator: no Go files in $HOME/gopaths/consoleoperator/src/github.com/openshift/console-operator`
+and you can safely ignore it.
 
-An `src` and `bin` dir is expected:
-
-```bash 
-mkdir $HOME/gopaths/consoleoperator/src
-mkdir $HOME/gopaths/consoleoperator/bin 
-```
-
-Then the familiar path for source code `src/github.com/openshift/console-operator`:
-
+You may now add your fork to the repo as a remote.
 ```bash
-# specifically for this repo
-mkdir -p $HOME/gopaths/consoleoperator/src/github.com/openshift
-cd $HOME/gopaths/consoleoperator/src/github.com/openshift
-
-```
-
-Now clone (or fork, then clone) into this directory:
-
-```bash 
-git clone git@github.com:openshift/console-operator.git 
-# or your fork 
-git clone git@github.com:<your-fork>/console-operator.git
+cd src/github.com/openshift/console-operator/
+git remote rename origin upstream
+git remote add origin {Your fork url}
 ```
 
 ### Gopath


### PR DESCRIPTION
Reduce the directory creating by using `go get` to setup environment.

I noticed that when I build I get the `console` binary directly in my working directory and not in an `_output` directory.  I didn't update that because I wasn't sure if that was correct or not.  Example below.  Let me know if that needs updating too or if my environment is bad.  

```
[vagrant@localhost console-operator]$ echo $GOPATH
/home/vagrant/codebase/console-operator
[vagrant@localhost console-operator]$ pwd
/home/vagrant/codebase/console-operator/src/github.com/openshift/console-operator
[vagrant@localhost console-operator]$ make clean && make
rm -f console
rm -f '_output/tools/bin/yq'
if [ -d '_output/tools/bin/' ]; then rmdir --ignore-fail-on-non-empty -p '_output/tools/bin/'; fi
rm -f '_output/tools/bin/yaml-patch'
if [ -d '_output/tools/bin/' ]; then rmdir --ignore-fail-on-non-empty -p '_output/tools/bin/'; fi
rm -rf 
fatal: No names found, cannot describe anything.
go build -mod=vendor -trimpath -ldflags "-X github.com/openshift/console-operator/pkg/version.versionFromGit="v0.0.0-unknown" -X github.com/openshift/console-operator/pkg/version.commitFromGit="aed4bbca" -X github.com/openshift/console-operator/pkg/version.gitTreeState="clean" -X github.com/openshift/console-operator/pkg/version.buildDate="2021-04-21T15:29:33Z" " github.com/openshift/console-operator/cmd/console
[vagrant@localhost console-operator]$ git status
On branch readme-updates
Untracked files:
  (use "git add <file>..." to include in what will be committed)
	console

nothing added to commit but untracked files present (use "git add" to track)
[vagrant@localhost console-operator]$ 
```