### PR TITLE
Bug 1962698: Console-operator can not create resource console-public configmap in the openshift-config-managed namespace

### DIFF
--- a/manifests/03-rbac-role-ns-openshift-config-managed.yaml
+++ b/manifests/03-rbac-role-ns-openshift-config-managed.yaml
@@ -15,6 +15,10 @@ rules:
   verbs:
   - get
   - list
+  # We cannot restrict create or deletecollection requests by resourceName.
+  # For create, this limitation is because the object name is not known at authorization time.
+  # Check: https://kubernetes.io/docs/reference/access-authn-authz/rbac/#referring-to-resources
+  - create
   - watch
 - apiGroups:
   - ""

--- a/pkg/console/operator/sync_v400.go
+++ b/pkg/console/operator/sync_v400.go
@@ -58,16 +58,15 @@ func (co *consoleOperator) sync_v400(ctx context.Context, controllerContext fact
 		routeName = api.OpenshiftConsoleCustomRouteName
 	}
 
-	route, routeErr := co.routeClient.Routes(api.TargetNamespace).Get(ctx, routeName, metav1.GetOptions{})
+	route, routeCanonicalHost, consoleURL, routeReasoneErr, routeErr := co.GetActiveRouteInfo(ctx, routeName)
 	// TODO: this controller is no longer responsible for syncing the route.
 	//   however, the route is essential for several of the components below.
-	//   - is it appropraite for SyncLoopRefresh InProgress to be used here?
-	//     the loop should exit early and wait until the RouteSyncController creates the route.
+	//   - the loop should exit early and wait until the RouteSyncController creates the route.
 	//     there is nothing new in this flow, other than 2 controllers now look
 	//     at the same resource.
 	//     - RouteSyncController is responsible for updates
 	//     - ConsoleOperatorController (future ConsoleDeploymentController) is responsible for reads only.
-	statusHandler.AddConditions(status.HandleProgressingOrDegraded("SyncLoopRefresh", "InProgress", routeErr))
+	statusHandler.AddConditions(status.HandleProgressingOrDegraded("SyncLoopRefresh", routeReasoneErr, routeErr))
 	if routeErr != nil {
 		return statusHandler.FlushAndReturn(routeErr)
 	}
@@ -115,7 +114,7 @@ func (co *consoleOperator) sync_v400(ctx context.Context, controllerContext fact
 		return statusHandler.FlushAndReturn(secErr)
 	}
 
