### PR TITLE
Bug 1999314: Resync all controllers periodically

### DIFF
--- a/pkg/console/controllers/clidownloads/controller.go
+++ b/pkg/console/controllers/clidownloads/controller.go
@@ -4,6 +4,7 @@ import (
 	// standard lib
 	"context"
 	"fmt"
+	"time"
 
 	// kube
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -78,7 +79,7 @@ func NewCLIDownloadsSyncController(
 		routeInformer.Informer(),
 	).WithInformers(
 		consoleCLIDownloadsInformers.Informer(),
-	).WithSync(ctrl.Sync).
+	).ResyncEvery(time.Minute).WithSync(ctrl.Sync).
 		ToController("ConsoleCLIDownloadsController", recorder.WithComponentSuffix("console-cli-downloads-controller"))
 }
 

--- a/pkg/console/controllers/downloadsdeployment/controller.go
+++ b/pkg/console/controllers/downloadsdeployment/controller.go
@@ -3,6 +3,7 @@ package downloadsdeployment
 import (
 	"context"
 	"fmt"
+	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -74,7 +75,7 @@ func NewDownloadsDeploymentSyncController(
 		).WithFilteredEventsInformers( // downloads deployment
 		downloadsNameFilter,
 		deploymentInformer.Informer(),
-	).WithSync(ctrl.Sync).
+	).ResyncEvery(time.Minute).WithSync(ctrl.Sync).
 		ToController("ConsoleDownloadsDeploymentSyncController", recorder.WithComponentSuffix("console-downloads-deployment-controller"))
 }
 

--- a/pkg/console/controllers/healthcheck/controller.go
+++ b/pkg/console/controllers/healthcheck/controller.go
@@ -76,7 +76,7 @@ func NewHealthCheckController(
 		).WithFilteredEventsInformers( // route
 		util.NamesFilter(api.OpenShiftConsoleRouteName, api.OpenshiftConsoleCustomRouteName),
 		routeInformer.Informer(),
-	).ResyncEvery(time.Minute).WithSync(ctrl.Sync).
+	).ResyncEvery(30*time.Second).WithSync(ctrl.Sync).
 		ToController("HealthCheckController", recorder.WithComponentSuffix("health-check-controller"))
 }
 

--- a/pkg/console/controllers/route/controller.go
+++ b/pkg/console/controllers/route/controller.go
@@ -90,7 +90,7 @@ func NewRouteSyncController(
 	).WithFilteredEventsInformers( // route
 		util.NamesFilter(routeName, routesub.GetCustomRouteName(routeName)),
 		routeInformer.Informer(),
-	).WithSync(ctrl.Sync).
+	).ResyncEvery(time.Minute).WithSync(ctrl.Sync).
 		ToController(fmt.Sprintf("%sRouteController", strings.Title(routeName)), recorder.WithComponentSuffix(fmt.Sprintf("%s-route-controller", routeName)))
 }
 

--- a/pkg/console/controllers/service/controller.go
+++ b/pkg/console/controllers/service/controller.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"fmt"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -76,7 +77,7 @@ func NewServiceSyncController(
 		).WithFilteredEventsInformers( // console resources
 		util.NamesFilter(serviceName, ctrl.getRedirectServiceName()),
 		serviceInformer.Informer(),
-	).WithSync(ctrl.Sync).
+	).ResyncEvery(time.Minute).WithSync(ctrl.Sync).
 		ToController("ConsoleServiceController", recorder.WithComponentSuffix("console-service-controller"))
 }
 

--- a/pkg/console/operator/operator.go
+++ b/pkg/console/operator/operator.go
@@ -157,7 +157,7 @@ func NewConsoleOperator(
 	).WithFilteredEventsInformers(
 		util.NamesFilter(deployment.ConsoleOauthConfigName),
 		secretsInformer.Informer(),
-	).WithSync(c.Sync).
+	).ResyncEvery(time.Minute).WithSync(c.Sync).
 		ToController("ConsoleOperator", recorder.WithComponentSuffix("console-operator"))
 }
 


### PR DESCRIPTION
Resync of the controllers was removed in https://github.com/openshift/console-operator/pull/531. But since it looks like we need it Im adding them back.
Together with https://github.com/openshift/console-operator/pull/580 PR this issue should be solved. Wondering if a minute is the right period here.

/assign @spadgett 
@TheRealJon @florkbr FIY