### PR TITLE
Bug 2089950: Deleting downloads deployment should not fail if already deleted

### DIFF
--- a/pkg/console/controllers/downloadsdeployment/controller.go
+++ b/pkg/console/controllers/downloadsdeployment/controller.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	appsinformersv1 "k8s.io/client-go/informers/apps/v1"
 	appsclientv1 "k8s.io/client-go/kubernetes/typed/apps/v1"
@@ -130,5 +131,9 @@ func (c *DownloadsDeploymentSyncController) SyncDownloadsDeployment(ctx context.
 }
 
 func (c *DownloadsDeploymentSyncController) removeDownloadsDeployment(ctx context.Context) error {
-	return c.deploymentClient.Deployments(api.OpenShiftConsoleNamespace).Delete(ctx, api.OpenShiftConsoleDownloadsDeploymentName, metav1.DeleteOptions{})
+	err := c.deploymentClient.Deployments(api.OpenShiftConsoleNamespace).Delete(ctx, api.OpenShiftConsoleDownloadsDeploymentName, metav1.DeleteOptions{})
+	if apierrors.IsNotFound(err) {
+		return nil
+	}
+	return err
 }


### PR DESCRIPTION
When the console-operator is in `Removed` state and the cluster is getting upgraded, the `ConsoleDownloadsDeploymentSyncController` is failing since it's trying to remove the deployment thats already gone. We should not error out.

```
2022-05-24T14:25:14.277200211Z E0524 14:25:14.277137       1 base_controller.go:272] ConsoleDownloadsDeploymentSyncController reconciliation failed: deployments.apps "downloads" not found
2022-05-24T14:25:24.526363410Z E0524 14:25:24.526308       1 base_controller.go:272] ConsoleDownloadsDeploymentSyncController reconciliation failed: deployments.apps "downloads" not found
2022-05-24T14:25:43.091148770Z I0524 14:25:43.090952       1 operator.go:257] deleting console resources
2022-05-24T14:25:43.116870499Z I0524 14:25:43.116796       1 operator.go:286] finished deleting console resources
2022-05-24T14:25:45.013569190Z E0524 14:25:45.013498       1 base_controller.go:272] ConsoleDownloadsDeploymentSyncController reconciliation failed: deployments.apps "downloads" not found
2022-05-24T14:26:03.438953369Z E0524 14:26:03.438369       1 base_controller.go:272] ConsoleDownloadsDeploymentSyncController reconciliation failed: deployments.apps "downloads" not found
2022-05-24T14:26:03.456702148Z I0524 14:26:03.456639       1 operator.go:257] deleting console resources
2022-05-24T14:26:03.488375037Z I0524 14:26:03.488310       1 operator.go:286] finished deleting console resources
2022-05-24T14:26:25.982125914Z E0524 14:26:25.981785       1 base_controller.go:272] ConsoleDownloadsDeploymentSyncController reconciliation failed: deployments.apps "downloads" not found
2022-05-24T14:27:03.442175603Z E0524 14:27:03.441850       1 base_controller.go:272] ConsoleDownloadsDeploymentSyncController reconciliation failed: deployments.apps "downloads" not found
```

/assign @TheRealJon 
/cherry-pick release-4.11