### PR TITLE
Bug 2046497: Metrics e2e should not fail on first failed polling attempt

### DIFF
--- a/test/e2e/metrics_test.go
+++ b/test/e2e/metrics_test.go
@@ -91,19 +91,19 @@ func metricsRequest(t *testing.T, routeForMetrics string) string {
 	err := wait.Poll(1*time.Second, 30*time.Second, func() (stop bool, err error) {
 		resp, err := httpClient.Do(req)
 		if err != nil {
-			t.Errorf("http error: %s\n", err)
+			t.Logf("http error: %s\n", err)
 			return false, err
 		}
 
 		if !httpOK(resp) {
-			t.Errorf("http error: %d %s\n", resp.StatusCode, http.StatusText(resp.StatusCode))
+			t.Logf("http error: %d %s\n", resp.StatusCode, http.StatusText(resp.StatusCode))
 			return false, err
 		}
 
 		defer resp.Body.Close()
 		bytes, err = ioutil.ReadAll(resp.Body)
 		if err != nil {
-			t.Errorf("error reading metrics response: %s\n", err)
+			t.Logf("error reading metrics response: %s\n", err)
 			return false, err
 		}
 		return true, nil


### PR DESCRIPTION
We need to replace `Errorf` with `Logf`. Its my failt, I should have noticed this when reviewing https://github.com/openshift/console-operator/pull/640

```go
// Errorf is equivalent to Logf followed by Fail.
func (c *common) Errorf(format string, args ...interface{}) {
	c.log(fmt.Sprintf(format, args...))
	c.Fail()
}

// Fail marks the function as having failed but continues execution.
func (c *common) Fail() {
    ...
}
```


/assign @TheRealJon 