### PR TITLE
ODC-6670: Sync consoleConfig telemetry annotations to console-config.yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 .idea
 ./deploy
 
+# Build result
+/console
+
 # tools output reports into _output
 _output
 

--- a/pkg/console/subresource/consoleserver/config_builder.go
+++ b/pkg/console/subresource/consoleserver/config_builder.go
@@ -49,6 +49,7 @@ type ConsoleServerCLIConfigBuilder struct {
 	pluginsList                map[string]string
 	proxyServices              []ProxyService
 	managedClusterConfigFile   string
+	telemetry                  map[string]string
 }
 
 func (b *ConsoleServerCLIConfigBuilder) Host(host string) *ConsoleServerCLIConfigBuilder {
@@ -144,6 +145,11 @@ func (b *ConsoleServerCLIConfigBuilder) ManagedClusterConfigFile(file string) *C
 	return b
 }
 
+func (b *ConsoleServerCLIConfigBuilder) TelemetryConfiguration(telemetry map[string]string) *ConsoleServerCLIConfigBuilder {
+	b.telemetry = telemetry
+	return b
+}
+
 func (b *ConsoleServerCLIConfigBuilder) Config() Config {
 	return Config{
 		Kind:                     "ConsoleConfig",
@@ -156,6 +162,7 @@ func (b *ConsoleServerCLIConfigBuilder) Config() Config {
 		Plugins:                  b.plugins(),
 		Proxy:                    b.proxy(),
 		ManagedClusterConfigFile: b.managedClusterConfigFile,
+		Telemetry:                b.telemetry,
 	}
 }
 
@@ -298,4 +305,8 @@ func (b *ConsoleServerCLIConfigBuilder) proxy() Proxy {
 	return Proxy{
 		Services: b.proxyServices,
 	}
+}
+
+func (b *ConsoleServerCLIConfigBuilder) Telemetry() map[string]string {
+	return b.telemetry
 }

--- a/pkg/console/subresource/consoleserver/config_builder_test.go
+++ b/pkg/console/subresource/consoleserver/config_builder_test.go
@@ -384,6 +384,38 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "Config builder should pass telemetry configuration",
+			input: func() Config {
+				b := &ConsoleServerCLIConfigBuilder{}
+				b.TelemetryConfiguration(map[string]string{
+					"a-key": "a-value",
+				})
+				return b.Config()
+			},
+			output: Config{
+				Kind:       "ConsoleConfig",
+				APIVersion: "console.openshift.io/v1",
+				ServingInfo: ServingInfo{
+					BindAddress: "https://[::]:8443",
+					CertFile:    certFilePath,
+					KeyFile:     keyFilePath,
+				},
+				ClusterInfo: ClusterInfo{
+					ConsoleBasePath: "",
+				},
+				Auth: Auth{
+					ClientID:            api.OpenShiftConsoleName,
+					ClientSecretFile:    clientSecretFilePath,
+					OAuthEndpointCAFile: oauthEndpointCAFilePath,
+				},
+				Customization: Customization{},
+				Providers:     Providers{},
+				Telemetry: map[string]string{
+					"a-key": "a-value",
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -688,6 +720,34 @@ customization:
     - quickStarts0
     - quickStarts1
 providers: {}
+`,
+		},
+		{
+			name: "Config builder should pass telemetry configuration",
+			input: func() ([]byte, error) {
+				b := &ConsoleServerCLIConfigBuilder{}
+				b.TelemetryConfiguration(map[string]string{
+					"a-key":               "a-value",
+					"a-boolean-as-string": "false",
+				})
+				return b.ConfigYAML()
+			},
+			output: `apiVersion: console.openshift.io/v1
+kind: ConsoleConfig
+servingInfo:
+  bindAddress: https://[::]:8443
+  certFile: /var/serving-cert/tls.crt
+  keyFile: /var/serving-cert/tls.key
+clusterInfo: {}
+auth:
+  clientID: console
+  clientSecretFile: /var/oauth-config/clientSecret
+  oauthEndpointCAFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+customization: {}
+providers: {}
+telemetry:
+  a-boolean-as-string: "false"
+  a-key: a-value
 `,
 		},
 	}

--- a/pkg/console/subresource/consoleserver/types.go
+++ b/pkg/console/subresource/consoleserver/types.go
@@ -25,6 +25,7 @@ type Config struct {
 	Plugins                  map[string]string `yaml:"plugins,omitempty"`
 	Proxy                    Proxy             `yaml:"proxy,omitempty"`
 	ManagedClusterConfigFile string            `yaml:"managedClusterConfigFile,omitempty"`
+	Telemetry                map[string]string `yaml:"telemetry,omitempty"`
 }
 
 type Proxy struct {


### PR DESCRIPTION
**Implements**: 
https://issues.redhat.com/browse/ODC-6670

### Solution Description
:arrow_right: [Full Epic implementation documentation](https://docs.google.com/document/d/1PgQvB1TKwRH9Peezbr7Fu-raj-zU4iDFK9SJ6bZqxhs/edit)

To configure the new (separate PR in [openshift/console](https://github.com/openshift/console)) `telemetry-plugin` we need a generic mechanism to configure this plugin.

This PR automatically applies `telemetry.console.openshift.io/` prefixed annotations of the `operator.openshift.io/Console` `cluster` resource [1] to the `console-config.yaml` [2].

### Test setup
Add some prefixed annotations to `operator.openshift.io/Console` `cluster` resource [1]:

```yaml
apiVersion: operator.openshift.io/v1
kind: Console
metadata:
  annotations:
    telemetry.console.openshift.io/A_CONFIG_KEY: value1
    telemetry.console.openshift.io/ANOTHER_CONFIG_KEY: value2
    telemetry.console.openshift.io/disabled: "true"
    // ...
```

Verify that this configuration are applied to the `console-config.yaml` part of the `console-config` `ConfigMap` (ns: `openshift-console`) [2]. It should look similar to this:

```yaml
kind: ConfigMap
apiVersion: v1
metadata:
  name: console-config
  namespace: openshift-console
  // ...
data:
  console-config.yaml: |
    apiVersion: console.openshift.io/v1
    kind: ConsoleConfig
    // ...
    telemetry:
      A_CONFIG_KEY: value1
      ANOTHER_CONFIG_KEY: value2
      disabled: "true"
```

Patch statements to apply and verify these annotations on the CLI:

```
oc patch consoles.operator.openshift.io cluster --type=merge --patch='{"metadata":{"annotations":{"telemetry.console.openshift.io/A_CONFIG_KEY":"value1"}}}'

oc patch consoles.operator.openshift.io cluster --type=merge --patch='{"metadata":{"annotations":{"telemetry.console.openshift.io/ANOTHER_CONFIG_KEY":"value2"}}}'

oc patch consoles.operator.openshift.io cluster --type=merge --patch='{"metadata":{"annotations":{"telemetry.console.openshift.io/disabled":"true"}}}'
```

To check the annotations:

```
oc get consoles.operator.openshift.io cluster "-o=jsonpath={.metadata.annotations}" | sed 's/^map.\(.*\).$/\1/g' | xargs -n 1 echo
```

# After 1-2 seconds:

oc get configmaps -n openshift-console console-config "-o=jsonpath={.data.console-config\.yaml}"
```

[1] http://localhost:9000/k8s/cluster/operator.openshift.io~v1~Console/cluster/yaml
[2] http://localhost:9000/k8s/ns/openshift-console/configmaps/console-config

:warning: The ConfigMap update should take just a few seconds, but please notice that the console needs to be restarted to use the latest configuration. This rollout will take roundabout a minute!

### Cluster bot verification

Test this together with https://github.com/openshift/console/pull/11531 on a cluster bot instance:

```
launch openshift/console-operator#653,openshift/console#11531
```

After applying the annotations with the `oc patch` commands you should see an updated SERVER_FLAGS when inspecting the console index.html. A new console pod will be started and this could take some seconds!

I have done this once:

![telemetry-backend-changes](https://user-images.githubusercontent.com/139310/169538945-e504665b-9b03-47f6-a080-552206c0ccd1.gif)
