### PR TITLE
Bug 1994443: console-operator should report Available=true when at least available replica exists

### DIFF
--- a/pkg/console/subresource/deployment/deployment.go
+++ b/pkg/console/subresource/deployment/deployment.go
@@ -524,35 +524,18 @@ func downloadsReadinessProbe() *corev1.Probe {
 	return probe
 }
 
-// for the purpose of availability, ready is when we have at least
-// one ready replica
-func IsReady(deployment *appsv1.Deployment) bool {
-	avail := deployment.Status.ReadyReplicas >= 1
+func IsAvailable(deployment *appsv1.Deployment) bool {
+	avail := deployment.Status.AvailableReplicas > 0
 	if !avail {
-		klog.V(4).Infof("deployment is not available, expected replicas: %v, ready replicas: %v", deployment.Spec.Replicas, deployment.Status.ReadyReplicas)
+		klog.V(4).Infof("deployment is not available, expected replicas: %v, available replicas: %v, total replicas: %v", deployment.Spec.Replicas, deployment.Status.AvailableReplicas, deployment.Status.Replicas)
 	}
 	return avail
 }
 
-func IsReadyAndUpdated(deployment *appsv1.Deployment) bool {
-	ready := deployment.Status.Replicas == deployment.Status.ReadyReplicas
-	updated := deployment.Status.Replicas == deployment.Status.UpdatedReplicas
-	if !ready {
-		klog.V(4).Infof("deployment is not ready, expected replicas: %v, ready replicas: %v, total replicas: %v", deployment.Spec.Replicas, deployment.Status.ReadyReplicas, deployment.Status.Replicas)
-	}
-	if !updated {
-		klog.V(4).Infof("deployment is not updated, expected replicas: %v, updated replicas: %v, total replicas: %v", deployment.Spec.Replicas, deployment.Status.UpdatedReplicas, deployment.Status.Replicas)
-	}
-	return ready && updated
-}
-
 func IsAvailableAndUpdated(deployment *appsv1.Deployment) bool {
-	available := deployment.Status.AvailableReplicas > 0
+	available := IsAvailable(deployment)
 	currentGen := deployment.Status.ObservedGeneration >= deployment.Generation
 	updated := deployment.Status.UpdatedReplicas == deployment.Status.Replicas
-	if !available {
-		klog.V(4).Infof("deployment is not available, expected replicas: %v, available replicas: %v, total replicas: %v", deployment.Spec.Replicas, deployment.Status.AvailableReplicas, deployment.Status.Replicas)
-	}
 	if !currentGen {
 		klog.V(4).Infof("deployment is not current, observing generation: %v, generation: %v", deployment.Status.ObservedGeneration, deployment.Generation)
 	}

--- a/pkg/console/subresource/deployment/deployment_test.go
+++ b/pkg/console/subresource/deployment/deployment_test.go
@@ -1011,7 +1011,7 @@ func Test_consoleVolumeMounts(t *testing.T) {
 	}
 }
 
-func TestIsReady(t *testing.T) {
+func TestIsAvailable(t *testing.T) {
 	type args struct {
 		deployment *appsv1.Deployment
 	}
@@ -1021,31 +1021,31 @@ func TestIsReady(t *testing.T) {
 		want bool
 	}{
 		{
-			name: "Test IsReady(): Deployment has one ready replica",
+			name: "Test IsAvailable(): Deployment has one ready replica",
 			args: args{
 				deployment: &appsv1.Deployment{
 					Status: appsv1.DeploymentStatus{
-						ReadyReplicas: 1,
+						AvailableReplicas: 1,
 					},
 				},
 			},
 			want: true,
 		}, {
-			name: "Test IsReady(): Deployment has multiple ready replicas",
+			name: "Test IsAvailable(): Deployment has multiple ready replicas",
 			args: args{
 				deployment: &appsv1.Deployment{
 					Status: appsv1.DeploymentStatus{
-						ReadyReplicas: 5,
+						AvailableReplicas: 5,
 					},
 				},
 			},
 			want: true,
 		}, {
-			name: "Test IsReady(): Deployment has no ready replicas",
+			name: "Test IsAvailable(): Deployment has no ready replicas",
 			args: args{
 				deployment: &appsv1.Deployment{
 					Status: appsv1.DeploymentStatus{
-						ReadyReplicas: 0,
+						AvailableReplicas: 0,
 					},
 				},
 			},
@@ -1054,7 +1054,7 @@ func TestIsReady(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := IsReady(tt.args.deployment); got != tt.want {
+			if got := IsAvailable(tt.args.deployment); got != tt.want {
 				t.Errorf("IsReady() = \n%v\n want \n%v", got, tt.want)
 			}
 		})


### PR DESCRIPTION
When setting console-operator Available condition it should be enough to check if there is at least one available replica.

/assign @spadgett 
