### PR TITLE
Bug 2117142: Update permission for projecthelmchartrepositories with an aggregator role

### DIFF
--- a/manifests/03-rbac-role-cluster.yaml
+++ b/manifests/03-rbac-role-cluster.yaml
@@ -156,3 +156,24 @@ rules:
       - watch
       - create
       - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: project-helm-chartrepository-editor
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+rules:
+- apiGroups:
+  - helm.openshift.io
+  resources:
+  - projecthelmchartrepositories
+  verbs:
+  - get
+  - list
+  - update
+  - create
+  - watch 
+  - patch
+  - delete


### PR DESCRIPTION
This PR updates the permission change for Project Helm Chart Repository . The PR aims to aggregate the admin and edit cluster role with ability to perform actions on ProjectHelmChartRepository.


Signed-off-by: Kartikey Mamgain <mamgainkartikey@gmail.com>