### PR TITLE
Bug 2008185: Console operator go.mod should use go 1.16 version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/console-operator
 
-go 1.15
+go 1.16
 
 require (
 	github.com/blang/semver v3.5.1+incompatible


### PR DESCRIPTION
/assign @spadgett 