### PR TITLE
update to non-deprecated NewCommand method

### DIFF
--- a/pkg/cmd/operator/cmd.go
+++ b/pkg/cmd/operator/cmd.go
@@ -1,6 +1,8 @@
 package operator
 
 import (
+	// golang
+	"context"
 	// 3rd party
 	"github.com/spf13/cobra"
 	// kube / openshift
@@ -17,7 +19,7 @@ func NewOperator() *cobra.Command {
 			"console-operator",
 			version.Get(),
 			starter.RunOperator).
-		NewCommand()
+		NewCommandWithContext(context.TODO())
 	cmd.Use = "operator"
 	cmd.Short = "Start the Console Operator"
 	// TODO: better docs on this


### PR DESCRIPTION
Update to non-deprecated cmd method with TODO context.

```go
// NewCommand returns a new command that a caller must set the Use and Descriptions on.  It wires default log, profiling,
// leader election and other "normal" behaviors.
// Deprecated: Use the NewCommandWithContext instead, this is here to be less disturbing for existing usages.
func (c *ControllerCommandConfig) NewCommand() *cobra.Command {
	return c.NewCommandWithContext(context.TODO())

}
```