### PR TITLE
[release-4.8] Bug 2008141: Change web terminal subscription permissions from get to list

### DIFF
--- a/manifests/03-rbac-role-cluster.yaml
+++ b/manifests/03-rbac-role-cluster.yaml
@@ -112,7 +112,7 @@ rules:
   resourceNames:
   - web-terminal
   verbs:
-  - get
+  - list
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
This PR cherry-picks https://github.com/openshift/console-operator/pull/588 back to 4.8. Related Console side PR backport for 4.8 is: https://github.com/openshift/console/pull/10134

Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>
(cherry picked from commit 84d500a1822961ba406736bca02864a7caffb9a6)