### PR TITLE
Bug 2001240: Remove SimpleHTTP 'server' response header value

### DIFF
--- a/pkg/console/subresource/deployment/deployment.go
+++ b/pkg/console/subresource/deployment/deployment.go
@@ -631,7 +631,10 @@ class Thread(threading.Thread):
 		self.start()
 
 	def run(self):
-		httpd = http.server.HTTPServer(addr, http.server.SimpleHTTPRequestHandler, False)
+		server = http.server.SimpleHTTPRequestHandler
+		server.server_version = "OpenShift Downloads Server"
+		server.sys_version = ""
+		httpd = http.server.HTTPServer(addr, server, False)
 
 		# Prevent the HTTP server from re-binding every handler.
 		# https://stackoverflow.com/questions/46210672/


### PR DESCRIPTION
This fix will set the `server` value to `""` since otherwise we would need to override the whole SimpleHTTP module. That would be an overkill due to that fact that we are inlining the server code in the containers spec.

response will look:
<img width="884" alt="Screenshot 2021-09-06 at 16 14 18" src="https://user-images.githubusercontent.com/1668218/132231786-e84c8d28-4753-4f77-987e-bf0114514f11.png">


/assign @spadgett 
@rludva FYI