### PR TITLE
[WIP] Update console operator cluster role rbac manifests

### DIFF
--- a/manifests/03-rbac-role-cluster.yaml
+++ b/manifests/03-rbac-role-cluster.yaml
@@ -110,6 +110,14 @@ rules:
       - create
       - update
       - delete
+  - apiGroups:
+      - cluster.open-cluster-management.io
+    resources:
+      - managedclusters
+    verbs:
+      - get
+      - list
+      - watch
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -160,3 +168,36 @@ rules:
     verbs:
       - get
       - list
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: console-operator-tech-preview-only
+  annotations:
+    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+rules:
+  - apiGroups:
+      - action.open-cluster-management.io
+    resources:
+      - managedclusteractions
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - delete
+  - apiGroups:
+      - view.open-cluster-management.io
+    resources:
+      - managedclusterviews
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - delete

--- a/manifests/04-rbac-rolebinding-cluster.yaml
+++ b/manifests/04-rbac-rolebinding-cluster.yaml
@@ -28,9 +28,9 @@ roleRef:
   name: console-extensions-reader
   apiGroup: rbac.authorization.k8s.io
 subjects:
-- kind: Group
-  name: system:authenticated
-  apiGroup: rbac.authorization.k8s.io
+  - kind: Group
+    name: system:authenticated
+    apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -83,8 +83,26 @@ metadata:
 subjects:
   - kind: Group
     apiGroup: rbac.authorization.k8s.io
-    name: 'system:authenticated'
+    name: "system:authenticated"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: helm-chartrepos-viewer
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: console-operator-tech-preview-only
+  annotations:
+    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: console-operator-tech-preview-only
+subjects:
+  - kind: ServiceAccount
+    name: console-operator
+    namespace: openshift-console-operator


### PR DESCRIPTION
Only provide ManagedClusterAction and ManagedClusterView permissions to the console operator when tech preview is enabled.
