### PR TITLE
CONSOLE-3162: Implement check for the new i18n annotation for dynamic plugins

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -54,6 +54,8 @@ const (
 	CreateOAuthClientManagedClusterActionName = "console-create-oauth-client"
 	OAuthServerCertManagedClusterViewName     = "console-oauth-server-cert"
 
+	PluginI18nAnnotation = "console.openshift.io/use-i18n"
+
 	ManagedClusterViewAPIGroup     = "view.open-cluster-management.io"
 	ManagedClusterViewAPIVersion   = "v1beta1"
 	ManagedClusterViewResource     = "managedclusterviews"

--- a/pkg/console/subresource/configmap/configmap_test.go
+++ b/pkg/console/subresource/configmap/configmap_test.go
@@ -663,8 +663,10 @@ managedClusterConfigFile: 'test'
 				useDefaultCAFile:         true,
 				inactivityTimeoutSeconds: 0,
 				availablePlugins: []*v1alpha1.ConsolePlugin{
-					testPlugins("pluginName1", "serviceName1", "serviceNamespace1"),
-					testPluginsWithProxy("pluginName2", "serviceName2", "serviceNamespace2"),
+					testPlugins("plugin1", "service1", "service-namespace1"),
+					testPluginsWithProxy("plugin2", "service2", "service-namespace2"),
+					testPluginsWithI18nAnnotation("plugin3", "service3", "service-namespace3", "false"),
+					testPluginsWithI18nAnnotation("plugin4", "service4", "service-namespace4", "true"),
 				},
 				managedClusterConfigFile: "",
 			},
@@ -691,14 +693,18 @@ clusterInfo:
 customization:
   branding: ` + DEFAULT_BRAND + `
   documentationBaseURL: ` + DEFAULT_DOC_URL + `
+i18nNamespaces:
+- plugin__plugin4 
 servingInfo:
   bindAddress: https://[::]:8443
   certFile: /var/serving-cert/tls.crt
   keyFile: /var/serving-cert/tls.key
 providers: {}
 plugins:
-  pluginName1: https://serviceName1.serviceNamespace1.svc.cluster.local:8443/
-  pluginName2: https://serviceName2.serviceNamespace2.svc.cluster.local:8443/
+  plugin1: https://service1.service-namespace1.svc.cluster.local:8443/
+  plugin2: https://service2.service-namespace2.svc.cluster.local:8443/
+  plugin3: https://service3.service-namespace3.svc.cluster.local:8443/
+  plugin4: https://service4.service-namespace4.svc.cluster.local:8443/
 proxy:
   services:
   - authorize: true
@@ -717,8 +723,8 @@ HQ4EFgQU0vhI4OPGEOqT+VAWwxdhVvcmgdIwHwYDVR0jBBgwFoAU0vhI4OPGEOqT` + "\n" + `
 nV5cXbp9W1bC12Tc8nnNXn4ypLE2JTQAvyp51zoZ8hQoSnRVx/VCY55Yu+br8gQZ` + "\n" + `
 +tW+O/PoE7B3tuY=` + "\n" + `
 -----END CERTIFICATE-----'
