### PR TITLE
[WIP] manifests: resources required for adding helm metrics in console

### DIFF
--- a/manifests/0000_90_console_01_prometheusrbac.yaml
+++ b/manifests/0000_90_console_01_prometheusrbac.yaml
@@ -1,0 +1,40 @@
+# Role for accessing metrics exposed by the console
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: prometheus-k8s
+  namespace: openshift-console
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - services
+      - endpoints
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+---
+# Grant cluster-monitoring access to console metrics
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: prometheus-k8s
+  namespace: openshift-console
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: prometheus-k8s
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-k8s
+    namespace: openshift-monitoring

--- a/manifests/0000_90_console_02_servicemonitor.yaml
+++ b/manifests/0000_90_console_02_servicemonitor.yaml
@@ -1,0 +1,24 @@
+# Configure cluster-monitoring for console
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: console
+  namespace: openshift-console
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+spec:
+  endpoints:
+    - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      interval: 30s
+      path: /metrics
+      port: https
+      scheme: https
+      tlsConfig:
+        caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+        serverName: console.openshift-console.svc
+  jobLabel: component
+  selector:
+    matchLabels:
+      app: console

--- a/manifests/02-namespace.yaml
+++ b/manifests/02-namespace.yaml
@@ -10,6 +10,7 @@ metadata:
     workload.openshift.io/allowed: "management"
   labels:
     network.openshift.io/policy-group: "console"
+    openshift.io/cluster-monitoring: "true"
 ---
 apiVersion: v1
 kind: Namespace

--- a/manifests/04-rbac-rolebinding-cluster.yaml
+++ b/manifests/04-rbac-rolebinding-cluster.yaml
@@ -88,3 +88,23 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: helm-chartrepos-viewer
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: console-auth-delegator
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+roleRef:
+  # for protected endpoints like /metrics, the operator must perform
+  # authentication (tokenreview) & authorization (subjectaccessreview)
+  # which are granted by this ClusterRole
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+  - kind: ServiceAccount
+    name: console
+    namespace: openshift-console

--- a/manifests/04-rbac-rolebinding.yaml
+++ b/manifests/04-rbac-rolebinding.yaml
@@ -122,3 +122,21 @@ subjects:
   - kind: ServiceAccount
     name: console
     namespace: openshift-console
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: console
+  namespace: kube-system
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+roleRef:
+  kind: Role
+  name: extension-apiserver-authentication-reader
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: console
+    namespace: openshift-console


### PR DESCRIPTION
Adds a new ServiceMonitor to allow the Helm metrics being scraped from
console /metrics endpoint by prometheus-k8s.

Closes: https://issues.redhat.com/browse/HELM-235
Reference: https://github.com/openshift/console-operator/pull/270
Signed-off-by: Allen Bai <abai@redhat.com>