### PR TITLE
CONSOLE-3125: Add cluster filtering by product and ocp version

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -60,12 +60,14 @@ const (
 
 	NodeArchitectureLabel = "kubernetes.io/arch"
 
-	ManagedClusterViewAPIGroup     = "view.open-cluster-management.io"
-	ManagedClusterViewAPIVersion   = "v1beta1"
-	ManagedClusterViewResource     = "managedclusterviews"
-	ManagedClusterActionAPIGroup   = "action.open-cluster-management.io"
-	ManagedClusterActionAPIVersion = "v1beta1"
-	ManagedClusterActionResource   = "managedclusteractions"
+	ManagedClusterViewAPIGroup           = "view.open-cluster-management.io"
+	ManagedClusterViewAPIVersion         = "v1beta1"
+	ManagedClusterViewResource           = "managedclusterviews"
+	ManagedClusterActionAPIGroup         = "action.open-cluster-management.io"
+	ManagedClusterActionAPIVersion       = "v1beta1"
+	ManagedClusterActionResource         = "managedclusteractions"
+	ManagedClusterClaimVersionAnnotation = "version.openshift.io"
+	ManagedClusterClaimProductAnnotation = "product.open-cluster-management.io"
 
 	ConsoleContainerPortName    = "https"
 	ConsoleContainerPort        = 443
@@ -90,3 +92,6 @@ var (
 		Resource: ManagedClusterActionResource,
 	}
 )
+
+// List of products we support for managed clusters (under the claims "product.open-cluster-management.io")
+var SupportedClusterProducts = []string{"OpenShift", "ROSA", "ARO", "ROKS", "OpenShiftDedicated"}

--- a/pkg/console/controllers/managedclusters/controller_test.go
+++ b/pkg/console/controllers/managedclusters/controller_test.go
@@ -1,0 +1,84 @@
+package managedcluster
+
+import (
+	"testing"
+
+	"github.com/go-test/deep"
+
+	v1 "github.com/open-cluster-management/api/cluster/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func generateClusters(t *testing.T) []v1.ManagedCluster {
+
+	clusters := []v1.ManagedCluster{}
+
+	cluster1 := v1.ManagedCluster{}
+	cluster1.ObjectMeta = metav1.ObjectMeta{Name: "ProductAKSVer412"}
+	cluster1.Status = v1.ManagedClusterStatus{
+		ClusterClaims: []v1.ManagedClusterClaim{
+			{Name: "product.open-cluster-management.io", Value: "AKS"},
+			{Name: "version.openshift.io", Value: "4.12.0-ec.1"},
+		},
+	}
+
+	clusters = append(clusters, cluster1)
+
+	cluster2 := v1.ManagedCluster{}
+	cluster2.ObjectMeta = metav1.ObjectMeta{Name: "ProductOpenshiftVer49"}
+	cluster2.Status = v1.ManagedClusterStatus{
+		ClusterClaims: []v1.ManagedClusterClaim{
+			{Name: "product.open-cluster-management.io", Value: "OpenShift"},
+			{Name: "version.openshift.io", Value: "4.9.0-ec.1"},
+		},
+	}
+	clusters = append(clusters, cluster2)
+
+	cluster3 := v1.ManagedCluster{}
+	cluster3.ObjectMeta = metav1.ObjectMeta{Name: "ProductOpenshiftVer39"}
+	cluster3.Status = v1.ManagedClusterStatus{
+		ClusterClaims: []v1.ManagedClusterClaim{
+			{Name: "product.open-cluster-management.io", Value: "OpenShift"},
+			{Name: "version.openshift.io", Value: "3.9"},
+		},
+	}
+	clusters = append(clusters, cluster3)
+
+	cluster4 := v1.ManagedCluster{}
+	cluster4.ObjectMeta = metav1.ObjectMeta{Name: "ProductEKSVer311"}
+	cluster4.Status = v1.ManagedClusterStatus{
+		ClusterClaims: []v1.ManagedClusterClaim{
+			{Name: "product.open-cluster-management.io", Value: "EKS"},
+			{Name: "version.openshift.io", Value: "3.11.rcbeata"},
+		},
+	}
+	clusters = append(clusters, cluster4)
+
+	return clusters
+}
+
+func TestProductAndVersionCheckForClusterList(t *testing.T) {
+	expectedCluster := []string{"ProductOpenshiftVer49"}
+	clusters := generateClusters(t)
+	validClusters := []string{}
+	if len(clusters) < 1 {
+		t.Fatalf("No clusters are defined")
+	}
+	for _, managedCluster := range clusters {
+		clusterName := managedCluster.GetName()
+		validProduct, validVersion := isSupportedCluster(managedCluster.Status.ClusterClaims)
+		if !validProduct {
+			t.Logf("Skipping managed cluster %q, product is unsupported", clusterName)
+			continue
+		}
+		if !validVersion {
+			t.Logf("Skipping managed cluster %q, version is unsupported", clusterName)
+			continue
+		}
+		validClusters = append(validClusters, clusterName)
+	}
+
+	if diff := deep.Equal(validClusters, expectedCluster); diff != nil {
+		t.Error(diff)
+	}
+}

--- a/pkg/console/controllers/util/util.go
+++ b/pkg/console/controllers/util/util.go
@@ -1,9 +1,13 @@
 package util
 
 import (
+	//k8s
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/klog/v2"
 
+	//github
+	"github.com/blang/semver"
 	"github.com/openshift/library-go/pkg/controller/factory"
 )
 
@@ -36,4 +40,23 @@ func LabelFilter(labels map[string]string) factory.EventFilterFunc {
 		}
 		return true
 	}
+}
+
+// contains checks if a string is present in a slice
+func SliceContains(s []string, value string) bool {
+	for _, v := range s {
+		if v == value {
+			return true
+		}
+	}
+	return false
+}
+
+func IsSupportedVersion(productVersion string) bool {
+	version, err := semver.Parse(productVersion)
+	if err != nil {
+		klog.V(4).Infof("unable to parse %q version", productVersion)
+		return false
+	}
+	return version.Compare(semver.MustParse("4.0.0")) == 1
 }


### PR DESCRIPTION
Add ability to remove clusters from cluster list based on several criteria:
1) ~~Remove all products with *KS values:  "AKS", "EKS", "IKS", "ROKS".  Instead of using regexp of *KS, a list was made based on product name so non-KS values can be added in the future~~
UPDATE: ROKS is allowed.  Switching logic to an allow list of: OpenShift, ROSA, ARO, ROKS, and OpenShiftDedicated
2) Remove all ocp versions less than 4.0
3) This solution does not offer the option of having the console show things as disable, instead, it works with existing filters and only includes managed clusters that pass the criteria.  To get more options on the dropdown, we probably would need to pass the entire set of managedClusters to console and then filter on the frontend side.