### PR TITLE
Switching the URL of the default openshift helm repo.

### DIFF
--- a/manifests/01-helm.yaml
+++ b/manifests/01-helm.yaml
@@ -6,7 +6,6 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     release.openshift.io/create-only: "true"
-    charts.openshift.io/overwrites: "redhat-helm-repo"
   name: openshift-helm-charts
 spec:
   name: OpenShift Helm Charts

--- a/manifests/01-helm.yaml
+++ b/manifests/01-helm.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     release.openshift.io/create-only: "true"
+    charts.openshift.io/overwrites: "redhat-helm-repo"
   name: openshift-helm-charts
 spec:
   name: OpenShift Helm Charts

--- a/manifests/01-helm.yaml
+++ b/manifests/01-helm.yaml
@@ -6,7 +6,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     release.openshift.io/create-only: "true"
-  name: redhat-helm-repo
+  name: openshift-helm-charts
 spec:
   name: OpenShift Helm Charts
   connectionConfig:

--- a/manifests/01-helm.yaml
+++ b/manifests/01-helm.yaml
@@ -8,6 +8,6 @@ metadata:
     release.openshift.io/create-only: "true"
   name: redhat-helm-repo
 spec:
-  name: Red Hat Helm Charts
+  name: OpenShift Helm Charts
   connectionConfig:
-    url: https://redhat-developer.github.io/redhat-helm-charts
+    url: https://charts.openshift.io


### PR DESCRIPTION
All OpenShift charts will come from the repo with OpenShift
certified charts. All the charts in the current repo will go
through the certification program https://charts.openshift.io