### PR TITLE
Bug 1954866: Add necessary priority class to downloads

### DIFF
--- a/pkg/console/subresource/deployment/deployment.go
+++ b/pkg/console/subresource/deployment/deployment.go
@@ -168,6 +168,7 @@ func DefaultDownloadsDeployment(operatorConfig *operatorv1.Console, infrastructu
 					},
 					Affinity:                      affinity,
 					Tolerations:                   tolerations(),
+					PriorityClassName:             "system-cluster-critical",
 					TerminationGracePeriodSeconds: &gracePeriod,
 					Containers: []corev1.Container{
 						{


### PR DESCRIPTION
This PR will add the priority class field to the downloads subresource.
Based on the descriptions Ravi put in the BZ, choosing to use
"system-cluster-critical" value for the default deployment. Updated
and de-duplicated unit tests.

https://bugzilla.redhat.com/show_bug.cgi?id=1954866