### PR TITLE
Rename Monitoring tab to Observe tab in monitoring sampleapp quickstart

### DIFF
--- a/quickstarts/monitor-sampleapp-quickstart.yaml
+++ b/quickstarts/monitor-sampleapp-quickstart.yaml
@@ -28,9 +28,9 @@ spec:
 
         1. Click on the **nodejs-sample** deployment to view its details.
         
-        1. Click on the **Monitoring** tab in the side panel.
+        1. Click on the **Observe** tab in the side panel.
 
-        You can see context sensitive metrics and alerts in the **Monitoring** tab.
+        You can see context sensitive metrics and alerts in the **Observe** tab.
       review:
         instructions: |-
           #### To verify you can view the monitoring information:
@@ -59,7 +59,7 @@ spec:
     - title: View custom metrics
       description: |-
         ### To view custom metrics:
-        1. Click on the **Metrics** tab of the **Monitoring** page.
+        1. Click on the **Metrics** tab of the **Observe** page.
         2. Click the **Select Query** drop-down list to see the available queries.
         3. Click on **Filesystem Usage** from the list to run the query.
       review:


### PR DESCRIPTION
**Fixes:**
https://issues.redhat.com/browse/ODC-6088

**Description:**
This PR Rename `Monitoring` tab to `Observe` tab in monitoring sampleapp quickstart. 

