### PR TITLE
CONSOLE 3070: Console-operator should pass infrastructure config's ControlPlaneToplogy to the console-config.yaml

### DIFF
--- a/pkg/console/subresource/configmap/configmap.go
+++ b/pkg/console/subresource/configmap/configmap.go
@@ -72,6 +72,7 @@ func DefaultConfigMap(
 		DocURL(operatorConfig.Spec.Customization.DocumentationBaseURL).
 		OAuthServingCert(useDefaultCAFile).
 		APIServerURL(getApiUrl(infrastructureConfig)).
+		TopologyMode(infrastructureConfig.Status.ControlPlaneTopology).
 		Plugins(GetPluginsEndpointMap(availablePlugins)).
 		Proxy(GetPluginsProxyServices(availablePlugins)).
 		CustomLogoFile(operatorConfig.Spec.Customization.CustomLogoFile.Key).

--- a/pkg/console/subresource/consoleserver/config_builder.go
+++ b/pkg/console/subresource/consoleserver/config_builder.go
@@ -1,6 +1,7 @@
 package consoleserver
 
 import (
+	configv1 "github.com/openshift/api/config/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	"github.com/openshift/console-operator/pkg/api"
 	"github.com/openshift/console-operator/pkg/console/subresource/util"
@@ -34,6 +35,7 @@ type ConsoleServerCLIConfigBuilder struct {
 	brand                      operatorv1.Brand
 	docURL                     string
 	apiServerURL               string
+	controlPlaneToplogy        configv1.TopologyMode
 	statusPageID               string
 	customProductName          string
 	devCatalogCustomization    operatorv1.DeveloperConsoleCatalogCustomization
@@ -67,6 +69,10 @@ func (b *ConsoleServerCLIConfigBuilder) DocURL(docURL string) *ConsoleServerCLIC
 }
 func (b *ConsoleServerCLIConfigBuilder) APIServerURL(apiServerURL string) *ConsoleServerCLIConfigBuilder {
 	b.apiServerURL = apiServerURL
+	return b
+}
+func (b *ConsoleServerCLIConfigBuilder) TopologyMode(topologyMode configv1.TopologyMode) *ConsoleServerCLIConfigBuilder {
+	b.controlPlaneToplogy = topologyMode
 	return b
 }
 func (b *ConsoleServerCLIConfigBuilder) CustomProductName(customProductName string) *ConsoleServerCLIConfigBuilder {
@@ -187,6 +193,9 @@ func (b *ConsoleServerCLIConfigBuilder) clusterInfo() ClusterInfo {
 	}
 	if len(b.host) > 0 {
 		conf.ConsoleBaseAddress = util.HTTPS(b.host)
+	}
+	if len(b.controlPlaneToplogy) > 0 {
+		conf.ControlPlaneToplogy = b.controlPlaneToplogy
 	}
 	return conf
 }

--- a/pkg/console/subresource/consoleserver/types.go
+++ b/pkg/console/subresource/consoleserver/types.go
@@ -1,5 +1,9 @@
 package consoleserver
 
+import (
+	configv1 "github.com/openshift/api/config/v1"
+)
+
 // This file is a copy of the struct within the console itself:
 //   https://github.com/openshift/console/blob/master/pkg/serverconfig/types.go
 // These structs need to remain in sync.
@@ -54,9 +58,10 @@ type ServingInfo struct {
 
 // ClusterInfo holds information the about the cluster such as master public URL and console public URL.
 type ClusterInfo struct {
-	ConsoleBaseAddress string `yaml:"consoleBaseAddress,omitempty"`
-	ConsoleBasePath    string `yaml:"consoleBasePath,omitempty"`
-	MasterPublicURL    string `yaml:"masterPublicURL,omitempty"`
+	ConsoleBaseAddress  string                `yaml:"consoleBaseAddress,omitempty"`
+	ConsoleBasePath     string                `yaml:"consoleBasePath,omitempty"`
+	MasterPublicURL     string                `yaml:"masterPublicURL,omitempty"`
+	ControlPlaneToplogy configv1.TopologyMode `yaml:"controlPlaneTopology,omitempty"`
 }
 
 // Auth holds configuration for authenticating with OpenShift. The auth method is assumed to be "openshift".


### PR DESCRIPTION
Infrastructure config's `ControlPlaneToplogy` will be stored in the console-config.yaml under `clusterInfo.controlPlaneTopology`.

/assign @zherman0 