### PR TITLE
CONSOLE-3242: Heterogeneous architecture clusters

### DIFF
--- a/manifests/03-rbac-role-cluster.yaml
+++ b/manifests/03-rbac-role-cluster.yaml
@@ -8,6 +8,14 @@ metadata:
     include.release.openshift.io/single-node-developer: "true"
 rules:
   - apiGroups:
+    - ""
+    resources:
+    - nodes
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
       - oauth.openshift.io
     resources:
       - oauthclients

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -58,6 +58,8 @@ const (
 
 	PluginI18nAnnotation = "console.openshift.io/use-i18n"
 
+	NodeArchitectureLabel = "kubernetes.io/arch"
+
 	ManagedClusterViewAPIGroup     = "view.open-cluster-management.io"
 	ManagedClusterViewAPIVersion   = "v1beta1"
 	ManagedClusterViewResource     = "managedclusterviews"

--- a/pkg/console/operator/operator.go
+++ b/pkg/console/operator/operator.go
@@ -59,6 +59,7 @@ type consoleOperator struct {
 	secretsClient    coreclientv1.SecretsGetter
 	configMapClient  coreclientv1.ConfigMapsGetter
 	serviceClient    coreclientv1.ServicesGetter
+	nodeClient       coreclientv1.NodesGetter
 	deploymentClient appsclientv1.DeploymentsGetter
 	// openshift
 	routeClient   routeclientv1.RoutesGetter
@@ -113,6 +114,7 @@ func NewConsoleOperator(
 		secretsClient:    corev1Client,
 		configMapClient:  corev1Client,
 		serviceClient:    corev1Client,
+		nodeClient:       corev1Client,
 		deploymentClient: deploymentClient,
 		// openshift
 		routeClient:   routev1Client,
@@ -128,6 +130,7 @@ func NewConsoleOperator(
 	configMapInformer := coreV1.ConfigMaps()
 	managedConfigMapInformer := managedCoreV1.ConfigMaps()
 	serviceInformer := coreV1.Services()
+	nodeInformer := coreV1.Nodes()
 	configV1Informers := configInformer.Config().V1()
 	configNameFilter := util.IncludeNamesFilter(api.ConfigResourceName)
 	targetNameFilter := util.IncludeNamesFilter(api.OpenShiftConsoleName)
@@ -148,6 +151,7 @@ func NewConsoleOperator(
 		serviceInformer.Informer(),
 		oauthClients.Informer(),
 	).WithInformers(
+		nodeInformer.Informer(),
 		consolePluginInformer.Informer(),
 	).WithFilteredEventsInformers(
 		util.LabelFilter(map[string]string{"app": "console"}),

--- a/pkg/console/subresource/configmap/configmap.go
+++ b/pkg/console/subresource/configmap/configmap.go
@@ -50,6 +50,7 @@ func DefaultConfigMap(
 	inactivityTimeoutSeconds int,
 	availablePlugins []*v1alpha1.ConsolePlugin,
 	managedClusterConfigFile string,
+	nodeArchitectures []string,
 ) (consoleConfigMap *corev1.ConfigMap, unsupportedOverridesHaveMerged bool, err error) {
 
 	defaultBuilder := &consoleserver.ConsoleServerCLIConfigBuilder{}
@@ -61,6 +62,7 @@ func DefaultConfigMap(
 		APIServerURL(getApiUrl(infrastructureConfig)).
 		InactivityTimeout(inactivityTimeoutSeconds).
 		ReleaseVersion().
+		NodesArchitecture(nodeArchitectures).
 		ConfigYAML()
 	if err != nil {
 		klog.Errorf("failed to generate default console-config config: %v", err)
@@ -91,6 +93,7 @@ func DefaultConfigMap(
 		ManagedClusterConfigFile(managedClusterConfigFile).
 		TelemetryConfiguration(GetTelemetryConfiguration(operatorConfig)).
 		ReleaseVersion().
+		NodesArchitecture(nodeArchitectures).
 		ConfigYAML()
 	if err != nil {
 		klog.Errorf("failed to generate user defined console-config config: %v", err)

--- a/pkg/console/subresource/configmap/configmap_test.go
+++ b/pkg/console/subresource/configmap/configmap_test.go
@@ -58,6 +58,7 @@ func TestDefaultConfigMap(t *testing.T) {
 		inactivityTimeoutSeconds int
 		availablePlugins         []*v1alpha1.ConsolePlugin
 		managedClusterConfigFile string
+		nodeArchitectures        []string
 	}
 	t.Setenv("RELEASE_VERSION", testReleaseVersion)
 	tests := []struct {
@@ -209,6 +210,7 @@ customization:
 				useDefaultCAFile:         true,
 				inactivityTimeoutSeconds: 0,
 				managedClusterConfigFile: "",
+				nodeArchitectures:        []string{"amd64", "arm64"},
 			},
 			want: &corev1.ConfigMap{
 				TypeMeta: metav1.TypeMeta{
@@ -231,6 +233,9 @@ clusterInfo:
   consoleBaseAddress: https://` + host + `
   masterPublicURL: ` + mockAPIServer + `
   releaseVersion: ` + testReleaseVersion + `
+  nodeArchitectures:
+  - amd64
+  - arm64
 customization:
   branding: online
   documentationBaseURL: https://docs.okd.io/4.4/
@@ -812,6 +817,7 @@ providers: {}
 				tt.args.inactivityTimeoutSeconds,
 				tt.args.availablePlugins,
 				tt.args.managedClusterConfigFile,
+				tt.args.nodeArchitectures,
 			)
 
 			// marshall the exampleYaml to map[string]interface{} so we can use it in diff below

--- a/pkg/console/subresource/consoleserver/config_builder.go
+++ b/pkg/console/subresource/consoleserver/config_builder.go
@@ -25,12 +25,17 @@ const (
 //
 // b := ConsoleYamlConfigBuilder{}
 // return the default config value immediately:
-//   b.Config()
-//   b.ConfigYAML()
+//
+//	b.Config()
+//	b.ConfigYAML()
+//
 // set all the values:
-//   b.Host(host).LogoutURL("").Brand("").DocURL("").APIServerURL("").Config()
+//
+//	b.Host(host).LogoutURL("").Brand("").DocURL("").APIServerURL("").Config()
+//
 // set only some values:
-//   b.Host().Brand("").Config()
+//
+//	b.Host().Brand("").Config()
 type ConsoleServerCLIConfigBuilder struct {
 	host                       string
 	logoutRedirectURL          string
@@ -54,6 +59,7 @@ type ConsoleServerCLIConfigBuilder struct {
 	managedClusterConfigFile   string
 	telemetry                  map[string]string
 	releaseVersion             string
+	nodeArchitectures          []string
 }
 
 func (b *ConsoleServerCLIConfigBuilder) Host(host string) *ConsoleServerCLIConfigBuilder {
@@ -164,6 +170,11 @@ func (b *ConsoleServerCLIConfigBuilder) ReleaseVersion() *ConsoleServerCLIConfig
 	return b
 }
 
+func (b *ConsoleServerCLIConfigBuilder) NodesArchitecture(architectures []string) *ConsoleServerCLIConfigBuilder {
+	b.nodeArchitectures = architectures
+	return b
+}
+
 func (b *ConsoleServerCLIConfigBuilder) Config() Config {
 	return Config{
 		Kind:                     "ConsoleConfig",
@@ -221,6 +232,9 @@ func (b *ConsoleServerCLIConfigBuilder) clusterInfo() ClusterInfo {
 	}
 	if len(b.releaseVersion) > 0 {
 		conf.ReleaseVersion = b.releaseVersion
+	}
+	if len(b.nodeArchitectures) > 0 {
+		conf.NodeArchitectures = b.nodeArchitectures
 	}
 	return conf
 }

--- a/pkg/console/subresource/consoleserver/types.go
+++ b/pkg/console/subresource/consoleserver/types.go
@@ -65,6 +65,7 @@ type ClusterInfo struct {
 	MasterPublicURL     string                `yaml:"masterPublicURL,omitempty"`
 	ControlPlaneToplogy configv1.TopologyMode `yaml:"controlPlaneTopology,omitempty"`
 	ReleaseVersion      string                `yaml:"releaseVersion,omitempty"`
+	NodeArchitectures   []string              `yaml:"nodeArchitectures,omitempty"`
 }
 
 // Auth holds configuration for authenticating with OpenShift. The auth method is assumed to be "openshift".


### PR DESCRIPTION
Implementing https://issues.redhat.com/browse/CONSOLE-3242

Implement logic in the console-operator that will scan though all the nodes and build a set of all the architecture types that the cluster nodes run on and pass it to the `console-config.yaml`