### PR TITLE
Dockerfile.rhel7: add new Helm CRD, ProjectHelmChartRepository

### DIFF
--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -20,6 +20,7 @@ COPY vendor/github.com/openshift/api/console/v1/*.yaml /manifests/
 COPY vendor/github.com/openshift/api/console/v1alpha1/*.yaml /manifests/
 COPY vendor/github.com/openshift/api/operator/v1/0000_70_console-operator.crd.yaml /manifests/
 COPY vendor/github.com/openshift/api/helm/v1beta1/0000_10-helm-chart-repository.crd.yaml /manifests/
+COPY vendor/github.com/openshift/api/helm/v1beta1/0000_10-project-helm-chart-repository.crd.yaml /manifests/
 
 LABEL io.k8s.display-name="OpenShift console-operator" \
       io.k8s.description="This is a component of OpenShift Container Platform and manages the lifecycle of the web console." \


### PR DESCRIPTION
This change is needed to initialize and vendor the newly add Helm CRD. Currently, the API schema has been merged but has not been initialized in our cluster yet.

Refer: https://github.com/openshift/api/pull/1084
Signed-off-by: Allen Bai <carpe.diem.allen@gmail.com>