### PR TITLE
Bug 1956610: Add missing cluster profile annotations to manage-helm-repos quickstart manifest

### DIFF
--- a/quickstarts/manage-helm-repos.yaml
+++ b/quickstarts/manage-helm-repos.yaml
@@ -2,6 +2,10 @@ apiVersion: console.openshift.io/v1
 kind: ConsoleQuickStart
 metadata:
   name: manage-helm-repos
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: 'true'
+    include.release.openshift.io/self-managed-high-availability: 'true'
+    include.release.openshift.io/single-node-developer: 'true'
 spec:
   description: Manage available content in the Helm Chart Catalog by adding a Helm Chart Repository.
   displayName: Manage available content in the Helm Chart Catalog


### PR DESCRIPTION
/assign @spadgett 