### PR TITLE
Bug 1954148: Implement console-operator updating Ingress operator config status with ComponentRoutes conditions

### DIFF
--- a/manifests/03-rbac-role-cluster.yaml
+++ b/manifests/03-rbac-role-cluster.yaml
@@ -38,6 +38,16 @@ rules:
 - apiGroups:
   - config.openshift.io
   resources:
+  - ingresses/status
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+- apiGroups:
+  - config.openshift.io
+  resources:
   - proxies
   verbs:
   - get

--- a/pkg/console/subresource/route/route.go
+++ b/pkg/console/subresource/route/route.go
@@ -48,7 +48,7 @@ type RouteControllerSpec struct {
 	secretName string
 }
 
-func getComponentRouteSpec(ingressConfig *configv1.Ingress, componentName string) *configv1.ComponentRouteSpec {
+func GetComponentRouteSpec(ingressConfig *configv1.Ingress, componentName string) *configv1.ComponentRouteSpec {
 	for i, componentRoute := range ingressConfig.Spec.ComponentRoutes {
 		if componentRoute.Name == componentName && componentRoute.Namespace == api.OpenShiftConsoleNamespace {
 			return ingressConfig.Spec.ComponentRoutes[i].DeepCopy()
@@ -57,7 +57,7 @@ func getComponentRouteSpec(ingressConfig *configv1.Ingress, componentName string
 	return nil
 }
 
-func getComponentRouteStatus(ingressConfig *configv1.Ingress, componentName string) *configv1.ComponentRouteStatus {
+func GetComponentRouteStatus(ingressConfig *configv1.Ingress, componentName string) *configv1.ComponentRouteStatus {
 	for i, componentRoute := range ingressConfig.Status.ComponentRoutes {
 		if componentRoute.Name == componentName && componentRoute.Namespace == api.OpenShiftConsoleNamespace {
 			return ingressConfig.Status.ComponentRoutes[i].DeepCopy()
@@ -74,7 +74,7 @@ func NewRouteConfig(operatorConfig *operatorv1.Console, ingressConfig *configv1.
 	var isIngressConfigCustomHostnameSet bool
 
 	// Custom hostname in ingress config takes precedent over console operator's config
-	componentRouteSpec := getComponentRouteSpec(ingressConfig, routeName)
+	componentRouteSpec := GetComponentRouteSpec(ingressConfig, routeName)
 	if componentRouteSpec != nil {
 		customRoute.hostname = string(componentRouteSpec.Hostname)
 		if componentRouteSpec.ServingCertKeyPairSecret.Name != "" {
@@ -117,6 +117,10 @@ func (rc *RouteConfig) IsCustomHostnameSet() bool {
 
 func (rc *RouteConfig) GetCustomRouteHostname() string {
 	return rc.customRoute.hostname
+}
+
+func (rc *RouteConfig) GetDefaultRouteHostname() string {
+	return rc.defaultRoute.hostname
 }
 
 func (rc *RouteConfig) IsCustomTLSSecretSet() bool {


### PR DESCRIPTION
Addressing per discussion with @awgreene, PTAL

FYI some methods have been borrowed from https://github.com/openshift/cluster-authentication-operator/pull/430/files, since the helpers for updating the status are still not available in library-go.

/assign @spadgett 