### PR TITLE
Bug 2018380: Migrate docs links to access.redhat.com

### DIFF
--- a/pkg/console/subresource/configmap/brand_ocp.go
+++ b/pkg/console/subresource/configmap/brand_ocp.go
@@ -4,5 +4,5 @@ package configmap
 
 const (
 	DEFAULT_BRAND   = "ocp"
-	DEFAULT_DOC_URL = "https://docs.openshift.com/container-platform/4.9/"
+	DEFAULT_DOC_URL = "https://access.redhat.com/documentation/en-us/openshift_container_platform/4.9/"
 )

--- a/quickstarts/add-healthchecks-quickstart.yaml
+++ b/quickstarts/add-healthchecks-quickstart.yaml
@@ -69,7 +69,7 @@ spec:
           #### Verify that health checks are now configured:
           Is the inline notification gone?
         failedTaskHelp:
-          This task isn’t verified yet. Try the task again, or [read more](https://docs.openshift.com/container-platform/4.6/applications/application-health.html#odc-adding-health-checks)
+          This task isn’t verified yet. Try the task again, or [read more](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.9/html/building_applications/application-health#odc-adding-health-checks)
           about this topic.
       summary:
         success: You have added health checks to your sample app!

--- a/quickstarts/explore-pipeline-quickstart.yaml
+++ b/quickstarts/explore-pipeline-quickstart.yaml
@@ -57,7 +57,7 @@ spec:
 
           In the status column, is the status of the OpenShift Pipelines Operator **Succeeded**?
         failedTaskHelp:
-          This task isn’t verified yet. Try the task again, or [read more](https://docs.openshift.com/container-platform/4.6/pipelines/installing-pipelines.html#op-installing-pipelines-operator-in-web-console_installing-pipelines)
+          This task isn’t verified yet. Try the task again, or [read more](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.9/html/cicd/pipelines#op-installing-pipelines-operator-in-web-console_installing-pipelines)
           about this topic.
       summary:
         success: You have installed the Pipelines Operator!

--- a/quickstarts/install-serverless.yaml
+++ b/quickstarts/install-serverless.yaml
@@ -65,7 +65,7 @@ spec:
           for use**?
         failedTaskHelp: >-
           This task is incomplete. Try the task again, or [read
-          more](https://docs.openshift.com/container-platform/4.6/serverless/installing_serverless/installing-openshift-serverless.html)
+          more](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.9/html/serverless/administration-guide#install-serverless-operator)
           about this topic.
       summary:
         success: >-
@@ -113,7 +113,7 @@ spec:
 
         failedTaskHelp: >-
           This task isn’t verified yet. Try the task again, or [read
-          more](https://docs.openshift.com/container-platform/4.6/serverless/installing_serverless/installing-knative-serving.html)
+          more](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.9/html/serverless/administration-guide#installing-knative-serving)
           about this topic.
       summary:
         success: You just created an instance of the Knative Service resource.
@@ -156,7 +156,7 @@ spec:
           **Note**: If the condition types have a status of **False**, wait a few minutes to allow the Knative Eventing resources creation process to complete. You can check the status in the **Resources** tab.
         failedTaskHelp: >-
           This task isn’t verified yet. Try the task again, or [read
-          more](https://docs.openshift.com/container-platform/4.6/serverless/installing_serverless/installing-knative-eventing.html)
+          more](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.9/html/serverless/administration-guide#installing-knative-eventing)
           about this topic.
       summary:
         success: You just created an instance of the Knative Eventing resource.


### PR DESCRIPTION
In line with efforts currently under way for OCM, we need to update and migrate all docs.openshift.com links to access.redhat.com.

This needs to be considered in tandem with https://github.com/openshift/console/pull/10354

/assign @spadgett﻿
