### PR TITLE
Bug 2016654: Use hard requirements for antiaffinity rules

### DIFF
--- a/manifests/07-downloads-deployment.yaml
+++ b/manifests/07-downloads-deployment.yaml
@@ -13,6 +13,11 @@ spec:
     matchLabels:
       app: console
       component: downloads
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 3
   template:
     metadata:
       name: downloads
@@ -20,6 +25,16 @@ spec:
         app: console
         component: downloads
     spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: component
+                    operator: In
+                    values:
+                      - downloads
+              topologyKey: kubernetes.io/hostname
       nodeSelector:
         kubernetes.io/os: "linux"
       tolerations:


### PR DESCRIPTION
Manual backport of https://github.com/openshift/console-operator/pull/589, stripped of single node cluster work.

/assign @spadgett 