### PR TITLE
Bug 2033434: clidownloads: add darwin/arm64 oc

### DIFF
--- a/bindata/deployments/downloads-deployment.yaml
+++ b/bindata/deployments/downloads-deployment.yaml
@@ -108,14 +108,8 @@ spec:
               temp_dir = tempfile.mkdtemp()
               print('serving from {}'.format(temp_dir))
               os.chdir(temp_dir)
-              for arch in ['amd64']:
+              for arch in ['amd64', 'arm64', 'ppc64le', 's390x']:
                 os.mkdir(arch)
-                for operating_system in ['linux', 'mac', 'windows']:
-                  os.mkdir(os.path.join(arch, operating_system))
-              for arch in ['arm64', 'ppc64le', 's390x']:
-                os.mkdir(arch)
-                for operating_system in ['linux']:
-                  os.mkdir(os.path.join(arch, operating_system))
               content = ['<a href="oc-license">license</a>']
               os.symlink('/usr/share/openshift/LICENSE', 'oc-license')
 
@@ -124,11 +118,13 @@ spec:
                   ('amd64', 'mac', '/usr/share/openshift/mac/oc'),
                   ('amd64', 'windows', '/usr/share/openshift/windows/oc.exe'),
                   ('arm64', 'linux', '/usr/share/openshift/linux_arm64/oc'),
+                  ('arm64', 'mac', '/usr/share/openshift/mac_arm64/oc'),
                   ('ppc64le', 'linux', '/usr/share/openshift/linux_ppc64le/oc'),
                   ('s390x', 'linux', '/usr/share/openshift/linux_s390x/oc'),
                   ]:
                 basename = os.path.basename(path)
                 target_path = os.path.join(arch, operating_system, basename)
+                os.mkdir(os.path.join(arch, operating_system))
                 os.symlink(path, target_path)
                 base_root, _ = os.path.splitext(basename)
                 archive_path_root = os.path.join(arch, operating_system, base_root)

--- a/pkg/console/assets/bindata.go
+++ b/pkg/console/assets/bindata.go
@@ -302,14 +302,8 @@ spec:
               temp_dir = tempfile.mkdtemp()
               print('serving from {}'.format(temp_dir))
               os.chdir(temp_dir)
-              for arch in ['amd64']:
+              for arch in ['amd64', 'arm64', 'ppc64le', 's390x']:
                 os.mkdir(arch)
-                for operating_system in ['linux', 'mac', 'windows']:
-                  os.mkdir(os.path.join(arch, operating_system))
-              for arch in ['arm64', 'ppc64le', 's390x']:
-                os.mkdir(arch)
-                for operating_system in ['linux']:
-                  os.mkdir(os.path.join(arch, operating_system))
               content = ['<a href="oc-license">license</a>']
               os.symlink('/usr/share/openshift/LICENSE', 'oc-license')
 
@@ -318,11 +312,13 @@ spec:
                   ('amd64', 'mac', '/usr/share/openshift/mac/oc'),
                   ('amd64', 'windows', '/usr/share/openshift/windows/oc.exe'),
                   ('arm64', 'linux', '/usr/share/openshift/linux_arm64/oc'),
+                  ('arm64', 'mac', '/usr/share/openshift/mac_arm64/oc'),
                   ('ppc64le', 'linux', '/usr/share/openshift/linux_ppc64le/oc'),
                   ('s390x', 'linux', '/usr/share/openshift/linux_s390x/oc'),
                   ]:
                 basename = os.path.basename(path)
                 target_path = os.path.join(arch, operating_system, basename)
+                os.mkdir(os.path.join(arch, operating_system))
                 os.symlink(path, target_path)
                 base_root, _ = os.path.splitext(basename)
                 archive_path_root = os.path.join(arch, operating_system, base_root)

--- a/pkg/console/controllers/clidownloads/controller.go
+++ b/pkg/console/controllers/clidownloads/controller.go
@@ -153,6 +153,7 @@ func PlatformBasedOCConsoleCLIDownloads(host, cliDownloadsName string) *v1.Conso
 		{"Mac for x86_64", "amd64/mac", "oc.zip"},
 		{"Windows for x86_64", "amd64/windows", "oc.zip"},
 		{"Linux for ARM 64", "arm64/linux", "oc.tar"},
+		{"Mac for ARM 64", "arm64/mac", "oc.zip"},
 		{"Linux for IBM Power, little endian", "ppc64le/linux", "oc.tar"},
 		{"Linux for IBM Z", "s390x/linux", "oc.tar"},
 	}

--- a/pkg/console/controllers/clidownloads/controller_test.go
+++ b/pkg/console/controllers/clidownloads/controller_test.go
@@ -56,13 +56,22 @@ func TestGetPlatformURL(t *testing.T) {
 			want: "https://www.example.com/s390x/linux/oc.tar",
 		},
 		{
-			name: "Test assembling mac specific URL",
+			name: "Test assembling mac x86_64 specific URL",
 			args: args{
 				baseURL:     "https://www.example.com/amd64",
 				platform:    "mac",
 				archiveType: "oc.zip",
 			},
 			want: "https://www.example.com/amd64/mac/oc.zip",
+		},
+		{
+			name: "Test assembling mac arm64 specific URL",
+			args: args{
+				baseURL:     "https://www.example.com/arm64",
+				platform:    "mac",
+				archiveType: "oc.zip",
+			},
+			want: "https://www.example.com/arm64/mac/oc.zip",
 		},
 		{
 			name: "Test assembling windows 64-bit specific URL",
@@ -126,6 +135,10 @@ The oc binary offers the same capabilities as the kubectl binary, but it is furt
 						{
 							Href: "https://www.example.com/arm64/linux/oc.tar",
 							Text: "Download oc for Linux for ARM 64",
+						},
+						{
+							Href: "https://www.example.com/arm64/mac/oc.zip",
+							Text: "Download oc for Mac for ARM 64",
 						},
 						{
 							Href: "https://www.example.com/ppc64le/linux/oc.tar",


### PR DESCRIPTION
A darwin/arm64 oc binary was added to cli-artifacts in https://github.com/openshift/oc/pull/990 .﻿
