### PR TITLE
Bug 2086519: AUTH-133: manifests: comply to restricted pod security

### DIFF
--- a/bindata/deployments/console-deployment.yaml
+++ b/bindata/deployments/console-deployment.yaml
@@ -27,7 +27,10 @@ spec:
       restartPolicy: Always
       serviceAccountName: console
       schedulerName: default-scheduler
-      securityContext: {}
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       terminationGracePeriodSeconds: 40
       priorityClassName: system-cluster-critical
       containers:
@@ -51,6 +54,11 @@ spec:
                   - sleep
                   - "25"
           name: console
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
           command:
             - /opt/bridge/bin/bridge
             - "--public-dir=/opt/bridge/static"

--- a/bindata/deployments/downloads-deployment.yaml
+++ b/bindata/deployments/downloads-deployment.yaml
@@ -26,7 +26,10 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       terminationGracePeriodSeconds: 0
-      securityContext: {}
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - resources:
             requests:
@@ -42,6 +45,11 @@ spec:
             successThreshold: 1
             failureThreshold: 3
           name: download-server
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
           command:
             - /bin/sh
           livenessProbe:

--- a/go.mod
+++ b/go.mod
@@ -22,4 +22,5 @@ require (
 	k8s.io/client-go v0.23.0
 	k8s.io/component-base v0.23.0
 	k8s.io/klog/v2 v2.30.0
+	k8s.io/utils v0.0.0-20210930125809-cb0fa318a74b
 )

--- a/manifests/07-operator-ibm-cloud-managed.yaml
+++ b/manifests/07-operator-ibm-cloud-managed.yaml
@@ -59,6 +59,11 @@ spec:
           requests:
             cpu: 10m
             memory: 100Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/run/configmaps/config
@@ -66,6 +71,10 @@ spec:
         - mountPath: /var/run/secrets/serving-cert
           name: serving-cert
       priorityClassName: system-cluster-critical
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: console-operator
       tolerations:
       - effect: NoSchedule

--- a/manifests/07-operator.yaml
+++ b/manifests/07-operator.yaml
@@ -19,6 +19,10 @@ spec:
       labels:
         name: console-operator
     spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       nodeSelector:
         node-role.kubernetes.io/master: ""
       tolerations:
@@ -37,6 +41,10 @@ spec:
       serviceAccountName: console-operator
       containers:
       - name: console-operator
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
         terminationMessagePolicy: FallbackToLogsOnError
         image: registry.svc.ci.openshift.org/openshift:console-operator
         ports:

--- a/pkg/console/assets/bindata.go
+++ b/pkg/console/assets/bindata.go
@@ -145,7 +145,10 @@ spec:
       restartPolicy: Always
       serviceAccountName: console
       schedulerName: default-scheduler
-      securityContext: {}
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       terminationGracePeriodSeconds: 40
       priorityClassName: system-cluster-critical
       containers:
@@ -169,6 +172,11 @@ spec:
                   - sleep
                   - "25"
           name: console
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
           command:
             - /opt/bridge/bin/bridge
             - "--public-dir=/opt/bridge/static"
@@ -248,7 +256,10 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       terminationGracePeriodSeconds: 0
-      securityContext: {}
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - resources:
             requests:
@@ -264,6 +275,11 @@ spec:
             successThreshold: 1
             failureThreshold: 3
           name: download-server
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
           command:
             - /bin/sh
           livenessProbe:

--- a/pkg/console/subresource/deployment/deployment_test.go
+++ b/pkg/console/subresource/deployment/deployment_test.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	utilpointer "k8s.io/utils/pointer"
 
 	configv1 "github.com/openshift/api/config/v1"
 	operatorsv1 "github.com/openshift/api/operator/v1"
