### PR TITLE
Bug 2036937: Update download odo link to new mirror

### DIFF
--- a/pkg/console/controllers/clidownloads/controller.go
+++ b/pkg/console/controllers/clidownloads/controller.go
@@ -198,7 +198,7 @@ odo abstracts away complex Kubernetes and OpenShift concepts, thus allowing deve
 			DisplayName: "odo - Developer-focused CLI for OpenShift",
 			Links: []v1.CLIDownloadLink{
 				{
-					Href: "https://mirror.openshift.com/pub/openshift-v4/clients/odo/latest/",
+					Href: "https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/latest",
 					Text: "Download odo",
 				},
 			},


### PR DESCRIPTION
Fixes - https://github.com/openshift/console/issues/10415

Updates in this PR -

- Changes the CLI download link for odo to latest developer mirror - https://developers.redhat.com/content-gateway/rest/mirror/pub/openshift-v4/clients/odo/latest.