### PR TITLE
Bug 1989055: Revoke usage of Default Ingress Cert for console route healthcheck

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -15,6 +15,7 @@ const (
 	OpenShiftConsoleConfigMapName           = "console-config"
 	OpenShiftConsolePublicConfigMapName     = "console-public"
 	ServiceCAConfigMapName                  = "service-ca"
+	DefaultIngressCertConfigMapName         = "default-ingress-cert"
 	OAuthServingCertConfigMapName           = "oauth-serving-cert"
 	OpenShiftConsoleDeploymentName          = OpenShiftConsoleName
 	OpenShiftConsoleServiceName             = OpenShiftConsoleName

--- a/pkg/console/controllers/healthcheck/controller.go
+++ b/pkg/console/controllers/healthcheck/controller.go
@@ -71,7 +71,7 @@ func NewHealthCheckController(
 
 	return factory.New().
 		WithFilteredEventsInformers( // service
-			util.NamesFilter(api.TrustedCAConfigMapName, api.OAuthServingCertConfigMapName),
+			util.NamesFilter(api.TrustedCAConfigMapName, api.DefaultIngressCertConfigMapName),
 			configMapInformer.Informer(),
 		).WithFilteredEventsInformers( // route
 		util.NamesFilter(api.OpenShiftConsoleRouteName, api.OpenshiftConsoleCustomRouteName),
@@ -164,7 +164,7 @@ func (c *HealthCheckController) getCA(ctx context.Context, tls *routev1.TLSConfi
 		}
 	}
 
-	for _, cmName := range []string{api.TrustedCAConfigMapName, api.OAuthServingCertConfigMapName} {
+	for _, cmName := range []string{api.TrustedCAConfigMapName, api.DefaultIngressCertConfigMapName} {
 		cm, err := c.configMapClient.ConfigMaps(api.OpenShiftConsoleNamespace).Get(ctx, cmName, metav1.GetOptions{})
 		if err != nil {
 			klog.V(4).Infof("failed to GET configmap %s / %s ", api.OpenShiftConsoleNamespace, cmName)

--- a/pkg/console/starter/starter.go
+++ b/pkg/console/starter/starter.go
@@ -261,10 +261,8 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 		operatorConfigClient.OperatorV1().Consoles(),
 		routesClient.RouteV1(),
 		kubeClient.CoreV1(),
-		kubeClient.CoreV1(),
 		// route
 		operatorConfigInformers.Operator().V1().Consoles(),
-		kubeInformersNamespaced.Core().V1(),                 // `openshift-console` namespace informers
 		kubeInformersConfigNamespaced.Core().V1().Secrets(), // `openshift-config` namespace informers
 		routesInformersNamespaced.Route().V1().Routes(),
 		// events
@@ -283,10 +281,8 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 		operatorConfigClient.OperatorV1().Consoles(),
 		routesClient.RouteV1(),
 		kubeClient.CoreV1(),
-		kubeClient.CoreV1(),
 		// route
 		operatorConfigInformers.Operator().V1().Consoles(),
-		kubeInformersNamespaced.Core().V1(),                 // `openshift-console` namespace informers
 		kubeInformersConfigNamespaced.Core().V1().Secrets(), // `openshift-config` namespace informers
 		routesInformersNamespaced.Route().V1().Routes(),
 		// events
@@ -405,9 +401,20 @@ func startStaticResourceSyncing(resourceSyncer *resourcesynccontroller.ResourceS
 	// sync: 'oauth-serving-cert' configmap
 	// from: 'openshift-config-managed' namespace
 	// to:   'openshift-console' namespace
-	return resourceSyncer.SyncConfigMap(
+	err := resourceSyncer.SyncConfigMap(
 		resourcesynccontroller.ResourceLocation{Name: api.OAuthServingCertConfigMapName, Namespace: api.OpenShiftConsoleNamespace},
 		resourcesynccontroller.ResourceLocation{Name: api.OAuthServingCertConfigMapName, Namespace: api.OpenShiftConfigManagedNamespace},
+	)
+	if err != nil {
+		return err
+	}
+
+	// sync: 'default-ingress-cert' configmap
+	// from: 'openshift-config-managed' namespace
+	// to:   'openshift-console' namespace
+	return resourceSyncer.SyncConfigMap(
+		resourcesynccontroller.ResourceLocation{Name: api.DefaultIngressCertConfigMapName, Namespace: api.OpenShiftConsoleNamespace},
+		resourcesynccontroller.ResourceLocation{Name: api.DefaultIngressCertConfigMapName, Namespace: api.OpenShiftConfigManagedNamespace},
 	)
 }
 


### PR DESCRIPTION
How route health check we need to use `DefaultIngressCert` not the `OAuthServingCertConfigMapName`.
This is related to failing health checks in the https://bugzilla.redhat.com/show_bug.cgi?id=1989055#c7

Also removing dead code from route controller.

/assign @stlaz @spadgett 

@florkbr FYI