### PR TITLE
Bug 1952405: Console operator should report Available:False when it's route is not accessible

### DIFF
--- a/pkg/console/controllers/healthcheck/controller.go
+++ b/pkg/console/controllers/healthcheck/controller.go
@@ -126,6 +126,7 @@ func (c *HealthCheckController) Sync(ctx context.Context, controllerContext fact
 
 	routeHealthCheckErrReason, routeHealthCheckErr := c.CheckRouteHealth(ctx, updatedOperatorConfig, activeRoute)
 	statusHandler.AddCondition(status.HandleDegraded("RouteHealth", routeHealthCheckErrReason, routeHealthCheckErr))
+	statusHandler.AddCondition(status.HandleAvailable("RouteHealth", routeHealthCheckErrReason, routeHealthCheckErr))
 
 	return statusHandler.FlushAndReturn(routeHealthCheckErr)
 }


### PR DESCRIPTION
We haven't been reporting `Available: False` when the console route was not accessible.

/assign @spadgett 