### PR TITLE
Fix for flaky test removed E2E test

### DIFF
--- a/pkg/console/subresource/deployment/deployment.go
+++ b/pkg/console/subresource/deployment/deployment.go
@@ -145,7 +145,7 @@ func DefaultDownloadsDeployment(operatorConfig *operatorv1.Console, infrastructu
 	meta.Name = api.OpenShiftConsoleDownloadsDeploymentName
 	replicas := Replicas(infrastructureConfig)
 	affinity := downloadsPodAffinity(infrastructureConfig)
-	gracePeriod := int64(1)
+	gracePeriod := int64(0)
 
 	downloadsDeployment := &appsv1.Deployment{
 		ObjectMeta: meta,


### PR DESCRIPTION
On some of our recent PRs we've seen the test removed E2E test fail.

For example: [PROW for PR 531](https://prow.ci.openshift.org/pr-history/?org=openshift&repo=console-operator&pr=531)

See attached log for example failure:
[test-removed-e2e-failure.log](https://github.com/openshift/console-operator/files/6423444/test-removed-e2e-failure.log)


Suspect this is a timing issue as it takes longer to remove all of the download resources.

By setting the grace period to 0 (from 1 second), it seems the resources are removed immediately preventing these issues. See the 3 consecutive pass logs I've attached from my local machine proxied to a dev cluster running the docker image from this PR:
[test-removed-e2e-3-consescutive-passes.log](https://github.com/openshift/console-operator/files/6423443/test-removed-e2e-3-consescutive-passes.log)

This allows us to avoid using a static timeout (waiting X amount of minutes).
