### PR TITLE
Bug 2117142:update annotations for project-helm-chartrepository-editor

### DIFF
--- a/manifests/03-rbac-role-cluster.yaml
+++ b/manifests/03-rbac-role-cluster.yaml
@@ -161,6 +161,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: project-helm-chartrepository-editor
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
   labels:
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-admin: "true"


### PR DESCRIPTION
This PR updates the annotations which support the cluster role project-helm-chartrepository-editor to be created. This PR is in addition to https://github.com/openshift/console-operator/pull/667 , as the cluster role is not getting created by the operator.
Signed-off-by: Kartikey Mamgain <mamgainkartikey@gmail.com>