### PR TITLE
Bug 1988401: Add console RBAC for listing operators

### DIFF
--- a/manifests/03-rbac-role-cluster.yaml
+++ b/manifests/03-rbac-role-cluster.yaml
@@ -113,6 +113,13 @@ rules:
   - web-terminal
   verbs:
   - get
+- apiGroups:
+  - operators.coreos.com
+  resources:
+  - operators
+  verbs:
+  - get
+  - list
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
We need to give `console` SA additional rights for listing operators, check https://github.com/openshift/console/pull/9142#issuecomment-889340172

Story: https://issues.redhat.com/browse/CONSOLE-2458

/assign @spadgett 