### PR TITLE
Bug 2032289: Add test case

### DIFF
--- a/pkg/console/subresource/consoleserver/types.go
+++ b/pkg/console/subresource/consoleserver/types.go
@@ -36,8 +36,8 @@ type Proxy struct {
 type ProxyService struct {
 	Endpoint       string `yaml:"endpoint"`
 	ConsoleAPIPath string `yaml:"consoleAPIPath"`
-	CACertificate  string `yaml:"caCertificate"`
-	Authorize      bool   `yaml:"authorize"`
+	CACertificate  string `yaml:"caCertificate,omitempty"`
+	Authorize      bool   `yaml:"authorize,omitempty"`
 }
 
 // ServingInfo holds configuration for serving HTTP.


### PR DESCRIPTION
Adding a test case related to https://github.com/openshift/api/pull/1085

Empty fields in ConsolePlugin Proxy , such as CACertificate, should
remain empty and not be transformed to an empty string, so that it isn't validated against regex