-	oauthClient, oauthChanged, oauthErrReason, oauthErr := co.SyncOAuthClient(ctx, set.Operator, sec, route)
+	oauthClient, oauthChanged, oauthErrReason, oauthErr := co.SyncOAuthClient(ctx, set.Operator, sec, routeCanonicalHost)
 	toUpdate = toUpdate || oauthChanged
 	statusHandler.AddConditions(status.HandleProgressingOrDegraded("OAuthClientSync", oauthErrReason, oauthErr))
 	if oauthErr != nil {
@@ -165,19 +164,19 @@ func (co *consoleOperator) sync_v400(ctx context.Context, controllerContext fact
 	// if we survive the gauntlet, we need to update the console config with the
 	// public hostname so that the world can know the console is ready to roll
 	klog.V(4).Infoln("sync_v400: updating console status")
-	consoleURL, err := getConsoleURL(route)
-	if err != nil {
-		return statusHandler.FlushAndReturn(err)
+
+	_, consoleConfigErr := co.SyncConsoleConfig(ctx, set.Console, consoleURL)
+	statusHandler.AddCondition(status.HandleDegraded("ConsoleConfig", "FailedUpdate", consoleConfigErr))
+	if consoleConfigErr != nil {
+		klog.Errorf("could not update console config status: %v", consoleConfigErr)
+		return statusHandler.FlushAndReturn(consoleConfigErr)
 	}
 
-	if _, err := co.SyncConsoleConfig(ctx, set.Console, consoleURL); err != nil {
-		klog.Errorf("could not update console config status: %v", err)
-		return statusHandler.FlushAndReturn(err)
-	}
-
-	if _, _, err := co.SyncConsolePublicConfig(consoleURL, controllerContext.Recorder()); err != nil {
-		klog.Errorf("could not update public console config status: %v", err)
-		return statusHandler.FlushAndReturn(err)
+	_, _, consolePublicConfigErr := co.SyncConsolePublicConfig(consoleURL, controllerContext.Recorder())
+	statusHandler.AddCondition(status.HandleDegraded("ConsolePublicConfigMap", "FailedApply", consolePublicConfigErr))
+	if consolePublicConfigErr != nil {
+		klog.Errorf("could not update public console config status: %v", consolePublicConfigErr)
+		return statusHandler.FlushAndReturn(consolePublicConfigErr)
 	}
 
 	defer func() {
@@ -201,6 +200,19 @@ func (co *consoleOperator) sync_v400(ctx context.Context, controllerContext fact
 	}()
 
 	return statusHandler.FlushAndReturn(nil)
+}
+
+func (co *consoleOperator) GetActiveRouteInfo(ctx context.Context, activeRouteName string) (route *routev1.Route, canonicalHost string, routeURL string, reason string, err error) {
+	route, routeErr := co.routeClient.Routes(api.TargetNamespace).Get(ctx, activeRouteName, metav1.GetOptions{})
+	if routeErr != nil {
+		return nil, "", "", "FailedGet", routeErr
+	}
+	canonicalHost, canonicalHostErr := routesub.GetCanonicalHost(route)
+	if canonicalHostErr != nil {
+		return nil, "", "", "FailedHost", canonicalHostErr
+	}
+
+	return route, canonicalHost, util.HTTPS(canonicalHost), "", nil
 }
 
 func (co *consoleOperator) SyncConsoleConfig(ctx context.Context, consoleConfig *configv1.Console, consoleURL string) (*configv1.Console, error) {
@@ -261,18 +273,14 @@ func (co *consoleOperator) SyncOAuthClient(
 	ctx context.Context,
 	operatorConfig *operatorv1.Console,
 	sec *corev1.Secret,
-	rt *routev1.Route,
+	routeCanonicalHost string,
 ) (consoleoauthclient *oauthv1.OAuthClient, changed bool, reason string, err error) {
-	host, routeErr := routesub.GetCanonicalHost(rt)
-	if routeErr != nil {
-		return nil, false, "FailedHost", routeErr
-	}
 	oauthClient, err := co.oauthClient.OAuthClients().Get(ctx, oauthsub.Stub().Name, metav1.GetOptions{})
 	if err != nil {
 		// at this point we must die & wait for someone to fix the lack of an outhclient. there is nothing we can do.
 		return nil, false, "FailedGet", errors.New(fmt.Sprintf("oauth client for console does not exist and cannot be created (%v)", err))
 	}
-	oauthsub.RegisterConsoleToOAuthClient(oauthClient, host, secretsub.GetSecretString(sec))
+	oauthsub.RegisterConsoleToOAuthClient(oauthClient, routeCanonicalHost, secretsub.GetSecretString(sec))
 	oauthClient, oauthChanged, oauthErr := oauthsub.CustomApplyOAuth(co.oauthClient, oauthClient, ctx)
 	if oauthErr != nil {
 		return nil, false, "FailedRegister", oauthErr
@@ -497,14 +505,6 @@ func (co *consoleOperator) ValidateCustomLogo(ctx context.Context, operatorConfi
 
 	klog.V(4).Infoln("custom logo ok to mount")
 	return true, "", nil
-}
-
-func getConsoleURL(route *routev1.Route) (string, error) {
-	host, err := routesub.GetCanonicalHost(route)
-	if err != nil {
-		return "", err
-	}
-	return util.HTTPS(host), nil
 }
 
 func (co *consoleOperator) GetPluginsEndpointMap(enabledPluginsNames []string) map[string]string {


### PR DESCRIPTION
console-operator doesnt have RBAc to create `console-public` CM in the `openshift-config-managed` NS, thats why we had it in the `/manifest` folder, so CVO would create it.

Just FYI, sin the `resourceapply.ApplyConfigMap()` is merging labels and annotations we dont need to have the `release.openshift.io` have in the bindata of the `console-public` CM. 

/assigne @spadgett 

@florkbr fyi 