### PR TITLE
Bug 2021297: Pass RELEASE_VERSION envar into the console pod

### DIFF
--- a/pkg/console/subresource/configmap/configmap.go
+++ b/pkg/console/subresource/configmap/configmap.go
@@ -60,6 +60,7 @@ func DefaultConfigMap(
 		OAuthServingCert(useDefaultCAFile).
 		APIServerURL(getApiUrl(infrastructureConfig)).
 		InactivityTimeout(inactivityTimeoutSeconds).
+		ReleaseVersion().
 		ConfigYAML()
 	if err != nil {
 		klog.Errorf("failed to generate default console-config config: %v", err)
@@ -89,6 +90,7 @@ func DefaultConfigMap(
 		InactivityTimeout(inactivityTimeoutSeconds).
 		ManagedClusterConfigFile(managedClusterConfigFile).
 		TelemetryConfiguration(GetTelemetryConfiguration(operatorConfig)).
+		ReleaseVersion().
 		ConfigYAML()
 	if err != nil {
 		klog.Errorf("failed to generate user defined console-config config: %v", err)

--- a/pkg/console/subresource/configmap/configmap_test.go
+++ b/pkg/console/subresource/configmap/configmap_test.go
@@ -26,6 +26,7 @@ const (
 	mockConsoleURL     = "https://console-openshift-console.apps.some.cluster.openshift.com"
 	configKey          = "console-config.yaml"
 	mockOperatorDocURL = "https://operator.config/doc/link/"
+	testReleaseVersion = "testReleaseVersion"
 	test               = 123
 
 	validCertificate = `-----BEGIN CERTIFICATE-----
@@ -58,6 +59,7 @@ func TestDefaultConfigMap(t *testing.T) {
 		availablePlugins         []*v1alpha1.ConsolePlugin
 		managedClusterConfigFile string
 	}
+	t.Setenv("RELEASE_VERSION", testReleaseVersion)
 	tests := []struct {
 		name string
 		args args
@@ -108,6 +110,7 @@ clusterInfo:
   consoleBaseAddress: https://` + host + `
   masterPublicURL: ` + mockAPIServer + `
   controlPlaneTopology: HighlyAvailable
+  releaseVersion: ` + testReleaseVersion + `
 customization:
   branding: ` + DEFAULT_BRAND + `
   documentationBaseURL: ` + DEFAULT_DOC_URL + `
@@ -163,6 +166,7 @@ auth:
 clusterInfo:
   consoleBaseAddress: https://` + host + `
   masterPublicURL: ` + mockAPIServer + `
+  releaseVersion: ` + testReleaseVersion + `
 customization:
   branding: ` + DEFAULT_BRAND + `
   documentationBaseURL: ` + DEFAULT_DOC_URL + `
@@ -226,6 +230,7 @@ auth:
 clusterInfo:
   consoleBaseAddress: https://` + host + `
   masterPublicURL: ` + mockAPIServer + `
+  releaseVersion: ` + testReleaseVersion + `
 customization:
   branding: online
   documentationBaseURL: https://docs.okd.io/4.4/
@@ -298,6 +303,7 @@ auth:
 clusterInfo:
   consoleBaseAddress: https://` + host + `
   masterPublicURL: ` + mockAPIServer + `
+  releaseVersion: ` + testReleaseVersion + `
 customization:
   branding: ` + string(operatorv1.BrandDedicated) + `
   documentationBaseURL: ` + mockOperatorDocURL + `
@@ -375,6 +381,7 @@ auth:
 clusterInfo:
   consoleBaseAddress: https://` + host + `
   masterPublicURL: ` + mockAPIServer + `
+  releaseVersion: ` + testReleaseVersion + `
 customization:
   branding: ` + string(operatorv1.BrandDedicated) + `
   documentationBaseURL: ` + mockOperatorDocURL + `
@@ -454,6 +461,7 @@ auth:
 clusterInfo:
   consoleBaseAddress: https://` + host + `
   masterPublicURL: ` + mockAPIServer + `
+  releaseVersion: ` + testReleaseVersion + `
 customization:
   branding: ` + string(operatorv1.BrandDedicated) + `
   documentationBaseURL: ` + mockOperatorDocURL + `
@@ -516,6 +524,7 @@ auth:
 clusterInfo:
   consoleBaseAddress: https://` + customHostname + `
   masterPublicURL: ` + mockAPIServer + `
+  releaseVersion: ` + testReleaseVersion + `
 customization:
   branding: ` + DEFAULT_BRAND + `
   documentationBaseURL: ` + DEFAULT_DOC_URL + `
@@ -573,6 +582,7 @@ auth:
 clusterInfo:
   consoleBaseAddress: https://` + host + `
   masterPublicURL: ` + mockAPIServer + `
+  releaseVersion: ` + testReleaseVersion + `
 customization:
   branding: ` + DEFAULT_BRAND + `
   documentationBaseURL: ` + DEFAULT_DOC_URL + `
@@ -628,6 +638,7 @@ auth:
 clusterInfo:
   consoleBaseAddress: https://` + host + `
   masterPublicURL: ` + mockAPIServer + `
+  releaseVersion: ` + testReleaseVersion + `
 customization:
   branding: ` + DEFAULT_BRAND + `
   documentationBaseURL: ` + DEFAULT_DOC_URL + `
@@ -690,6 +701,7 @@ auth:
 clusterInfo:
   consoleBaseAddress: https://` + host + `
   masterPublicURL: ` + mockAPIServer + `
+  releaseVersion: ` + testReleaseVersion + `
 customization:
   branding: ` + DEFAULT_BRAND + `
   documentationBaseURL: ` + DEFAULT_DOC_URL + `
@@ -774,6 +786,7 @@ clusterInfo:
   consoleBaseAddress: https://` + host + `
   masterPublicURL: ` + mockAPIServer + `
   controlPlaneTopology: External
+  releaseVersion: ` + testReleaseVersion + `
 customization:
   branding: ` + DEFAULT_BRAND + `
   documentationBaseURL: ` + DEFAULT_DOC_URL + `

--- a/pkg/console/subresource/consoleserver/config_builder.go
+++ b/pkg/console/subresource/consoleserver/config_builder.go
@@ -1,6 +1,8 @@
 package consoleserver
 
 import (
+	"os"
+
 	configv1 "github.com/openshift/api/config/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	"github.com/openshift/console-operator/pkg/api"
@@ -51,6 +53,7 @@ type ConsoleServerCLIConfigBuilder struct {
 	proxyServices              []ProxyService
 	managedClusterConfigFile   string
 	telemetry                  map[string]string
+	releaseVersion             string
 }
 
 func (b *ConsoleServerCLIConfigBuilder) Host(host string) *ConsoleServerCLIConfigBuilder {
@@ -156,6 +159,11 @@ func (b *ConsoleServerCLIConfigBuilder) TelemetryConfiguration(telemetry map[str
 	return b
 }
 
+func (b *ConsoleServerCLIConfigBuilder) ReleaseVersion() *ConsoleServerCLIConfigBuilder {
+	b.releaseVersion = os.Getenv("RELEASE_VERSION")
+	return b
+}
+
 func (b *ConsoleServerCLIConfigBuilder) Config() Config {
 	return Config{
 		Kind:                     "ConsoleConfig",
@@ -210,6 +218,9 @@ func (b *ConsoleServerCLIConfigBuilder) clusterInfo() ClusterInfo {
 	}
 	if len(b.controlPlaneToplogy) > 0 {
 		conf.ControlPlaneToplogy = b.controlPlaneToplogy
+	}
+	if len(b.releaseVersion) > 0 {
+		conf.ReleaseVersion = b.releaseVersion
 	}
 	return conf
 }

--- a/pkg/console/subresource/consoleserver/types.go
+++ b/pkg/console/subresource/consoleserver/types.go
@@ -64,6 +64,7 @@ type ClusterInfo struct {
 	ConsoleBasePath     string                `yaml:"consoleBasePath,omitempty"`
 	MasterPublicURL     string                `yaml:"masterPublicURL,omitempty"`
 	ControlPlaneToplogy configv1.TopologyMode `yaml:"controlPlaneTopology,omitempty"`
+	ReleaseVersion      string                `yaml:"releaseVersion,omitempty"`
 }
 
 // Auth holds configuration for authenticating with OpenShift. The auth method is assumed to be "openshift".


### PR DESCRIPTION
We should be passing the RELEASE_VERSION envar into the console so we can then use is for [implementing dynamic plugin dependency resolution](https://github.com/openshift/console/pull/11626).

To achieve this we could:
1. Pass the RELEASE_VERSION envar into the console pod, so we so console backend can read it as a envar
2. We could be publishing the RELEASE_VERSION var into the console-config.yaml so the console server will read the variable and add it to `SERVER_FLAGS`. 

Based on [slack conversation](https://coreos.slack.com/archives/C011BL0FEKZ/p1653600473874119?thread_ts=1653599045.025239&cid=C011BL0FEKZ)

/assign @TheRealJon 
@vojtechszocs @spadgett FYI