### PR TITLE
Bump api master to fix plural name for CloudPrivateIPConfig

### DIFF
--- a/vendor/github.com/openshift/api/cloudnetwork/v1/001-cloudprivateipconfig.crd.yaml
+++ b/vendor/github.com/openshift/api/cloudnetwork/v1/001-cloudprivateipconfig.crd.yaml
@@ -1,13 +1,13 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: cloudprivateipconfig.cloud.network.openshift.io
+  name: cloudprivateipconfigs.cloud.network.openshift.io
 spec:
   group: cloud.network.openshift.io
   names:
     kind: CloudPrivateIPConfig
     listKind: CloudPrivateIPConfigList
-    plural: cloudprivateipconfig
+    plural: cloudprivateipconfigs
     singular: cloudprivateipconfig
   scope: Cluster
   versions:

--- a/vendor/github.com/openshift/api/cloudnetwork/v1/generated.proto
+++ b/vendor/github.com/openshift/api/cloudnetwork/v1/generated.proto
@@ -28,7 +28,7 @@ option go_package = "v1";
 // +k8s:openapi-gen=true
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:path=cloudprivateipconfig,scope=Cluster
+// +kubebuilder:resource:path=cloudprivateipconfigs,scope=Cluster
 message CloudPrivateIPConfig {
   optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 

--- a/vendor/github.com/openshift/api/cloudnetwork/v1/types.go
+++ b/vendor/github.com/openshift/api/cloudnetwork/v1/types.go
@@ -20,7 +20,7 @@ import (
 // +k8s:openapi-gen=true
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:path=cloudprivateipconfig,scope=Cluster
+// +kubebuilder:resource:path=cloudprivateipconfigs,scope=Cluster
 type CloudPrivateIPConfig struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`


### PR DESCRIPTION
Bump latest changes from api to verify if tests run successfully for this change.

(Because #527 fails and includes this changes as well.)