### PR TITLE
CONSOLE-2837: Enable plugins by default when migrating from static to dynamic

### DIFF
--- a/pkg/console/controllers/plugins/controller.go
+++ b/pkg/console/controllers/plugins/controller.go
@@ -26,7 +26,7 @@ import (
 )
 
 const (
-	migratedPluginsAnnotation = "console.openshift.io/migrated-plugins"
+	MigratedPluginsAnnotation = "console.openshift.io/migrated-plugins"
 )
 
 type PluginsMigrationController struct {
@@ -125,7 +125,7 @@ func (c *PluginsMigrationController) GetAvailablePluginsName() ([]string, error)
 }
 
 func GetMigratedPlugins(operatorConfig *operatorv1.Console) ([]string, error) {
-	migratedPluginsAnnotation, migratedPluginsAnnotationExists := operatorConfig.Annotations[migratedPluginsAnnotation]
+	migratedPluginsAnnotation, migratedPluginsAnnotationExists := operatorConfig.Annotations[MigratedPluginsAnnotation]
 	migratedPluginsArray := []string{}
 	if migratedPluginsAnnotationExists {
 		err := json.Unmarshal([]byte(migratedPluginsAnnotation), &migratedPluginsArray)
@@ -170,7 +170,7 @@ func (c *PluginsMigrationController) UpdateOperatorConfig(
 	if err != nil {
 		return err
 	}
-	updatedOperatorConfig.Annotations[migratedPluginsAnnotation] = string(marshaledPluginsToAnnotate)
+	updatedOperatorConfig.Annotations[MigratedPluginsAnnotation] = string(marshaledPluginsToAnnotate)
 
 	_, err = c.operatorConfigClient.Update(ctx, updatedOperatorConfig, metav1.UpdateOptions{})
 	return err
@@ -183,7 +183,7 @@ func (c *PluginsMigrationController) removeMigratedPlugins(ctx context.Context, 
 	if err != nil {
 		return err
 	}
-	updatedOperatorConfig.Annotations[migratedPluginsAnnotation] = string(marshaledPluginsToAnnotate)
+	updatedOperatorConfig.Annotations[MigratedPluginsAnnotation] = string(marshaledPluginsToAnnotate)
 	_, err = c.operatorConfigClient.Update(ctx, updatedOperatorConfig, metav1.UpdateOptions{})
 	return nil
 }

--- a/pkg/console/controllers/plugins/controller.go
+++ b/pkg/console/controllers/plugins/controller.go
@@ -1,0 +1,189 @@
+package plugins
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	// k8s
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/klog/v2"
+
+	// openshift
+	operatorv1 "github.com/openshift/api/operator/v1"
+	consoleinformersv1alpha1 "github.com/openshift/client-go/console/informers/externalversions/console/v1alpha1"
+	listerv1alpha1 "github.com/openshift/client-go/console/listers/console/v1alpha1"
+	operatorclientv1 "github.com/openshift/client-go/operator/clientset/versioned/typed/operator/v1"
+	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+
+	// console-operator
+	"github.com/openshift/console-operator/pkg/api"
+	"github.com/openshift/console-operator/pkg/console/controllers/util"
+	"github.com/openshift/console-operator/pkg/console/status"
+)
+
+const (
+	migratedPluginsAnnotation = "console.openshift.io/migrated-plugins"
+)
+
+type PluginsMigrationController struct {
+	// configs
+	operatorClient       v1helpers.OperatorClient
+	operatorConfigClient operatorclientv1.ConsoleInterface
+	// lister
+	consolePluginLister   listerv1alpha1.ConsolePluginLister
+	consolePluginInformer consoleinformersv1alpha1.ConsolePluginInformer
+}
+
+func NewPluginsMigrationController(
+	// operator
+	operatorClient v1helpers.OperatorClient,
+	operatorConfigClient operatorclientv1.ConsoleInterface,
+	// operatorConfigInformer operatorinformerv1.ConsoleInformer,
+	// plugins
+	consolePluginInformer consoleinformersv1alpha1.ConsolePluginInformer,
+	// events
+	recorder events.Recorder,
+) factory.Controller {
+
+	c := &PluginsMigrationController{
+		// configs
+		operatorClient:       operatorClient,
+		operatorConfigClient: operatorConfigClient,
+		// plugins
+		consolePluginLister: consolePluginInformer.Lister(),
+	}
+
+	return factory.New().
+		WithInformers(
+			consolePluginInformer.Informer(),
+		).WithSync(c.Sync).
+		ToController("PluginsMigrationController", recorder.WithComponentSuffix("plugins-migration-controller"))
+}
+
+func (c *PluginsMigrationController) Sync(ctx context.Context, controllerContext factory.SyncContext) error {
+
+	operatorConfig, err := c.operatorConfigClient.Get(ctx, api.ConfigResourceName, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	switch operatorConfig.Spec.ManagementState {
+	case operatorv1.Managed:
+		klog.V(4).Infof("console-operator is in a managed state: migrating available plugins")
+	case operatorv1.Unmanaged:
+		klog.V(4).Infof("console-operator is in an unmanaged state: skipping available plugins migration")
+		return nil
+	case operatorv1.Removed:
+		klog.V(4).Infof("console-operator is in a removed state: removing migrated plugins")
+		return c.removeMigratedPlugins(ctx, operatorConfig)
+	default:
+		return fmt.Errorf("unknown state: %v", operatorConfig.Spec.ManagementState)
+	}
+
+	statusHandler := status.NewStatusHandler(c.operatorClient)
+
+	availablePluginsName, err := c.GetAvailablePluginsName()
+	statusHandler.AddConditions(status.HandleProgressingOrDegraded("AvailablePluginMigration", "FailedAvailablePluginsGet", err))
+	if err != nil {
+		return statusHandler.FlushAndReturn(err)
+	}
+	migratedPluginsArray, err := GetMigratedPlugins(operatorConfig)
+	statusHandler.AddConditions(status.HandleProgressingOrDegraded("AvailablePluginMigration", "FailedMigratedPluginsGet", err))
+	if err != nil {
+		return statusHandler.FlushAndReturn(err)
+	}
+
+	pluginsToEnable := GetPluginsToEnable(operatorConfig, availablePluginsName, migratedPluginsArray)
+
+	if len(pluginsToEnable) == 0 {
+		return statusHandler.FlushAndReturn(nil)
+	}
+
+	err = c.UpdateOperatorConfig(ctx, operatorConfig, pluginsToEnable, migratedPluginsArray)
+	statusHandler.AddConditions(status.HandleProgressingOrDegraded("AvailablePluginMigration", "FailedOperatorConfigUpdate", err))
+	if err != nil {
+		return statusHandler.FlushAndReturn(err)
+	}
+
+	return statusHandler.FlushAndReturn(err)
+}
+
+func (c *PluginsMigrationController) GetAvailablePluginsName() ([]string, error) {
+	availablePlugins, err := c.consolePluginLister.List(labels.Everything())
+	if err != nil {
+		return nil, err
+	}
+	var availablePluginsName []string
+	for _, plugin := range availablePlugins {
+		availablePluginsName = append(availablePluginsName, plugin.Name)
+	}
+	return availablePluginsName, nil
+}
+
+func GetMigratedPlugins(operatorConfig *operatorv1.Console) ([]string, error) {
+	migratedPluginsAnnotation, migratedPluginsAnnotationExists := operatorConfig.Annotations[migratedPluginsAnnotation]
+	migratedPluginsArray := []string{}
+	if migratedPluginsAnnotationExists {
+		err := json.Unmarshal([]byte(migratedPluginsAnnotation), &migratedPluginsArray)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return migratedPluginsArray, nil
+}
+
+func GetPluginsToEnable(
+	operatorConfig *operatorv1.Console,
+	availablePluginsName []string,
+	migratedPluginsArray []string,
+) []string {
+	var pluginsToEnable []string
+	for _, availablePluginName := range availablePluginsName {
+		if !util.ContainsString(migratedPluginsArray, availablePluginName) && !util.ContainsString(operatorConfig.Spec.Plugins, availablePluginName) {
+			pluginsToEnable = append(pluginsToEnable, availablePluginName)
+		}
+	}
+
+	return pluginsToEnable
+}
+
+func (c *PluginsMigrationController) UpdateOperatorConfig(
+	ctx context.Context,
+	operatorConfig *operatorv1.Console,
+	pluginsToEnable []string,
+	migratedPluginsArray []string,
+) error {
+	if len(pluginsToEnable) == 0 {
+		return nil
+	}
+
+	updatedOperatorConfig := operatorConfig.DeepCopy()
+	updatedOperatorConfig.Spec.Plugins = append(updatedOperatorConfig.Spec.Plugins, pluginsToEnable...)
+
+	pluginsToAnnotate := append(migratedPluginsArray, pluginsToEnable...)
+	marshaledPluginsToAnnotate, err := json.Marshal(pluginsToAnnotate)
+	if err != nil {
+		return err
+	}
+	updatedOperatorConfig.Annotations[migratedPluginsAnnotation] = string(marshaledPluginsToAnnotate)
+
+	_, err = c.operatorConfigClient.Update(ctx, updatedOperatorConfig, metav1.UpdateOptions{})
+	return err
+}
+
+func (c *PluginsMigrationController) removeMigratedPlugins(ctx context.Context, operatorConfig *operatorv1.Console) error {
+	updatedOperatorConfig := operatorConfig.DeepCopy()
+	updatedOperatorConfig.Spec.Plugins = []string{}
+	marshaledPluginsToAnnotate, err := json.Marshal([]string{})
+	if err != nil {
+		return err
+	}
+	updatedOperatorConfig.Annotations[migratedPluginsAnnotation] = string(marshaledPluginsToAnnotate)
+	_, err = c.operatorConfigClient.Update(ctx, updatedOperatorConfig, metav1.UpdateOptions{})
+	return nil
+}

--- a/pkg/console/controllers/util/util.go
+++ b/pkg/console/controllers/util/util.go
@@ -17,3 +17,13 @@ func NamesFilter(names ...string) factory.EventFilterFunc {
 		return false
 	}
 }
+
+func ContainsString(stringArray []string, str string) bool {
+	for _, v := range stringArray {
+		if v == str {
+			return true
+		}
+	}
+
+	return false
+}

--- a/pkg/console/starter/starter.go
+++ b/pkg/console/starter/starter.go
@@ -21,6 +21,7 @@ import (
 	"github.com/openshift/console-operator/pkg/console/controllers/clidownloads"
 	"github.com/openshift/console-operator/pkg/console/controllers/downloadsdeployment"
 	"github.com/openshift/console-operator/pkg/console/controllers/healthcheck"
+	"github.com/openshift/console-operator/pkg/console/controllers/plugins"
 	"github.com/openshift/console-operator/pkg/console/controllers/route"
 	"github.com/openshift/console-operator/pkg/console/controllers/service"
 	"github.com/openshift/console-operator/pkg/console/operatorclient"
@@ -309,6 +310,15 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 		recorder,
 	)
 
+	pluginMigrationController := plugins.NewPluginsMigrationController(
+		// clients
+		operatorClient,
+		operatorConfigClient.OperatorV1().Consoles(),
+		// plugins
+		consoleInformers.Console().V1alpha1().ConsolePlugins(),
+		recorder,
+	)
+
 	versionRecorder := status.NewVersionGetter()
 	versionRecorder.SetVersion("operator", os.Getenv("RELEASE_VERSION"))
 
@@ -385,6 +395,7 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 		consoleRouteController,
 		downloadsServiceController,
 		downloadsRouteController,
+		pluginMigrationController,
 		consoleOperator,
 		cliDownloadsController,
 		downloadsDeploymentController,

--- a/test/e2e/plugins_test.go
+++ b/test/e2e/plugins_test.go
@@ -2,6 +2,7 @@ package e2e
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"testing"
 	"time"
@@ -15,13 +16,17 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/retry"
 
+	"github.com/openshift/client-go/console/clientset/versioned/typed/console/v1alpha1"
 	consoleapi "github.com/openshift/console-operator/pkg/api"
+	"github.com/openshift/console-operator/pkg/console/controllers/plugins"
 	"github.com/openshift/console-operator/pkg/console/subresource/consoleserver"
 	"github.com/openshift/console-operator/test/e2e/framework"
 )
 
 const (
 	availablePluginName   = "test-plugin"
+	testPluginName1       = availablePluginName
+	testPluginaName2      = "test-plugin-2"
 	unavailablePluginName = "missing-test-plugin"
 )
 
@@ -45,29 +50,12 @@ func TestAddPlugins(t *testing.T) {
 	client, _ := setupPluginsTestCase(t)
 	defer cleanupPluginsTestCase(t, client)
 
-	plugin := &consolev1alpha.ConsolePlugin{
-		ObjectMeta: v1.ObjectMeta{
-			Name: availablePluginName,
-		},
-		Spec: consolev1alpha.ConsolePluginSpec{
-			DisplayName: "TestPlugin",
-			Service: consolev1alpha.ConsolePluginService{
-				Name:      "test-plugin-service-name",
-				Namespace: "test-plugin-service-namespace",
-				Port:      8443,
-				BasePath:  "/manifest",
-			},
-		},
-	}
+	createConsolePlugins(t, client.ConsolePlugin, []string{availablePluginName})
 
-	_, err := client.ConsolePlugin.Create(context.TODO(), plugin, metav1.CreateOptions{})
-	if err != nil {
-		t.Fatalf("could not create ConsolePlugin custom resource: %s", err)
-	}
 	enabledPlugins := []string{availablePluginName, unavailablePluginName}
 	setOperatorConfigPlugins(t, client, enabledPlugins)
 
-	err = wait.Poll(1*time.Second, pollTimeout, func() (stop bool, err error) {
+	err := wait.Poll(1*time.Second, pollTimeout, func() (stop bool, err error) {
 		currentPlugins = getConsolePluginsField(t, client)
 		if reflect.DeepEqual(expectedPlugins, currentPlugins) {
 			return true, nil
@@ -76,6 +64,53 @@ func TestAddPlugins(t *testing.T) {
 	})
 	if err != nil {
 		t.Errorf("error: expected '%v' plugins, got '%v': '%v'", expectedPlugins, currentPlugins, err)
+	}
+}
+
+func TestPluginsMigration(t *testing.T) {
+	expectedMigratedPluginsAnnotation := "['test-plugin','test-plugin-2']"
+	migratedPluginsAnnotation := ""
+	client, _ := setupPluginsTestCase(t)
+	defer cleanupPluginsTestCase(t, client)
+
+	createConsolePlugins(t, client.ConsolePlugin, []string{testPluginName1, testPluginName1})
+
+	err := wait.Poll(1*time.Second, pollTimeout, func() (stop bool, err error) {
+		operatorConfig, err := client.Operator.Consoles().Get(context.TODO(), consoleapi.ConfigResourceName, metav1.GetOptions{})
+		migratedPluginsAnnotation, migratedPluginsAnnotationExists := operatorConfig.Annotations[plugins.MigratedPluginsAnnotation]
+		if !migratedPluginsAnnotationExists {
+			return false, fmt.Errorf("%q annotation is missing on the console-operator config", plugins.MigratedPluginsAnnotation)
+		}
+		if reflect.DeepEqual(expectedMigratedPluginsAnnotation, migratedPluginsAnnotation) {
+			return true, nil
+		}
+		return false, nil
+	})
+	if err != nil {
+		t.Errorf("error: expected '%v' plugins, got '%v': '%v'", expectedMigratedPluginsAnnotation, migratedPluginsAnnotation, err)
+	}
+}
+
+func createConsolePlugins(t *testing.T, client v1alpha1.ConsolePluginInterface, pluginNames []string) {
+	for _, pluginName := range pluginNames {
+		plugin := &consolev1alpha.ConsolePlugin{
+			ObjectMeta: v1.ObjectMeta{
+				Name: pluginName,
+			},
+			Spec: consolev1alpha.ConsolePluginSpec{
+				DisplayName: "TestPlugin",
+				Service: consolev1alpha.ConsolePluginService{
+					Name:      "test-plugin-service-name",
+					Namespace: "test-plugin-service-namespace",
+					Port:      8443,
+					BasePath:  "/manifest",
+				},
+			},
+		}
+		_, err := client.Create(context.TODO(), plugin, metav1.CreateOptions{})
+		if err != nil {
+			t.Fatalf("could not create ConsolePlugin custom resource: %s", err)
+		}
 	}
 }
 


### PR DESCRIPTION
Adding functionality for enable plugins by default when migrating from static to dynamic.
When operator is in `Managed` state it will check for available `ConsolePlugins` CRs on the cluster. if any of the available ConsolePlugin CR's name is not present in the console-operator configs `console.openshift.io/migrated-plugins` annotation array, it will be enabled by the operator and added to the `console.openshift.io/migrated-plugins` annotation array.
When the operator is in `Removed` state it will remove all the ConsolePlugins from its `Spec.Plugins` field and the `console.openshift.io/migrated-plugins` annotation will be set to empty array, so when the operator is back to the `Managed` state all the available ConsolePlugins will be enabled.

/assign @TheRealJon @spadgett   