### PR TITLE
OCPBUGS-785: Bump documentationBaseURL to 4.12

### DIFF
--- a/pkg/console/subresource/configmap/brand_ocp.go
+++ b/pkg/console/subresource/configmap/brand_ocp.go
@@ -5,5 +5,5 @@ package configmap
 
 const (
 	DEFAULT_BRAND   = "ocp"
-	DEFAULT_DOC_URL = "https://access.redhat.com/documentation/en-us/openshift_container_platform/4.11/"
+	DEFAULT_DOC_URL = "https://access.redhat.com/documentation/en-us/openshift_container_platform/4.12/"
 )


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/OCPBUGS-785

Signed-off-by: Pavel Kratochvil <pakratoc@redhat.com>