### PR TITLE
Adds ODF install tour

### DIFF
--- a/quickstarts/install-odf.yaml
+++ b/quickstarts/install-odf.yaml
@@ -1,0 +1,92 @@
+apiVersion: console.openshift.io/v1
+kind: ConsoleQuickStart
+metadata:
+  name: odf-install-tour
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+spec:
+  displayName: Install the OpenShift Data Foundation
+  durationMinutes: 5
+  icon: data:image/svg+xml;base64,PHN2ZyBlbmFibGUtYmFja2dyb3VuZD0ibmV3IDAgMCAxMDAgMTAwIiBoZWlnaHQ9IjEwMCIgdmlld0JveD0iMCAwIDEwMCAxMDAiIHdpZHRoPSIxMDAiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PHBhdGggZD0ibTY2LjcgNTUuOGM2LjYgMCAxNi4xLTEuNCAxNi4xLTkuMiAwLS42IDAtMS4yLS4yLTEuOGwtMy45LTE3Yy0uOS0zLjctMS43LTUuNC04LjMtOC43LTUuMS0yLjYtMTYuMi02LjktMTkuNS02LjktMy4xIDAtNCA0LTcuNiA0LTMuNSAwLTYuMS0yLjktOS40LTIuOS0zLjIgMC01LjIgMi4xLTYuOCA2LjYgMCAwLTQuNCAxMi41LTUgMTQuMy0uMS4zLS4xLjctLjEgMSAuMSA0LjcgMTkuMiAyMC42IDQ0LjcgMjAuNm0xNy4xLTZjLjkgNC4zLjkgNC44LjkgNS4zIDAgNy40LTguMyAxMS40LTE5LjEgMTEuNC0yNC42IDAtNDYuMS0xNC40LTQ2LjEtMjMuOSAwLTEuMy4zLTIuNi44LTMuOS04LjkuNS0yMC4zIDIuMS0yMC4zIDEyLjIgMCAxNi41IDM5LjIgMzYuOSA3MC4yIDM2LjkgMjMuOCAwIDI5LjgtMTAuNyAyOS44LTE5LjIgMC02LjctNS44LTE0LjMtMTYuMi0xOC44IiBmaWxsPSIjZWQxYzI0Ii8+PHBhdGggZD0ibTgzLjggNDkuOGMuOSA0LjMuOSA0LjguOSA1LjMgMCA3LjQtOC4zIDExLjQtMTkuMSAxMS40LTI0LjYgMC00Ni4xLTE0LjQtNDYuMS0yMy45IDAtMS4zLjMtMi42LjgtMy45bDEuOS00LjhjLS4xLjMtLjEuNy0uMSAxIDAgNC44IDE5LjEgMjAuNyA0NC43IDIwLjcgNi42IDAgMTYuMS0xLjQgMTYuMS05LjIgMC0uNiAwLTEuMi0uMi0xLjh6IiBmaWxsPSIjMDEwMTAxIi8+PC9zdmc+
+  description: Install the OpenShift Data Foundation (ODF) operator and create a storage system.
+  introduction: >- 
+    **Red Hat OpenShift® Data Foundation** is persistent software-defined storage integrated with and optimized for Red Hat OpenShift Container Platform. 
+    
+      Dynamic, stateful, and highly available container-native storage can be provisioned and de-provisioned on demand as an integral part of the OpenShift administrator console.
+  tasks:
+  - title: Install the OpenShift Data Foundation
+    description: |- 
+      The OperatorHub is where you can find a catalog of available Operators to install on your cluster.
+      
+      To install OpenShift Data Foundation, follow these steps:
+
+      1. Enter the administrator perspective: In the main navigation, click the dropdown menu and select Administrator.
+
+      1. In the main navigation menu, click on [Operators]{{highlight qs-nav-operators}} and select **OperatorHub**
+
+      1. In the **Filter by keyword** field, type `OpenShift Data Foundation`
+
+      1. Click the **OpenShift Data Foundation** tile to initiate the operator installation on your cluster.
+      
+      1. In the panel that appears, click **Install.** 
+      
+      1. On the operator installation page, fill out the Operator Subscription form. 
+      
+      1. Click **Install.**
+    review:
+      instructions: |-
+        ####  Verify that the OpenShift Data Foundation operator is installed:
+
+        In the navigation menu, click **Operators** > **Installed Operators**. 
+        
+        Does the **Status** column for **OpenShift Data Foundation** show **Succeeded**?
+      failedTaskHelp: This task isn’t verified yet. Try the task again.
+    summary:
+      success:  Great work! You installed the OpenShift Data Foundation operator.
+      failed: Try the steps again.
+  - title: Create a StorageSystem
+    description: |-
+      A **StorageSystem** includes a Ceph cluster, Multi cloud gateway, and all the required storage resources.
+
+      To create a StorageSystem, follow these steps:
+
+      1. Click on the [perspective switcher]{{highlight qs-perspective-switcher}} at the top of the navigation, and select **Administrator.**
+
+      2. In the main navigation menu, click on [Operators]{{highlight qs-nav-operators}} and select **Installed Operators.**
+      
+      3. From your list of installed operators, click **OpenShift Data Foundation.**
+      
+      4. On the StorageSystem tile, click **Create Instance.**
+      
+      5. Select the **Backing Storage**
+          - **Use an existing storage class:**  
+              
+              Select an existing StorageClass to create the StorageSystem
+          - **Create a new storage class using local storage devices:**  
+              
+              Can be used on any platform where there are attached devices to the nodes, using the Local Storage Operator (LSO)
+          - **Create a new external storage class:**  
+              
+              Used for connecting to an external storage platform to the ODF internal system
+
+      6. Follow the on-screen instructions to create the StorageSystem.
+      
+      7. Once the state of the storage system is **Ready**, you can start using the storage resources (eg: StorageCluster, BucketClass) and allow ODF to manage your storage.
+    review:
+      instructions: |-
+        #### Verify that the Storage System is created:
+
+        On the storage system details page, is the state of the system **Ready** ?
+      failedTaskHelp: This task isn’t verified yet. Try the task again.
+    summary:
+      success: Great work! You installed the OpenShift Data Foundation operator.
+      failed: Try the steps again.
+  conclusion: >- 
+    Congratulations! **OpenShift Data Foundation** is ready to use. 
+    
+    
+    To learn how you can manage your storage space effectively, take the Getting Started with OpenShift Data Foundation Quick Start.
+  nextQuickStart:
+    - "getting-started-odf"

--- a/quickstarts/ocs-install-tour-quickstart.yaml
+++ b/quickstarts/ocs-install-tour-quickstart.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/delete: "true"
 spec:
   displayName: Install the OpenShift Container Storage Operator
   durationMinutes: 5


### PR DESCRIPTION
For 4.9 release, OCS operator will be replaced with the ODF at a higher level. Hence we would want to make sure that new install quickstart accurately represent the workflows for ODF operator.

This commit adds quickstart for installing the ODF operator and setting up the storage cluster.

Signed-off-by: Vineet Badrinath <vbadrina@redhat.com>