### PR TITLE
Bug 1975379: Use hard requirement for anti-affinity rules on both console's deployments

### DIFF
--- a/pkg/console/subresource/deployment/deployment.go
+++ b/pkg/console/subresource/deployment/deployment.go
@@ -257,15 +257,13 @@ func consolePodAffinity(infrastructureConfig *configv1.Infrastructure) *corev1.A
 	}
 	return &corev1.Affinity{
 		PodAntiAffinity: &corev1.PodAntiAffinity{
-			PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{{
-				Weight: 100,
-				PodAffinityTerm: corev1.PodAffinityTerm{
-					LabelSelector: &metav1.LabelSelector{
-						MatchLabels: util.SharedLabels(),
-					},
-					TopologyKey: "topology.kubernetes.io/zone",
+			RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{{
+				LabelSelector: &metav1.LabelSelector{
+					MatchLabels: util.LabelsForConsole(),
 				},
-			}},
+				TopologyKey: "topology.kubernetes.io/zone",
+			},
+			},
 		},
 	}
 }
@@ -277,15 +275,13 @@ func downloadsPodAffinity(infrastructureConfig *configv1.Infrastructure) *corev1
 	}
 	return &corev1.Affinity{
 		PodAntiAffinity: &corev1.PodAntiAffinity{
-			PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{{
-				Weight: 100,
-				PodAffinityTerm: corev1.PodAffinityTerm{
-					LabelSelector: &metav1.LabelSelector{
-						MatchLabels: util.SharedLabels(),
-					},
-					TopologyKey: "topology.kubernetes.io/zone",
+			RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{{
+				LabelSelector: &metav1.LabelSelector{
+					MatchLabels: util.LabelsForDownloads(),
 				},
-			}},
+				TopologyKey: "topology.kubernetes.io/zone",
+			},
+			},
 		},
 	}
 }

