### PR TITLE
Bug 1975714: Add policy-group label to the openshift-console namespace manifest

### DIFF
--- a/manifests/02-namespace.yaml
+++ b/manifests/02-namespace.yaml
@@ -8,6 +8,8 @@ metadata:
     include.release.openshift.io/single-node-developer: "true"
     openshift.io/node-selector: ""
     workload.openshift.io/allowed: "management"
+  labels:
+    network.openshift.io/policy-group: "console"
 ---
 apiVersion: v1
 kind: Namespace


### PR DESCRIPTION
Adding the `network.openshift.io/policy-group` label based.
@sleshchenko FYI

/assign @spadgett 