### PR TITLE
Bug 2057696: Console operator should not block installation/upgrade process when set to Removed state

### DIFF
--- a/pkg/console/status/status.go
+++ b/pkg/console/status/status.go
@@ -55,6 +55,12 @@ func HandleAvailable(typePrefix string, reason string, err error) v1helpers.Upda
 	return v1helpers.UpdateConditionFn(condition)
 }
 
+func HandleUpgradable(typePrefix string, reason string, err error) v1helpers.UpdateStatusFunc {
+	conditionType := typePrefix + operatorsv1.OperatorStatusTypeUpgradeable
+	condition := handleCondition(conditionType, reason, err)
+	return v1helpers.UpdateConditionFn(condition)
+}
+
 // HandleProgressingOrDegraded exists until we remove type SyncError
 // If isSyncError
 // - Type suffix will be set to Progressing
@@ -90,9 +96,9 @@ func handleCondition(conditionTypeWithSuffix string, reason string, err error) o
 	}
 }
 
-// Available is an inversion of the other conditions
+// Available and Upgradable are an inversions of the Degraded and Progressing conditions
 func setConditionValue(conditionType string, err error) operatorsv1.ConditionStatus {
-	if strings.HasSuffix(conditionType, operatorsv1.OperatorStatusTypeAvailable) {
+	if strings.HasSuffix(conditionType, operatorsv1.OperatorStatusTypeAvailable) || strings.HasSuffix(conditionType, operatorsv1.OperatorStatusTypeUpgradeable) {
 		if err != nil {
 			return operatorsv1.ConditionFalse
 		}


### PR DESCRIPTION
We havent been setting the right conditions when the console-operator has been set to `Removed` state. The correct ones should be `Available: True` & `Degraded: False`, when no error occurs during the removal process. 

/assign @TheRealJon 