### PR TITLE
Bug 2093852: InfrastructureTopology must be driving console affinity rule creation

### DIFF
--- a/pkg/console/subresource/deployment/deployment.go
+++ b/pkg/console/subresource/deployment/deployment.go
@@ -107,7 +107,7 @@ func withReplicas(deployment *appsv1.Deployment, infrastructureConfig *configv1.
 
 func withAffinity(deployment *appsv1.Deployment, infrastructureConfig *configv1.Infrastructure, component string) {
 	affinity := &corev1.Affinity{}
-	if infrastructureConfig.Status.ControlPlaneTopology != configv1.SingleReplicaTopologyMode {
+	if infrastructureConfig.Status.InfrastructureTopology != configv1.SingleReplicaTopologyMode {
 		affinity = &corev1.Affinity{
 			PodAntiAffinity: &corev1.PodAntiAffinity{
 				RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{{


### PR DESCRIPTION
This PR fixes bug described in the issue https://github.com/openshift/console-operator/issues/656