@@ -244,7 +245,12 @@ func TestDefaultDeployment(t *testing.T) {
 							RestartPolicy:                 corev1.RestartPolicyAlways,
 							SchedulerName:                 corev1.DefaultSchedulerName,
 							TerminationGracePeriodSeconds: &gracePeriod,
-							SecurityContext:               &corev1.PodSecurityContext{},
+							SecurityContext: &corev1.PodSecurityContext{
+								RunAsNonRoot: utilpointer.Bool(true),
+								SeccompProfile: &corev1.SeccompProfile{
+									Type: corev1.SeccompProfileTypeRuntimeDefault,
+								},
+							},
 							Containers: []corev1.Container{
 								consoleDeploymentContainer,
 							},
@@ -322,7 +328,12 @@ func TestDefaultDeployment(t *testing.T) {
 							RestartPolicy:                 corev1.RestartPolicyAlways,
 							SchedulerName:                 corev1.DefaultSchedulerName,
 							TerminationGracePeriodSeconds: &gracePeriod,
-							SecurityContext:               &corev1.PodSecurityContext{},
+							SecurityContext: &corev1.PodSecurityContext{
+								RunAsNonRoot: utilpointer.Bool(true),
+								SeccompProfile: &corev1.SeccompProfile{
+									Type: corev1.SeccompProfileTypeRuntimeDefault,
+								},
+							},
 							Containers: []corev1.Container{
 								consoleDeploymentContainerTrusted,
 							},
@@ -400,7 +411,12 @@ func TestDefaultDeployment(t *testing.T) {
 							RestartPolicy:                 corev1.RestartPolicyAlways,
 							SchedulerName:                 corev1.DefaultSchedulerName,
 							TerminationGracePeriodSeconds: &gracePeriod,
-							SecurityContext:               &corev1.PodSecurityContext{},
+							SecurityContext: &corev1.PodSecurityContext{
+								RunAsNonRoot: utilpointer.Bool(true),
+								SeccompProfile: &corev1.SeccompProfile{
+									Type: corev1.SeccompProfileTypeRuntimeDefault,
+								},
+							},
 							Containers: []corev1.Container{
 								consoleDeploymentContainer,
 							},
@@ -468,7 +484,12 @@ func TestDefaultDeployment(t *testing.T) {
 							RestartPolicy:                 corev1.RestartPolicyAlways,
 							SchedulerName:                 corev1.DefaultSchedulerName,
 							TerminationGracePeriodSeconds: &gracePeriod,
-							SecurityContext:               &corev1.PodSecurityContext{},
+							SecurityContext: &corev1.PodSecurityContext{
+								RunAsNonRoot: utilpointer.Bool(true),
+								SeccompProfile: &corev1.SeccompProfile{
+									Type: corev1.SeccompProfileTypeRuntimeDefault,
+								},
+							},
 							Containers: []corev1.Container{
 								consoleDeploymentContainer,
 							},
@@ -1375,7 +1396,12 @@ func TestDefaultDownloadsDeployment(t *testing.T) {
 				TolerationSeconds: &tolerationSeconds,
 			},
 		},
-		SecurityContext:               &corev1.PodSecurityContext{},
+		SecurityContext: &corev1.PodSecurityContext{
+			RunAsNonRoot: utilpointer.Bool(true),
+			SeccompProfile: &corev1.SeccompProfile{
+				Type: corev1.SeccompProfileTypeRuntimeDefault,
+			},
+		},
 		PriorityClassName:             "system-cluster-critical",
 		TerminationGracePeriodSeconds: &gracePeriod,
 		Containers: []corev1.Container{
@@ -1423,6 +1449,14 @@ func TestDefaultDownloadsDeployment(t *testing.T) {
 					},
 				},
 				Args: downloadsDeploymentTemplate.Spec.Template.Spec.Containers[0].Args,
+				SecurityContext: &corev1.SecurityContext{
+					Capabilities: &corev1.Capabilities{
+						Drop: []corev1.Capability{
+							"ALL",
+						},
+					},
+					AllowPrivilegeEscalation: utilpointer.Bool(false),
+				},
 			},
 		},
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1096,6 +1096,7 @@ k8s.io/kube-openapi/pkg/util
 k8s.io/kube-openapi/pkg/util/proto
 k8s.io/kube-openapi/pkg/validation/spec
 # k8s.io/utils v0.0.0-20210930125809-cb0fa318a74b
+## explicit
 k8s.io/utils/buffer
 k8s.io/utils/clock
 k8s.io/utils/clock/testing


### PR DESCRIPTION
Starting from OpenShift 4.11 pod security admission is being activated. In OpenShift the default pod security admission level is going to be `restricted`. This PR fixes workloads from this repository. Concretely, the following violations have been detected:

```
{
  "objectRef": "openshift-console-operator/pods/",
  "pod-security.kubernetes.io/audit-violations": "would violate PodSecurity \"restricted:latest\": runAsNonRoot != true (pod or container \"console-operator\" must set securityContext.runAsNonRoot=true)"
}
```

/cc @stlaz 