### PR TITLE
Bug 198053 - Add delete annotation to console link manifests

### DIFF
--- a/manifests/09-console-link-openshift-blog.yaml
+++ b/manifests/09-console-link-openshift-blog.yaml
@@ -3,10 +3,11 @@ kind: ConsoleLink
 metadata:
   name: openshift-blog
   annotations:
+    release.openshift.io/delete: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
 spec:
-  href: 'https://blog.openshift.com'
+  href: "https://blog.openshift.com"
   location: HelpMenu
   text: OpenShift Blog

--- a/manifests/09-console-link-openshift-learning-portal.yaml
+++ b/manifests/09-console-link-openshift-learning-portal.yaml
@@ -3,10 +3,11 @@ kind: ConsoleLink
 metadata:
   name: openshift-learning-portal
   annotations:
+    release.openshift.io/delete: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
 spec:
-  href: 'https://learn.openshift.com/?ref=webconsole'
+  href: "https://learn.openshift.com/?ref=webconsole"
   location: HelpMenu
   text: Learning Portal


### PR DESCRIPTION
Addresses [Bug 1980531](https://bugzilla.redhat.com/show_bug.cgi?id=1980531)

In order for help links in the console they are being created directly in the console code and should not be sent from the operator. See https://github.com/openshift/console/pull/9495 for console changes.

Instead of removing YAML manifests, the `release.openshift.io/delete: "true"` annotation was added.

NOTE: This should not be merged until Addresses [Bug 1980531](https://bugzilla.redhat.com/show_bug.cgi?id=1980531) is merged.

Work and investigation was also performed by @florkbr and @jhadvig