### PR TITLE
Bug 1966480: Console-operator's controllers are passed resourceSyncer which is not used

### DIFF
--- a/pkg/console/controllers/clidownloads/controller.go
+++ b/pkg/console/controllers/clidownloads/controller.go
@@ -19,7 +19,6 @@ import (
 	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/resource/resourcemerge"
-	"github.com/openshift/library-go/pkg/operator/resourcesynccontroller"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 
 	// informers
@@ -46,8 +45,6 @@ type CLIDownloadsSyncController struct {
 	consoleCliDownloadsClient consoleclientv1.ConsoleCLIDownloadInterface
 	routeClient               routeclientv1.RoutesGetter
 	operatorConfigClient      operatorclientv1.ConsoleInterface
-	// events
-	resourceSyncer resourcesynccontroller.ResourceSyncer
 }
 
 func NewCLIDownloadsSyncController(
@@ -62,7 +59,6 @@ func NewCLIDownloadsSyncController(
 	routeInformer routesinformersv1.RouteInformer,
 	// events
 	recorder events.Recorder,
-	resourceSyncer resourcesynccontroller.ResourceSyncer,
 ) factory.Controller {
 
 	ctrl := &CLIDownloadsSyncController{
@@ -71,8 +67,6 @@ func NewCLIDownloadsSyncController(
 		consoleCliDownloadsClient: cliDownloadsInterface,
 		routeClient:               routeClient,
 		operatorConfigClient:      operatorConfigClient.Consoles(),
-		// events
-		resourceSyncer: resourceSyncer,
 	}
 
 	return factory.New().

--- a/pkg/console/controllers/downloadsdeployment/controller.go
+++ b/pkg/console/controllers/downloadsdeployment/controller.go
@@ -22,7 +22,6 @@ import (
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
 	"github.com/openshift/library-go/pkg/operator/resource/resourcemerge"
-	"github.com/openshift/library-go/pkg/operator/resourcesynccontroller"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 
 	"github.com/openshift/console-operator/pkg/console/controllers/util"
@@ -36,8 +35,6 @@ type DownloadsDeploymentSyncController struct {
 	infrastructureConfigClient configclientv1.InfrastructureInterface
 	// core kube
 	deploymentClient appsclientv1.DeploymentsGetter
-	// events
-	resourceSyncer resourcesynccontroller.ResourceSyncer
 }
 
 func NewDownloadsDeploymentSyncController(
@@ -54,7 +51,6 @@ func NewDownloadsDeploymentSyncController(
 	deploymentInformer appsinformersv1.DeploymentInformer,
 	// events
 	recorder events.Recorder,
-	resourceSyncer resourcesynccontroller.ResourceSyncer,
 ) factory.Controller {
 	configV1Informers := configInformer.Config().V1()
 
@@ -65,8 +61,6 @@ func NewDownloadsDeploymentSyncController(
 		infrastructureConfigClient: configClient.Infrastructures(),
 		// client
 		deploymentClient: deploymentClient,
-		// events
-		resourceSyncer: resourceSyncer,
 	}
 
 	configNameFilter := util.NamesFilter(api.ConfigResourceName)

--- a/pkg/console/controllers/healthcheck/controller.go
+++ b/pkg/console/controllers/healthcheck/controller.go
@@ -25,7 +25,6 @@ import (
 	routesinformersv1 "github.com/openshift/client-go/route/informers/externalversions/route/v1"
 	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/events"
-	"github.com/openshift/library-go/pkg/operator/resourcesynccontroller"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 
 	// console-operator
@@ -42,8 +41,6 @@ type HealthCheckController struct {
 	ingressClient        configclientv1.IngressInterface
 	routeClient          routeclientv1.RoutesGetter
 	configMapClient      coreclientv1.ConfigMapsGetter
-	// events
-	resourceSyncer resourcesynccontroller.ResourceSyncer
 }
 
 func NewHealthCheckController(
@@ -60,7 +57,6 @@ func NewHealthCheckController(
 	routeInformer routesinformersv1.RouteInformer,
 	// events
 	recorder events.Recorder,
-	resourceSyncer resourcesynccontroller.ResourceSyncer,
 ) factory.Controller {
 	ctrl := &HealthCheckController{
 		operatorClient:       operatorClient,
@@ -68,8 +64,6 @@ func NewHealthCheckController(
 		ingressClient:        configClient.Ingresses(),
 		routeClient:          routev1Client,
 		configMapClient:      configMapClient,
-		// events
-		resourceSyncer: resourceSyncer,
 	}
 
 	configMapInformer := coreInformer.ConfigMaps()

--- a/pkg/console/controllers/route/controller.go
+++ b/pkg/console/controllers/route/controller.go
@@ -29,7 +29,6 @@ import (
 	routesinformersv1 "github.com/openshift/client-go/route/informers/externalversions/route/v1"
 	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/events"
-	"github.com/openshift/library-go/pkg/operator/resourcesynccontroller"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 
 	// console-operator
@@ -49,8 +48,6 @@ type RouteSyncController struct {
 	routeClient          routeclientv1.RoutesGetter
 	configMapClient      coreclientv1.ConfigMapsGetter
 	secretClient         coreclientv1.SecretsGetter
-	// events
-	resourceSyncer resourcesynccontroller.ResourceSyncer
 }
 
 func NewRouteSyncController(
@@ -72,7 +69,6 @@ func NewRouteSyncController(
 	routeInformer routesinformersv1.RouteInformer,
 	// events
 	recorder events.Recorder,
-	resourceSyncer resourcesynccontroller.ResourceSyncer,
 ) factory.Controller {
 	ctrl := &RouteSyncController{
 		routeName:            routeName,
@@ -83,8 +79,6 @@ func NewRouteSyncController(
 		routeClient:          routev1Client,
 		configMapClient:      configMapClient,
 		secretClient:         secretClient,
-		// events
-		resourceSyncer: resourceSyncer,
 	}
 
 	configMapInformer := coreInformer.ConfigMaps()
@@ -179,7 +173,7 @@ func (c *RouteSyncController) SyncDefaultRoute(ctx context.Context, routeConfig 
 
 	requiredDefaultRoute := routeConfig.DefaultRoute(customTLSCert)
 
-	defaultRoute, _, defaultRouteError := routesub.ApplyRoute(c.routeClient, controllerContext.Recorder(), requiredDefaultRoute)
+	defaultRoute, _, defaultRouteError := routesub.ApplyRoute(c.routeClient, requiredDefaultRoute)
 	if defaultRouteError != nil {
 		return nil, "FailedDefaultRouteApply", defaultRouteError
 	}
@@ -219,7 +213,7 @@ func (c *RouteSyncController) SyncCustomRoute(ctx context.Context, routeConfig *
 	}
 
 	requiredCustomRoute := routeConfig.CustomRoute(customTLSCert, c.routeName)
-	customRoute, _, customRouteError := routesub.ApplyRoute(c.routeClient, controllerContext.Recorder(), requiredCustomRoute)
+	customRoute, _, customRouteError := routesub.ApplyRoute(c.routeClient, requiredCustomRoute)
 	if customRouteError != nil {
 		return nil, "FailedCustomRouteApply", customRouteError
 	}

--- a/pkg/console/controllers/service/controller.go
+++ b/pkg/console/controllers/service/controller.go
@@ -25,7 +25,6 @@ import (
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceread"
-	"github.com/openshift/library-go/pkg/operator/resourcesynccontroller"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 )
 
@@ -39,8 +38,6 @@ type ServiceSyncController struct {
 	ingressClient        configclientv1.IngressInterface
 	// live clients, we dont need listers w/caches
 	serviceClient coreclientv1.ServicesGetter
-	// events
-	resourceSyncer resourcesynccontroller.ResourceSyncer
 }
 
 // factory func needs clients and informers
@@ -59,7 +56,6 @@ func NewServiceSyncController(
 	serviceInformer coreinformersv1.ServiceInformer,
 	// events
 	recorder events.Recorder,
-	resourceSyncer resourcesynccontroller.ResourceSyncer,
 ) factory.Controller {
 
 	ctrl := &ServiceSyncController{
@@ -68,7 +64,6 @@ func NewServiceSyncController(
 		operatorConfigClient: operatorConfigClient,
 		ingressClient:        configClient.Ingresses(),
 		serviceClient:        corev1Client,
-		resourceSyncer:       resourceSyncer,
 	}
 
 	configV1Informers := configInformer.Config().V1()

--- a/pkg/console/starter/starter.go
+++ b/pkg/console/starter/starter.go
@@ -201,7 +201,6 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 		kubeClient.AppsV1(), // Deployments
 		kubeInformersNamespaced.Apps().V1().Deployments(), // Deployments
 		recorder,
-		resourceSyncer,
 	)
 
 	cliDownloadsController := clidownloads.NewCLIDownloadsSyncController(
@@ -216,7 +215,6 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 		routesInformersNamespaced.Route().V1().Routes(),       // Routes
 		// events
 		recorder,
-		resourceSyncer,
 	)
 
 	consoleServiceController := service.NewServiceSyncController(
@@ -233,7 +231,6 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 		kubeInformersNamespaced.Core().V1().Services(),     // Services
 		// events
 		recorder,
-		resourceSyncer,
 	)
 
 	downloadsServiceController := service.NewServiceSyncController(
@@ -250,7 +247,6 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 		kubeInformersNamespaced.Core().V1().Services(),     // Services
 		// events
 		recorder,
-		resourceSyncer,
 	)
 
 	consoleRouteController := route.NewRouteSyncController(
@@ -273,7 +269,6 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 		routesInformersNamespaced.Route().V1().Routes(),
 		// events
 		recorder,
-		resourceSyncer,
 	)
 
 	downloadsRouteController := route.NewRouteSyncController(
@@ -296,7 +291,6 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 		routesInformersNamespaced.Route().V1().Routes(),
 		// events
 		recorder,
-		resourceSyncer,
 	)
 
 	consoleRouteHealthCheckController := healthcheck.NewHealthCheckController(
@@ -313,7 +307,6 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 		routesInformersNamespaced.Route().V1().Routes(),
 		// events
 		recorder,
-		resourceSyncer,
 	)
 
 	versionRecorder := status.NewVersionGetter()

--- a/pkg/console/subresource/route/route.go
+++ b/pkg/console/subresource/route/route.go
@@ -15,7 +15,6 @@ import (
 	operatorv1 "github.com/openshift/api/operator/v1"
 	routev1 "github.com/openshift/api/route/v1"
 	routeclient "github.com/openshift/client-go/route/clientset/versioned/typed/route/v1"
-	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/resource/resourcemerge"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceread"
 
@@ -165,7 +164,7 @@ func GetDefaultRouteHost(routeName string, ingressConfig *configv1.Ingress) stri
 	return fmt.Sprintf("%s-%s.%s", routeName, api.OpenShiftConsoleNamespace, ingressConfig.Spec.Domain)
 }
 
-func ApplyRoute(client routeclient.RoutesGetter, recorder events.Recorder, required *routev1.Route) (*routev1.Route, bool, error) {
+func ApplyRoute(client routeclient.RoutesGetter, required *routev1.Route) (*routev1.Route, bool, error) {
 	existing, err := client.Routes(required.Namespace).Get(context.TODO(), required.Name, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
 		requiredCopy := required.DeepCopy()


### PR DESCRIPTION
Removing all the unnecessary resourceSyncer instances passed to operator's controllers.
Originally this refactoring PR should be bigger, but since we are too close to release I've decide to address other naming and structural changes in 4.9

/assign @spadgett @florkbr 

