### PR TITLE
Remove references to upstream UI components and config

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -27,7 +27,6 @@ const (
 	OAuthClientName                         = OpenShiftConsoleName
 	OpenShiftConfigManagedNamespace         = "openshift-config-managed"
 	OpenShiftConfigNamespace                = "openshift-config"
-	OpenShiftMonitoringConfigMapName        = "monitoring-shared-config"
 	OpenShiftCustomLogoConfigMapName        = "custom-logo"
 	TrustedCAConfigMapName                  = "trusted-ca-bundle"
 	TrustedCABundleKey                      = "ca-bundle.crt"

--- a/pkg/console/operator/sync_v400.go
+++ b/pkg/console/operator/sync_v400.go
@@ -342,12 +342,8 @@ func (co *consoleOperator) SyncConfigMap(
 	}
 
 	pluginsEndpoingMap := co.GetPluginsEndpointMap(operatorConfig.Spec.Plugins)
-	monitoringSharedConfig, mscErr := co.configMapClient.ConfigMaps(api.OpenShiftConfigManagedNamespace).Get(ctx, api.OpenShiftMonitoringConfigMapName, metav1.GetOptions{})
-	if mscErr != nil && !apierrors.IsNotFound(mscErr) {
-		return nil, false, "FailedGetMonitoringSharedConfig", mscErr
-	}
 
-	defaultConfigmap, _, err := configmapsub.DefaultConfigMap(operatorConfig, consoleConfig, managedConfig, monitoringSharedConfig, infrastructureConfig, activeConsoleRoute, useDefaultCAFile, inactivityTimeoutSeconds, pluginsEndpoingMap)
+	defaultConfigmap, _, err := configmapsub.DefaultConfigMap(operatorConfig, consoleConfig, managedConfig, infrastructureConfig, activeConsoleRoute, useDefaultCAFile, inactivityTimeoutSeconds, pluginsEndpoingMap)
 	if err != nil {
 		return nil, false, "FailedConsoleConfigBuilder", err
 	}

--- a/pkg/console/subresource/configmap/configmap.go
+++ b/pkg/console/subresource/configmap/configmap.go
@@ -39,7 +39,6 @@ func DefaultConfigMap(
 	operatorConfig *operatorv1.Console,
 	consoleConfig *configv1.Console,
 	managedConfig *corev1.ConfigMap,
-	monitoringSharedConfig *corev1.ConfigMap,
 	infrastructureConfig *configv1.Infrastructure,
 	activeConsoleRoute *routev1.Route,
 	useDefaultCAFile bool,
@@ -53,7 +52,6 @@ func DefaultConfigMap(
 		DocURL(DEFAULT_DOC_URL).
 		DefaultIngressCert(useDefaultCAFile).
 		APIServerURL(getApiUrl(infrastructureConfig)).
-		Monitoring(monitoringSharedConfig).
 		InactivityTimeout(inactivityTimeoutSeconds).
 		ConfigYAML()
 	if err != nil {
@@ -69,7 +67,6 @@ func DefaultConfigMap(
 		DocURL(operatorConfig.Spec.Customization.DocumentationBaseURL).
 		DefaultIngressCert(useDefaultCAFile).
 		APIServerURL(getApiUrl(infrastructureConfig)).
-		Monitoring(monitoringSharedConfig).
 		Plugins(pluginsEndpoingMap).
 		CustomLogoFile(operatorConfig.Spec.Customization.CustomLogoFile.Key).
 		CustomProductName(operatorConfig.Spec.Customization.CustomProductName).

--- a/pkg/console/subresource/configmap/configmap_test.go
+++ b/pkg/console/subresource/configmap/configmap_test.go
@@ -33,7 +33,6 @@ func TestDefaultConfigMap(t *testing.T) {
 		operatorConfig           *operatorv1.Console
 		consoleConfig            *configv1.Console
 		managedConfig            *corev1.ConfigMap
-		monitoringSharedConfig   *corev1.ConfigMap
 		infrastructureConfig     *configv1.Infrastructure
 		rt                       *routev1.Route
 		useDefaultCAFile         bool
@@ -48,10 +47,9 @@ func TestDefaultConfigMap(t *testing.T) {
 		{
 			name: "Test default configmap, no customization",
 			args: args{
-				operatorConfig:         &operatorv1.Console{},
-				consoleConfig:          &configv1.Console{},
-				managedConfig:          &corev1.ConfigMap{},
-				monitoringSharedConfig: &corev1.ConfigMap{},
+				operatorConfig: &operatorv1.Console{},
+				consoleConfig:  &configv1.Console{},
+				managedConfig:  &corev1.ConfigMap{},
 				infrastructureConfig: &configv1.Infrastructure{
 					Status: configv1.InfrastructureStatus{
 						APIServerURL: mockAPIServer,
@@ -99,10 +97,9 @@ providers: {}
 		{
 			name: "Test configmap with default-ingress-cert",
 			args: args{
-				operatorConfig:         &operatorv1.Console{},
-				consoleConfig:          &configv1.Console{},
-				managedConfig:          &corev1.ConfigMap{},
-				monitoringSharedConfig: &corev1.ConfigMap{},
+				operatorConfig: &operatorv1.Console{},
+				consoleConfig:  &configv1.Console{},
+				managedConfig:  &corev1.ConfigMap{},
 				infrastructureConfig: &configv1.Infrastructure{
 					Status: configv1.InfrastructureStatus{
 						APIServerURL: mockAPIServer,
@@ -161,7 +158,6 @@ customization:
 `,
 					},
 				},
-				monitoringSharedConfig: &corev1.ConfigMap{},
 				infrastructureConfig: &configv1.Infrastructure{
 					Status: configv1.InfrastructureStatus{
 						APIServerURL: mockAPIServer,
@@ -229,7 +225,6 @@ customization:
 `,
 					},
 				},
-				monitoringSharedConfig: &corev1.ConfigMap{},
 				infrastructureConfig: &configv1.Infrastructure{
 					Status: configv1.InfrastructureStatus{
 						APIServerURL: mockAPIServer,
@@ -302,7 +297,6 @@ customization:
 `,
 					},
 				},
-				monitoringSharedConfig: &corev1.ConfigMap{},
 				infrastructureConfig: &configv1.Infrastructure{
 					Status: configv1.InfrastructureStatus{
 						APIServerURL: mockAPIServer,
@@ -377,7 +371,6 @@ customization:
 `,
 					},
 				},
-				monitoringSharedConfig: &corev1.ConfigMap{},
 				infrastructureConfig: &configv1.Infrastructure{
 					Status: configv1.InfrastructureStatus{
 						APIServerURL: mockAPIServer,
@@ -424,69 +417,6 @@ providers:
 			},
 		},
 		{
-			name: "Test operator config with monitoring URLs",
-			args: args{
-				operatorConfig: &operatorv1.Console{},
-				consoleConfig:  &configv1.Console{},
-				managedConfig:  &corev1.ConfigMap{},
-				monitoringSharedConfig: &corev1.ConfigMap{
-					Data: map[string]string{
-						"alertmanagerPublicURL": "https://alertmanager.url.com",
-						"grafanaPublicURL":      "https://grafana.url.com",
-						"prometheusPublicURL":   "https://prometheus.url.com",
-						"thanosPublicURL":       "https://thanos.url.com",
-					},
-				},
-				infrastructureConfig: &configv1.Infrastructure{
-					Status: configv1.InfrastructureStatus{
-						APIServerURL: mockAPIServer,
-					},
-				},
-				rt: &routev1.Route{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: api.OpenShiftConsoleName,
-					},
-					Spec: routev1.RouteSpec{
-						Host: host,
-					},
-				},
-				useDefaultCAFile:         true,
-				inactivityTimeoutSeconds: 0,
-			},
-			want: &corev1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:        api.OpenShiftConsoleConfigMapName,
-					Namespace:   api.OpenShiftConsoleNamespace,
-					Labels:      map[string]string{"app": api.OpenShiftConsoleName},
-					Annotations: map[string]string{},
-				},
-				Data: map[string]string{configKey: `kind: ConsoleConfig
-apiVersion: console.openshift.io/v1
-auth:
-  clientID: console
-  clientSecretFile: /var/oauth-config/clientSecret
-  oauthEndpointCAFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-clusterInfo:
-  consoleBaseAddress: https://` + host + `
-  masterPublicURL: ` + mockAPIServer + `
-monitoringInfo:
-  alertmanagerPublicURL: https://alertmanager.url.com
-  grafanaPublicURL: https://grafana.url.com
-  prometheusPublicURL: https://prometheus.url.com
-  thanosPublicURL: https://thanos.url.com
-customization:
-  branding: ` + DEFAULT_BRAND + `
-  documentationBaseURL: ` + DEFAULT_DOC_URL + `
-servingInfo:
-  bindAddress: https://[::]:8443
-  certFile: /var/serving-cert/tls.crt
-  keyFile: /var/serving-cert/tls.key
-providers: {}
-`,
-				},
-			},
-		},
-		{
 			name: "Test operator config with custom route hostname",
 			args: args{
 				operatorConfig: &operatorv1.Console{
@@ -496,9 +426,8 @@ providers: {}
 						},
 					},
 				},
-				consoleConfig:          &configv1.Console{},
-				managedConfig:          &corev1.ConfigMap{},
-				monitoringSharedConfig: &corev1.ConfigMap{},
+				consoleConfig: &configv1.Console{},
+				managedConfig: &corev1.ConfigMap{},
 				infrastructureConfig: &configv1.Infrastructure{
 					Status: configv1.InfrastructureStatus{
 						APIServerURL: mockAPIServer,
@@ -547,10 +476,9 @@ providers: {}
 		{
 			name: "Test operator config, with inactivityTimeoutSeconds set",
 			args: args{
-				operatorConfig:         &operatorv1.Console{},
-				consoleConfig:          &configv1.Console{},
-				managedConfig:          &corev1.ConfigMap{},
-				monitoringSharedConfig: &corev1.ConfigMap{},
+				operatorConfig: &operatorv1.Console{},
+				consoleConfig:  &configv1.Console{},
+				managedConfig:  &corev1.ConfigMap{},
 				infrastructureConfig: &configv1.Infrastructure{
 					Status: configv1.InfrastructureStatus{
 						APIServerURL: mockAPIServer,
@@ -599,10 +527,9 @@ providers: {}
 		{
 			name: "Test operator config, with enabledPlugins set",
 			args: args{
-				operatorConfig:         &operatorv1.Console{},
-				consoleConfig:          &configv1.Console{},
-				managedConfig:          &corev1.ConfigMap{},
-				monitoringSharedConfig: &corev1.ConfigMap{},
+				operatorConfig: &operatorv1.Console{},
+				consoleConfig:  &configv1.Console{},
+				managedConfig:  &corev1.ConfigMap{},
 				infrastructureConfig: &configv1.Infrastructure{
 					Status: configv1.InfrastructureStatus{
 						APIServerURL: mockAPIServer,
@@ -661,7 +588,6 @@ plugins:
 				tt.args.operatorConfig,
 				tt.args.consoleConfig,
 				tt.args.managedConfig,
-				tt.args.monitoringSharedConfig,
 				tt.args.infrastructureConfig,
 				tt.args.rt,
 				tt.args.useDefaultCAFile,

--- a/pkg/console/subresource/consoleserver/config_builder.go
+++ b/pkg/console/subresource/consoleserver/config_builder.go
@@ -1,12 +1,10 @@
 package consoleserver
 
 import (
-	corev1 "k8s.io/api/core/v1"
-
 	operatorv1 "github.com/openshift/api/operator/v1"
 	"github.com/openshift/console-operator/pkg/api"
 	"github.com/openshift/console-operator/pkg/console/subresource/util"
-	yaml "gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v2"
 	"k8s.io/klog/v2"
 )
 
@@ -44,7 +42,6 @@ type ConsoleServerCLIConfigBuilder struct {
 	addPage                    operatorv1.AddPage
 	customLogoFile             string
 	CAFile                     string
-	monitoring                 map[string]string
 	customHostnameRedirectPort int
 	inactivityTimeoutSeconds   int
 	pluginsList                map[string]string
@@ -119,13 +116,6 @@ func (b *ConsoleServerCLIConfigBuilder) DefaultIngressCert(useDefaultDefaultIngr
 	return b
 }
 
-func (b *ConsoleServerCLIConfigBuilder) Monitoring(monitoringConfig *corev1.ConfigMap) *ConsoleServerCLIConfigBuilder {
-	if monitoringConfig != nil {
-		b.monitoring = monitoringConfig.Data
-	}
-	return b
-}
-
 func (b *ConsoleServerCLIConfigBuilder) InactivityTimeout(timeout int) *ConsoleServerCLIConfigBuilder {
 	b.inactivityTimeoutSeconds = timeout
 	return b
@@ -138,15 +128,14 @@ func (b *ConsoleServerCLIConfigBuilder) Plugins(plugins map[string]string) *Cons
 
 func (b *ConsoleServerCLIConfigBuilder) Config() Config {
 	return Config{
-		Kind:           "ConsoleConfig",
-		APIVersion:     "console.openshift.io/v1",
-		Auth:           b.auth(),
-		ClusterInfo:    b.clusterInfo(),
-		Customization:  b.customization(),
-		ServingInfo:    b.servingInfo(),
-		Providers:      b.providers(),
-		MonitoringInfo: b.monitoringInfo(),
-		Plugins:        b.plugins(),
+		Kind:          "ConsoleConfig",
+		APIVersion:    "console.openshift.io/v1",
+		Auth:          b.auth(),
+		ClusterInfo:   b.clusterInfo(),
+		Customization: b.customization(),
+		ServingInfo:   b.servingInfo(),
+		Providers:     b.providers(),
+		Plugins:       b.plugins(),
 	}
 }
 
@@ -184,34 +173,6 @@ func (b *ConsoleServerCLIConfigBuilder) clusterInfo() ClusterInfo {
 	}
 	if len(b.host) > 0 {
 		conf.ConsoleBaseAddress = util.HTTPS(b.host)
-	}
-	return conf
-}
-
-func (b *ConsoleServerCLIConfigBuilder) monitoringInfo() MonitoringInfo {
-	conf := MonitoringInfo{}
-	if len(b.monitoring) > 0 {
-		var monitoringURLs MonitoringInfo
-		urls, err := yaml.Marshal(b.monitoring)
-		if err != nil {
-			return conf
-		}
-		err = yaml.Unmarshal(urls, &monitoringURLs)
-		if err != nil {
-			return conf
-		}
-		if len(monitoringURLs.AlertmanagerPublicURL) > 0 {
-			conf.AlertmanagerPublicURL = monitoringURLs.AlertmanagerPublicURL
-		}
-		if len(monitoringURLs.GrafanaPublicURL) > 0 {
-			conf.GrafanaPublicURL = monitoringURLs.GrafanaPublicURL
-		}
-		if len(monitoringURLs.PrometheusPublicURL) > 0 {
-			conf.PrometheusPublicURL = monitoringURLs.PrometheusPublicURL
-		}
-		if len(monitoringURLs.ThanosPublicURL) > 0 {
-			conf.ThanosPublicURL = monitoringURLs.ThanosPublicURL
-		}
 	}
 	return conf
 }

--- a/pkg/console/subresource/consoleserver/config_builder_test.go
+++ b/pkg/console/subresource/consoleserver/config_builder_test.go
@@ -4,12 +4,9 @@ import (
 	"strconv"
 	"testing"
 
-	v1 "github.com/openshift/api/operator/v1"
-	corev1 "k8s.io/api/core/v1"
-
-	"github.com/openshift/console-operator/pkg/api"
-
 	"github.com/go-test/deep"
+	v1 "github.com/openshift/api/operator/v1"
+	"github.com/openshift/console-operator/pkg/api"
 )
 
 // Tests that the builder will return a correctly structured
@@ -86,14 +83,6 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 					APIServerURL("https://foobar.com/api").
 					Host("https://foobar.com/host").
 					LogoutURL("https://foobar.com/logout").
-					Monitoring(&corev1.ConfigMap{
-						Data: map[string]string{
-							"alertmanagerPublicURL": "https://alertmanager.url.com",
-							"grafanaPublicURL":      "https://grafana.url.com",
-							"prometheusPublicURL":   "https://prometheus.url.com",
-							"thanosPublicURL":       "https://thanos.url.com",
-						},
-					}).
 					DefaultIngressCert(false).
 					Config()
 			},
@@ -109,12 +98,6 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 					ConsoleBasePath:    "",
 					ConsoleBaseAddress: "https://foobar.com/host",
 					MasterPublicURL:    "https://foobar.com/api",
-				},
-				MonitoringInfo: MonitoringInfo{
-					AlertmanagerPublicURL: "https://alertmanager.url.com",
-					GrafanaPublicURL:      "https://grafana.url.com",
-					PrometheusPublicURL:   "https://prometheus.url.com",
-					ThanosPublicURL:       "https://thanos.url.com",
 				},
 				Auth: Auth{
 					ClientID:            api.OpenShiftConsoleName,
@@ -474,48 +457,6 @@ providers: {}
 `,
 		},
 		{
-			name: "Config builder should handle monitoring and info",
-			input: func() ([]byte, error) {
-				b := &ConsoleServerCLIConfigBuilder{}
-				return b.
-					APIServerURL("https://foobar.com/api").
-					Host("https://foobar.com/host").
-					LogoutURL("https://foobar.com/logout").
-					Monitoring(&corev1.ConfigMap{
-						Data: map[string]string{
-							"alertmanagerPublicURL": "https://alertmanager.url.com",
-							"grafanaPublicURL":      "https://grafana.url.com",
-							"prometheusPublicURL":   "https://prometheus.url.com",
-							"thanosPublicURL":       "https://thanos.url.com",
-						},
-					}).
-					DefaultIngressCert(false).
-					ConfigYAML()
-			},
-			output: `apiVersion: console.openshift.io/v1
-kind: ConsoleConfig
-servingInfo:
-  bindAddress: https://[::]:8443
-  certFile: /var/serving-cert/tls.crt
-  keyFile: /var/serving-cert/tls.key
-clusterInfo:
-  consoleBaseAddress: https://foobar.com/host
-  masterPublicURL: https://foobar.com/api
-auth:
-  clientID: console
-  clientSecretFile: /var/oauth-config/clientSecret
-  oauthEndpointCAFile: /var/default-ingress-cert/ca-bundle.crt
-  logoutRedirect: https://foobar.com/logout
-customization: {}
-providers: {}
-monitoringInfo:
-  alertmanagerPublicURL: https://alertmanager.url.com
-  grafanaPublicURL: https://grafana.url.com
-  prometheusPublicURL: https://prometheus.url.com
-  thanosPublicURL: https://thanos.url.com
-`,
-		},
-		{
 			name: "Config builder should handle StatuspageID",
 			input: func() ([]byte, error) {
 				b := &ConsoleServerCLIConfigBuilder{}
@@ -691,14 +632,6 @@ providers: {}
 						"plugin1": "plugin1_url",
 						"plugin2": "plugin2_url",
 					}).
-					Monitoring(&corev1.ConfigMap{
-						Data: map[string]string{
-							"alertmanagerPublicURL": "https://alertmanager.url.com",
-							"grafanaPublicURL":      "https://grafana.url.com",
-							"prometheusPublicURL":   "https://prometheus.url.com",
-							"thanosPublicURL":       "https://thanos.url.com",
-						},
-					}).
 					DefaultIngressCert(true)
 				return b.ConfigYAML()
 			},
@@ -721,11 +654,6 @@ customization:
   documentationBaseURL: https://foobar.com/docs
 providers:
   statuspageID: status-12345
-monitoringInfo:
-  alertmanagerPublicURL: https://alertmanager.url.com
-  grafanaPublicURL: https://grafana.url.com
-  prometheusPublicURL: https://prometheus.url.com
-  thanosPublicURL: https://thanos.url.com
 plugins:
   plugin1: plugin1_url
   plugin2: plugin2_url

--- a/pkg/console/subresource/consoleserver/types.go
+++ b/pkg/console/subresource/consoleserver/types.go
@@ -11,15 +11,14 @@ package consoleserver
 
 // Config is the top-level console server cli configuration.
 type Config struct {
-	APIVersion     string `yaml:"apiVersion"`
-	Kind           string `yaml:"kind"`
-	ServingInfo    `yaml:"servingInfo"`
-	ClusterInfo    `yaml:"clusterInfo"`
-	Auth           `yaml:"auth"`
-	Customization  `yaml:"customization"`
-	Providers      `yaml:"providers"`
-	MonitoringInfo `yaml:"monitoringInfo,omitempty"`
-	Plugins        map[string]string `yaml:"plugins,omitempty"`
+	APIVersion    string `yaml:"apiVersion"`
+	Kind          string `yaml:"kind"`
+	ServingInfo   `yaml:"servingInfo"`
+	ClusterInfo   `yaml:"clusterInfo"`
+	Auth          `yaml:"auth"`
+	Customization `yaml:"customization"`
+	Providers     `yaml:"providers"`
+	Plugins       map[string]string `yaml:"plugins,omitempty"`
 }
 
 // ServingInfo holds configuration for serving HTTP.
@@ -45,14 +44,6 @@ type ClusterInfo struct {
 	ConsoleBaseAddress string `yaml:"consoleBaseAddress,omitempty"`
 	ConsoleBasePath    string `yaml:"consoleBasePath,omitempty"`
 	MasterPublicURL    string `yaml:"masterPublicURL,omitempty"`
-}
-
-// Monitoring holds URLs for monitoring related services
-type MonitoringInfo struct {
-	AlertmanagerPublicURL string `yaml:"alertmanagerPublicURL,omitempty"`
-	GrafanaPublicURL      string `yaml:"grafanaPublicURL,omitempty"`
-	PrometheusPublicURL   string `yaml:"prometheusPublicURL,omitempty"`
-	ThanosPublicURL       string `yaml:"thanosPublicURL,omitempty"`
 }
 
 // Auth holds configuration for authenticating with OpenShift. The auth method is assumed to be "openshift".


### PR DESCRIPTION
This is related to [CMO-#1223](https://github.com/openshift/cluster-monitoring-operator/pull/1223) and [Console-#9276](https://github.com/openshift/console/pull/9276)

See the following epic for context https://issues.redhat.com/browse/MON-1591

cc @simonpasquier, @kyoto - obviously I'm not too familiar with the console repo's but I've gone through it and cannot see any other touch points. Any suggestions on the best way to test these three PR's e2e?