--- a/pkg/console/subresource/deployment/deployment.go
+++ b/pkg/console/subresource/deployment/deployment.go
@@ -83,6 +83,7 @@ func DefaultDeployment(operatorConfig *operatorv1.Console, cm *corev1.ConfigMap,
 	meta.Annotations = deploymentAnnotations
 	replicas := Replicas(infrastructureConfig)
 	affinity := consolePodAffinity(infrastructureConfig)
+	rollingUpdateParams := rollingUpdateParams(infrastructureConfig)
 	gracePeriod := int64(40)
 	volumeConfig := defaultVolumeConfig()
 	caBundle, caBundleExists := trustedCAConfigMap.Data["ca-bundle.crt"]
@@ -105,6 +106,10 @@ func DefaultDeployment(operatorConfig *operatorv1.Console, cm *corev1.ConfigMap,
 			Replicas: &replicas,
 			Selector: &metav1.LabelSelector{
 				MatchLabels: labels,
+			},
+			Strategy: appsv1.DeploymentStrategy{
+				Type:          appsv1.RollingUpdateDeploymentStrategyType,
+				RollingUpdate: rollingUpdateParams,
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
@@ -146,14 +151,18 @@ func DefaultDownloadsDeployment(operatorConfig *operatorv1.Console, infrastructu
 	meta.Name = api.OpenShiftConsoleDownloadsDeploymentName
 	replicas := Replicas(infrastructureConfig)
 	affinity := downloadsPodAffinity(infrastructureConfig)
+	rollingUpdateParams := rollingUpdateParams(infrastructureConfig)
 	gracePeriod := int64(0)
-
 	downloadsDeployment := &appsv1.Deployment{
 		ObjectMeta: meta,
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &replicas,
 			Selector: &metav1.LabelSelector{
 				MatchLabels: labels,
+			},
+			Strategy: appsv1.DeploymentStrategy{
+				Type:          appsv1.RollingUpdateDeploymentStrategyType,
+				RollingUpdate: rollingUpdateParams,
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
@@ -229,6 +238,20 @@ func LogDeploymentAnnotationChanges(client appsclientv1.DeploymentsGetter, updat
 	}
 }
 
+func rollingUpdateParams(infrastructureConfig *configv1.Infrastructure) *appsv1.RollingUpdateDeployment {
+	if infrastructureConfig.Status.InfrastructureTopology == configv1.SingleReplicaTopologyMode {
+		return &appsv1.RollingUpdateDeployment{}
+	}
+	return &appsv1.RollingUpdateDeployment{
+		MaxSurge: &intstr.IntOrString{
+			IntVal: int32(3),
+		},
+		MaxUnavailable: &intstr.IntOrString{
+			IntVal: int32(1),
+		},
+	}
+}
+
 func tolerations() []corev1.Toleration {
 	return []corev1.Toleration{
 		{
@@ -259,7 +282,24 @@ func consolePodAffinity(infrastructureConfig *configv1.Infrastructure) *corev1.A
 		PodAntiAffinity: &corev1.PodAntiAffinity{
 			RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{{
 				LabelSelector: &metav1.LabelSelector{
-					MatchLabels: util.LabelsForConsole(),
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						{
+							Key:      "component",
+							Operator: metav1.LabelSelectorOpIn,
+							Values:   []string{"ui"},
+						},
+					},
+				},
+				TopologyKey: "kubernetes.io/hostname",
+			}, {
+				LabelSelector: &metav1.LabelSelector{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						{
+							Key:      "component",
+							Operator: metav1.LabelSelectorOpIn,
+							Values:   []string{"ui"},
+						},
+					},
 				},
 				TopologyKey: "topology.kubernetes.io/zone",
 			},
@@ -277,7 +317,24 @@ func downloadsPodAffinity(infrastructureConfig *configv1.Infrastructure) *corev1
 		PodAntiAffinity: &corev1.PodAntiAffinity{
 			RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{{
 				LabelSelector: &metav1.LabelSelector{
-					MatchLabels: util.LabelsForDownloads(),
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						{
+							Key:      "component",
+							Operator: metav1.LabelSelectorOpIn,
+							Values:   []string{"downloads"},
+						},
+					},
+				},
+				TopologyKey: "kubernetes.io/hostname",
+			}, {
+				LabelSelector: &metav1.LabelSelector{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						{
+							Key:      "component",
+							Operator: metav1.LabelSelectorOpIn,
+							Values:   []string{"downloads"},
+						},
+					},
 				},
 				TopologyKey: "topology.kubernetes.io/zone",
 			},

--- a/pkg/console/subresource/deployment/deployment_test.go
+++ b/pkg/console/subresource/deployment/deployment_test.go
@@ -132,15 +132,13 @@ func TestDefaultDeployment(t *testing.T) {
 	consoleDeploymentAffinity := &corev1.Affinity{
 		// spread out across master nodes rather than congregate on one
 		PodAntiAffinity: &corev1.PodAntiAffinity{
-			PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{{
-				Weight: 100,
-				PodAffinityTerm: corev1.PodAffinityTerm{
-					LabelSelector: &metav1.LabelSelector{
-						MatchLabels: util.SharedLabels(),
-					},
-					TopologyKey: "topology.kubernetes.io/zone",
+			RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{{
+				LabelSelector: &metav1.LabelSelector{
+					MatchLabels: util.LabelsForConsole(),
 				},
-			}},
+				TopologyKey: "topology.kubernetes.io/zone",
+			},
+			},
 		},
 	}
 
@@ -585,15 +583,13 @@ func TestConsolePodAffinity(t *testing.T) {
 			},
 			want: &corev1.Affinity{
 				PodAntiAffinity: &corev1.PodAntiAffinity{
-					PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{{
-						Weight: 100,
-						PodAffinityTerm: corev1.PodAffinityTerm{
-							LabelSelector: &metav1.LabelSelector{
-								MatchLabels: util.SharedLabels(),
-							},
-							TopologyKey: "topology.kubernetes.io/zone",
+					RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{{
+						LabelSelector: &metav1.LabelSelector{
+							MatchLabels: util.LabelsForConsole(),
 						},
-					}},
+						TopologyKey: "topology.kubernetes.io/zone",
+					},
+					},
 				},
 			},
 		},
@@ -635,15 +631,13 @@ func TestDownalodsPodAffinity(t *testing.T) {
 			},
 			want: &corev1.Affinity{
 				PodAntiAffinity: &corev1.PodAntiAffinity{
-					PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{{
-						Weight: 100,
-						PodAffinityTerm: corev1.PodAffinityTerm{
-							LabelSelector: &metav1.LabelSelector{
-								MatchLabels: util.SharedLabels(),
-							},
-							TopologyKey: "topology.kubernetes.io/zone",
+					RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{{
+						LabelSelector: &metav1.LabelSelector{
+							MatchLabels: util.LabelsForDownloads(),
 						},
-					}},
+						TopologyKey: "topology.kubernetes.io/zone",
+					},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
Use `requiredDuringSchedulingIgnoredDuringExecution` for anti-affinity rules on both console's deployments.
The label selectors for console deployment will be:
`"app": "console", "component": "ui"`
The label selectors for downloads deployment will be:
`"app": "console", "component": "downloads"`

/assign @spadgett 