### PR TITLE
Bug 1975605: Schedule downloads pods on master nodes

### DIFF
--- a/pkg/console/subresource/deployment/deployment.go
+++ b/pkg/console/subresource/deployment/deployment.go
@@ -165,7 +165,8 @@ func DefaultDownloadsDeployment(operatorConfig *operatorv1.Console, infrastructu
 				},
 				Spec: corev1.PodSpec{
 					NodeSelector: map[string]string{
-						"kubernetes.io/os": "linux",
+						"kubernetes.io/os":               "linux",
+						"node-role.kubernetes.io/master": "",
 					},
 					Affinity:                      affinity,
 					Tolerations:                   tolerations(),

--- a/pkg/console/subresource/deployment/deployment_test.go
+++ b/pkg/console/subresource/deployment/deployment_test.go
@@ -414,7 +414,8 @@ func TestDefaultDownloadsDeployment(t *testing.T) {
 
 	downloadsDeploymentPodSpecSingleReplica := corev1.PodSpec{
 		NodeSelector: map[string]string{
-			"kubernetes.io/os": "linux",
+			"kubernetes.io/os":               "linux",
+			"node-role.kubernetes.io/master": "",
 		},
 		Affinity:                      downloadsPodAffinity(infrastructureConfigSingleReplica),
 		Tolerations:                   tolerations(),


### PR DESCRIPTION
Adding the `"node-role.kubernetes.io/master": "",` nodeSelector for the downloads pods.

/assign @spadgett 

@florkbr FYI this will need to ported to your https://github.com/openshift/console-operator/pull/550 PR afterwards.