### PR TITLE
Bug 2100860: Retrieve user-defined  Alertmanager services from shared configmap

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -33,6 +33,7 @@ const (
 	OAuthClientName                           = OpenShiftConsoleName
 	OpenShiftConfigManagedNamespace           = "openshift-config-managed"
 	OpenShiftConfigNamespace                  = "openshift-config"
+	OpenShiftMonitoringConfigMapName          = "monitoring-shared-config"
 	OpenShiftCustomLogoConfigMapName          = "custom-logo"
 	TrustedCAConfigMapName                    = "trusted-ca-bundle"
 	TrustedCABundleKey                        = "ca-bundle.crt"

--- a/pkg/console/operator/sync_v400.go
+++ b/pkg/console/operator/sync_v400.go
@@ -395,10 +395,17 @@ func (co *consoleOperator) SyncConfigMap(
 	if managedClusterConfigMap != nil {
 		managedClusterConfigFile = fmt.Sprintf("%v/%v", api.ManagedClusterConfigMountDir, api.ManagedClusterConfigKey)
 	}
+
+	monitoringSharedConfig, mscErr := co.configMapClient.ConfigMaps(api.OpenShiftConfigManagedNamespace).Get(ctx, api.OpenShiftMonitoringConfigMapName, metav1.GetOptions{})
+	if mscErr != nil && !apierrors.IsNotFound(mscErr) {
+		return nil, false, "FailedGetMonitoringSharedConfig", mscErr
+	}
+
 	defaultConfigmap, _, err := configmapsub.DefaultConfigMap(
 		operatorConfig,
 		consoleConfig,
 		managedConfig,
+		monitoringSharedConfig,
 		infrastructureConfig,
 		activeConsoleRoute,
 		useDefaultCAFile,

--- a/pkg/console/subresource/configmap/configmap.go
+++ b/pkg/console/subresource/configmap/configmap.go
@@ -44,6 +44,7 @@ func DefaultConfigMap(
 	operatorConfig *operatorv1.Console,
 	consoleConfig *configv1.Console,
 	managedConfig *corev1.ConfigMap,
+	monitoringSharedConfig *corev1.ConfigMap,
 	infrastructureConfig *configv1.Infrastructure,
 	activeConsoleRoute *routev1.Route,
 	useDefaultCAFile bool,
@@ -59,6 +60,7 @@ func DefaultConfigMap(
 		DocURL(DEFAULT_DOC_URL).
 		OAuthServingCert(useDefaultCAFile).
 		APIServerURL(getApiUrl(infrastructureConfig)).
+		Monitoring(monitoringSharedConfig).
 		InactivityTimeout(inactivityTimeoutSeconds).
 		ReleaseVersion().
 		ConfigYAML()
@@ -76,6 +78,7 @@ func DefaultConfigMap(
 		OAuthServingCert(useDefaultCAFile).
 		APIServerURL(getApiUrl(infrastructureConfig)).
 		TopologyMode(infrastructureConfig.Status.ControlPlaneTopology).
+		Monitoring(monitoringSharedConfig).
 		Plugins(getPluginsEndpointMap(availablePlugins)).
 		I18nNamespaces(pluginsWithI18nNamespace(availablePlugins)).
 		Proxy(getPluginsProxyServices(availablePlugins)).

--- a/pkg/console/subresource/configmap/configmap_test.go
+++ b/pkg/console/subresource/configmap/configmap_test.go
@@ -52,6 +52,7 @@ func TestDefaultConfigMap(t *testing.T) {
 		operatorConfig           *operatorv1.Console
 		consoleConfig            *configv1.Console
 		managedConfig            *corev1.ConfigMap
+		monitoringSharedConfig   *corev1.ConfigMap
 		infrastructureConfig     *configv1.Infrastructure
 		rt                       *routev1.Route
 		useDefaultCAFile         bool
@@ -799,6 +800,73 @@ providers: {}
 				},
 			},
 		},
+		{
+			name: "Test default configmap with monitoring config",
+			args: args{
+				operatorConfig: &operatorv1.Console{},
+				consoleConfig:  &configv1.Console{},
+				managedConfig:  &corev1.ConfigMap{},
+				infrastructureConfig: &configv1.Infrastructure{
+					Status: configv1.InfrastructureStatus{
+						APIServerURL:         mockAPIServer,
+						ControlPlaneTopology: configv1.HighlyAvailableTopologyMode,
+					},
+				},
+				rt: &routev1.Route{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: api.OpenShiftConsoleName,
+					},
+					Spec: routev1.RouteSpec{
+						Host: host,
+					},
+				},
+				useDefaultCAFile:         true,
+				inactivityTimeoutSeconds: 0,
+				managedClusterConfigFile: "",
+				monitoringSharedConfig: &corev1.ConfigMap{
+					Data: map[string]string{
+						"alertmanagerUserWorkloadHost": "alertmanager-user-workload.openshift-user-workload-monitoring.svc:9094",
+						"alertmanagerTenancyHost":      "alertmanager-user-workload.openshift-user-workload-monitoring.svc:9092",
+					},
+				},
+			},
+			want: &corev1.ConfigMap{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "ConfigMap",
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        api.OpenShiftConsoleConfigMapName,
+					Namespace:   api.OpenShiftConsoleNamespace,
+					Labels:      map[string]string{"app": api.OpenShiftConsoleName},
+					Annotations: map[string]string{},
+				},
+				Data: map[string]string{configKey: `kind: ConsoleConfig
+apiVersion: console.openshift.io/v1
+auth:
+  clientID: console
+  clientSecretFile: /var/oauth-config/clientSecret
+  oauthEndpointCAFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+clusterInfo:
+  consoleBaseAddress: https://` + host + `
+  masterPublicURL: ` + mockAPIServer + `
+  controlPlaneTopology: HighlyAvailable
+  releaseVersion: ` + testReleaseVersion + `
+customization:
+  branding: ` + DEFAULT_BRAND + `
+  documentationBaseURL: ` + DEFAULT_DOC_URL + `
+monitoringInfo:
+  alertmanagerTenancyHost: alertmanager-user-workload.openshift-user-workload-monitoring.svc:9092
+  alertmanagerUserWorkloadHost: alertmanager-user-workload.openshift-user-workload-monitoring.svc:9094
+servingInfo:
+  bindAddress: https://[::]:8443
+  certFile: /var/serving-cert/tls.crt
+  keyFile: /var/serving-cert/tls.key
+providers: {}
+`,
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -806,6 +874,7 @@ providers: {}
 				tt.args.operatorConfig,
 				tt.args.consoleConfig,
 				tt.args.managedConfig,
+				tt.args.monitoringSharedConfig,
 				tt.args.infrastructureConfig,
 				tt.args.rt,
 				tt.args.useDefaultCAFile,

--- a/pkg/console/subresource/consoleserver/config_builder.go
+++ b/pkg/console/subresource/consoleserver/config_builder.go
@@ -8,6 +8,7 @@ import (
 	"github.com/openshift/console-operator/pkg/api"
 	"github.com/openshift/console-operator/pkg/console/subresource/util"
 	"gopkg.in/yaml.v2"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
 )
 
@@ -46,6 +47,7 @@ type ConsoleServerCLIConfigBuilder struct {
 	addPage                    operatorv1.AddPage
 	customLogoFile             string
 	CAFile                     string
+	monitoring                 map[string]string
 	customHostnameRedirectPort int
 	inactivityTimeoutSeconds   int
 	pluginsList                map[string]string
@@ -129,6 +131,13 @@ func (b *ConsoleServerCLIConfigBuilder) OAuthServingCert(useDefaultCAFile bool) 
 	return b
 }
 
+func (b *ConsoleServerCLIConfigBuilder) Monitoring(monitoringConfig *corev1.ConfigMap) *ConsoleServerCLIConfigBuilder {
+	if monitoringConfig != nil {
+		b.monitoring = monitoringConfig.Data
+	}
+	return b
+}
+
 func (b *ConsoleServerCLIConfigBuilder) InactivityTimeout(timeout int) *ConsoleServerCLIConfigBuilder {
 	b.inactivityTimeoutSeconds = timeout
 	return b
@@ -173,6 +182,7 @@ func (b *ConsoleServerCLIConfigBuilder) Config() Config {
 		Customization:            b.customization(),
 		ServingInfo:              b.servingInfo(),
 		Providers:                b.providers(),
+		MonitoringInfo:           b.monitoringInfo(),
 		Plugins:                  b.plugins(),
 		I18nNamespaces:           b.i18nNamespaces(),
 		Proxy:                    b.proxy(),
@@ -222,6 +232,34 @@ func (b *ConsoleServerCLIConfigBuilder) clusterInfo() ClusterInfo {
 	if len(b.releaseVersion) > 0 {
 		conf.ReleaseVersion = b.releaseVersion
 	}
+	return conf
+}
+
+func (b *ConsoleServerCLIConfigBuilder) monitoringInfo() MonitoringInfo {
+	conf := MonitoringInfo{}
+	if len(b.monitoring) == 0 {
+		return conf
+	}
+
+	m, err := yaml.Marshal(b.monitoring)
+	if err != nil {
+		return conf
+	}
+
+	var monitoringInfo MonitoringInfo
+	err = yaml.Unmarshal(m, &monitoringInfo)
+	if err != nil {
+		return conf
+	}
+
+	if len(monitoringInfo.AlertmanagerUserWorkloadHost) > 0 {
+		conf.AlertmanagerUserWorkloadHost = monitoringInfo.AlertmanagerUserWorkloadHost
+	}
+
+	if len(monitoringInfo.AlertmanagerTenancyHost) > 0 {
+		conf.AlertmanagerTenancyHost = monitoringInfo.AlertmanagerTenancyHost
+	}
+
 	return conf
 }
 

--- a/pkg/console/subresource/consoleserver/config_builder_test.go
+++ b/pkg/console/subresource/consoleserver/config_builder_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/go-test/deep"
 	v1 "github.com/openshift/api/operator/v1"
 	"github.com/openshift/console-operator/pkg/api"
+	corev1 "k8s.io/api/core/v1"
 )
 
 // Tests that the builder will return a correctly structured
@@ -415,6 +416,42 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 				Providers:     Providers{},
 				Telemetry: map[string]string{
 					"a-key": "a-value",
+				},
+			},
+		},
+		{
+			name: "Config builder should pass monitoring info",
+			input: func() Config {
+				b := &ConsoleServerCLIConfigBuilder{}
+				b.Monitoring(&corev1.ConfigMap{
+					Data: map[string]string{
+						"alertmanagerUserWorkloadHost": "alertmanager-user-workload.openshift-user-workload-monitoring.svc:9094",
+						"alertmanagerTenancyHost":      "alertmanager-user-workload.openshift-user-workload-monitoring.svc:9092",
+					},
+				})
+				return b.Config()
+			},
+			output: Config{
+				Kind:       "ConsoleConfig",
+				APIVersion: "console.openshift.io/v1",
+				ServingInfo: ServingInfo{
+					BindAddress: "https://[::]:8443",
+					CertFile:    certFilePath,
+					KeyFile:     keyFilePath,
+				},
+				ClusterInfo: ClusterInfo{
+					ConsoleBasePath: "",
+				},
+				Auth: Auth{
+					ClientID:            api.OpenShiftConsoleName,
+					ClientSecretFile:    clientSecretFilePath,
+					OAuthEndpointCAFile: oauthEndpointCAFilePath,
+				},
+				Customization: Customization{},
+				Providers:     Providers{},
+				MonitoringInfo: MonitoringInfo{
+					AlertmanagerUserWorkloadHost: "alertmanager-user-workload.openshift-user-workload-monitoring.svc:9094",
+					AlertmanagerTenancyHost:      "alertmanager-user-workload.openshift-user-workload-monitoring.svc:9092",
 				},
 			},
 		},

--- a/pkg/console/subresource/consoleserver/types.go
+++ b/pkg/console/subresource/consoleserver/types.go
@@ -22,6 +22,7 @@ type Config struct {
 	Auth                     `yaml:"auth"`
 	Customization            `yaml:"customization"`
 	Providers                `yaml:"providers"`
+	MonitoringInfo           `yaml:"monitoringInfo,omitempty"`
 	Plugins                  map[string]string `yaml:"plugins,omitempty"`
 	I18nNamespaces           []string          `yaml:"i18nNamespaces,omitempty"`
 	Proxy                    Proxy             `yaml:"proxy,omitempty"`
@@ -65,6 +66,12 @@ type ClusterInfo struct {
 	MasterPublicURL     string                `yaml:"masterPublicURL,omitempty"`
 	ControlPlaneToplogy configv1.TopologyMode `yaml:"controlPlaneTopology,omitempty"`
 	ReleaseVersion      string                `yaml:"releaseVersion,omitempty"`
+}
+
+// MonitoringInfo holds configuration for monitoring related services
+type MonitoringInfo struct {
+	AlertmanagerUserWorkloadHost string `yaml:"alertmanagerUserWorkloadHost,omitempty"`
+	AlertmanagerTenancyHost      string `yaml:"alertmanagerTenancyHost,omitempty"`
 }
 
 // Auth holds configuration for authenticating with OpenShift. The auth method is assumed to be "openshift".


### PR DESCRIPTION
https://issues.redhat.com/browse/MON-2289

Requires https://github.com/openshift/cluster-monitoring-operator/pull/1690
Required by https://github.com/openshift/console/pull/11712