-    consoleAPIPath: /api/proxy/plugin/pluginName2/test-alias/
-    endpoint: https://proxy-serviceName2.proxy-serviceNamespace2.svc.cluster.local:9991
+    consoleAPIPath: /api/proxy/plugin/plugin2/test-alias/
+    endpoint: https://proxy-service2.proxy-service-namespace2.svc.cluster.local:9991
 `,
 				},
 			},
@@ -818,6 +824,7 @@ providers: {}
 
 			// compare the configs
 			if diff := deep.Equal(exampleConfig, actualConfig); diff != nil {
+				fmt.Printf("\n EXAMPLE: %#v\n\n ACTUAL: %#v\n", exampleConfig, actualConfig)
 				t.Error(diff)
 			}
 
@@ -921,6 +928,12 @@ func TestTelemetryConfiguration(t *testing.T) {
 			}
 		})
 	}
+}
+
+func testPluginsWithI18nAnnotation(pluginName, serviceName, serviceNamespace, annotationValue string) *v1alpha1.ConsolePlugin {
+	plugin := testPlugins(pluginName, serviceName, serviceNamespace)
+	plugin.SetAnnotations(map[string]string{api.PluginI18nAnnotation: annotationValue})
+	return plugin
 }
 
 func TestStub(t *testing.T) {

--- a/pkg/console/subresource/consoleserver/config_builder.go
+++ b/pkg/console/subresource/consoleserver/config_builder.go
@@ -47,6 +47,7 @@ type ConsoleServerCLIConfigBuilder struct {
 	customHostnameRedirectPort int
 	inactivityTimeoutSeconds   int
 	pluginsList                map[string]string
+	i18nNamespaceList          []string
 	proxyServices              []ProxyService
 	managedClusterConfigFile   string
 	telemetry                  map[string]string
@@ -135,6 +136,11 @@ func (b *ConsoleServerCLIConfigBuilder) Plugins(plugins map[string]string) *Cons
 	return b
 }
 
+func (b *ConsoleServerCLIConfigBuilder) I18nNamespaces(i18nNamespaces []string) *ConsoleServerCLIConfigBuilder {
+	b.i18nNamespaceList = i18nNamespaces
+	return b
+}
+
 func (b *ConsoleServerCLIConfigBuilder) Proxy(proxyServices []ProxyService) *ConsoleServerCLIConfigBuilder {
 	b.proxyServices = proxyServices
 	return b
@@ -160,6 +166,7 @@ func (b *ConsoleServerCLIConfigBuilder) Config() Config {
 		ServingInfo:              b.servingInfo(),
 		Providers:                b.providers(),
 		Plugins:                  b.plugins(),
+		I18nNamespaces:           b.i18nNamespaces(),
 		Proxy:                    b.proxy(),
 		ManagedClusterConfigFile: b.managedClusterConfigFile,
 		Telemetry:                b.telemetry,
@@ -299,6 +306,10 @@ func (b *ConsoleServerCLIConfigBuilder) providers() Providers {
 
 func (b *ConsoleServerCLIConfigBuilder) plugins() map[string]string {
 	return b.pluginsList
+}
+
+func (b *ConsoleServerCLIConfigBuilder) i18nNamespaces() []string {
+	return b.i18nNamespaceList
 }
 
 func (b *ConsoleServerCLIConfigBuilder) proxy() Proxy {

--- a/pkg/console/subresource/consoleserver/config_builder_test.go
+++ b/pkg/console/subresource/consoleserver/config_builder_test.go
@@ -350,7 +350,8 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 					Plugins(map[string]string{
 						"plugin1": "plugin1_url",
 						"plugin2": "plugin2_url",
-					})
+					}).
+					I18nNamespaces([]string{"plugin__plugin1"})
 				return b.Config()
 			},
 			output: Config{
@@ -382,6 +383,7 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 					"plugin1": "plugin1_url",
 					"plugin2": "plugin2_url",
 				},
+				I18nNamespaces: []string{"plugin__plugin1"},
 			},
 		},
 		{
@@ -664,6 +666,7 @@ providers: {}
 						"plugin1": "plugin1_url",
 						"plugin2": "plugin2_url",
 					}).
+					I18nNamespaces([]string{"plugin__plugin1"}).
 					OAuthServingCert(true)
 				return b.ConfigYAML()
 			},
@@ -689,6 +692,8 @@ providers:
 plugins:
   plugin1: plugin1_url
   plugin2: plugin2_url
+i18nNamespaces:
+- plugin__plugin1
 `,
 		},
 		{

--- a/pkg/console/subresource/consoleserver/types.go
+++ b/pkg/console/subresource/consoleserver/types.go
@@ -23,6 +23,7 @@ type Config struct {
 	Customization            `yaml:"customization"`
 	Providers                `yaml:"providers"`
 	Plugins                  map[string]string `yaml:"plugins,omitempty"`
+	I18nNamespaces           []string          `yaml:"i18nNamespaces,omitempty"`
 	Proxy                    Proxy             `yaml:"proxy,omitempty"`
 	ManagedClusterConfigFile string            `yaml:"managedClusterConfigFile,omitempty"`
 	Telemetry                map[string]string `yaml:"telemetry,omitempty"`


### PR DESCRIPTION
console-operator should be checking for the new `console.openshift.io/default-i18next-namespace` annotation, update the `console-config.yaml` accordingly and redeploy the console server.

For that I've refact the internal consoleserver API.

/assign @spadgett @TheRealJon 

Story: https://issues.redhat.com/browse/CONSOLE-3162