### PR TITLE
CONSOLE-3069: Handle new v1 ConsolePlugin api in the operator

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -57,7 +57,7 @@ const (
 	CreateOAuthClientManagedClusterActionName = "console-create-oauth-client"
 	OAuthServerCertManagedClusterViewName     = "console-oauth-server-cert"
 
-	PluginI18nAnnotation = "console.openshift.io/use-i18n"
+	V1Alpha1PluginI18nAnnotation = "console.openshift.io/use-i18n"
 
 	NodeArchitectureLabel = "kubernetes.io/arch"
 

--- a/pkg/cmd/crdconversionwebhook/converter/converter.go
+++ b/pkg/cmd/crdconversionwebhook/converter/converter.go
@@ -75,10 +75,10 @@ func convertPluginV1ToV1alpha1(convertedObject *unstructured.Unstructured) (*uns
 		annotations := v1Plugin.GetAnnotations()
 		if annotations == nil {
 			annotations = map[string]string{
-				api.PluginI18nAnnotation: "true",
+				api.V1Alpha1PluginI18nAnnotation: "true",
 			}
 		} else {
-			annotations[api.PluginI18nAnnotation] = "true"
+			annotations[api.V1Alpha1PluginI18nAnnotation] = "true"
 		}
 
 		v1alpha1Plugin.SetAnnotations(annotations)
@@ -149,10 +149,10 @@ func convertPluginV1alpha1ToV1(convertedObject *unstructured.Unstructured) (*uns
 
 	// i18n
 	updatedV1alpha1PluginAnnotations := v1alpha1Plugin.GetAnnotations()
-	if v := updatedV1alpha1PluginAnnotations[api.PluginI18nAnnotation]; v == "true" {
+	if v := updatedV1alpha1PluginAnnotations[api.V1Alpha1PluginI18nAnnotation]; v == "true" {
 		v1Plugin.Spec.I18n.LoadType = v1.Preload
 	}
-	delete(updatedV1alpha1PluginAnnotations, api.PluginI18nAnnotation)
+	delete(updatedV1alpha1PluginAnnotations, api.V1Alpha1PluginI18nAnnotation)
 	v1Plugin.SetAnnotations(updatedV1alpha1PluginAnnotations)
 
 	// service -> backend

--- a/pkg/console/operator/operator.go
+++ b/pkg/console/operator/operator.go
@@ -20,8 +20,8 @@ import (
 	operatorsv1 "github.com/openshift/api/operator/v1"
 	configclientv1 "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
 	configinformer "github.com/openshift/client-go/config/informers/externalversions"
-	consoleinformersv1alpha1 "github.com/openshift/client-go/console/informers/externalversions/console/v1alpha1"
-	listerv1alpha1 "github.com/openshift/client-go/console/listers/console/v1alpha1"
+	consoleinformersv1 "github.com/openshift/client-go/console/informers/externalversions/console/v1"
+	listerv1 "github.com/openshift/client-go/console/listers/console/v1"
 	oauthclientv1 "github.com/openshift/client-go/oauth/clientset/versioned/typed/oauth/v1"
 	oauthinformersv1 "github.com/openshift/client-go/oauth/informers/externalversions/oauth/v1"
 	operatorclientv1 "github.com/openshift/client-go/operator/clientset/versioned/typed/operator/v1"
@@ -66,7 +66,7 @@ type consoleOperator struct {
 	oauthClient   oauthclientv1.OAuthClientsGetter
 	versionGetter status.VersionGetter
 	// lister
-	consolePluginLister listerv1alpha1.ConsolePluginLister
+	consolePluginLister listerv1.ConsolePluginLister
 
 	resourceSyncer resourcesynccontroller.ResourceSyncer
 }
@@ -92,7 +92,7 @@ func NewConsoleOperator(
 	oauthv1Client oauthclientv1.OAuthClientsGetter,
 	oauthClients oauthinformersv1.OAuthClientInformer,
 	// plugins
-	consolePluginInformer consoleinformersv1alpha1.ConsolePluginInformer,
+	consolePluginInformer consoleinformersv1.ConsolePluginInformer,
 	// openshift managed
 	managedCoreV1 corev1.Interface,
 	// event handling

--- a/pkg/console/operator/sync_v400.go
+++ b/pkg/console/operator/sync_v400.go
@@ -17,7 +17,7 @@ import (
 
 	// openshift
 	configv1 "github.com/openshift/api/config/v1"
-	v1alpha1 "github.com/openshift/api/console/v1alpha1"
+	v1 "github.com/openshift/api/console/v1"
 	oauthv1 "github.com/openshift/api/oauth/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	routev1 "github.com/openshift/api/route/v1"
@@ -596,8 +596,8 @@ func (co *consoleOperator) ValidateCustomLogo(ctx context.Context, operatorConfi
 	return true, "", nil
 }
 
-func (co *consoleOperator) GetAvailablePlugins(enabledPluginsNames []string) []*v1alpha1.ConsolePlugin {
-	var availablePlugins []*v1alpha1.ConsolePlugin
+func (co *consoleOperator) GetAvailablePlugins(enabledPluginsNames []string) []*v1.ConsolePlugin {
+	var availablePlugins []*v1.ConsolePlugin
 	for _, pluginName := range enabledPluginsNames {
 		plugin, err := co.consolePluginLister.Get(pluginName)
 		if err != nil {

--- a/pkg/console/starter/starter.go
+++ b/pkg/console/starter/starter.go
@@ -206,7 +206,7 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 		oauthClient.OauthV1(),
 		oauthInformers.Oauth().V1().OAuthClients(), // OAuth clients
 		// plugins
-		consoleInformers.Console().V1alpha1().ConsolePlugins(),
+		consoleInformers.Console().V1().ConsolePlugins(),
 		// openshift managed
 		kubeInformersManagedNamespaced.Core().V1(), // Managed ConfigMaps
 		// event handling

--- a/test/e2e/framework/clientset.go
+++ b/test/e2e/framework/clientset.go
@@ -26,7 +26,8 @@ type ClientSet struct {
 	ConsoleExternalLogLink consoleclientv1.ConsoleExternalLogLinkInterface
 	ConsoleLink            consoleclientv1.ConsoleLinkInterface
 	ConsoleNotification    consoleclientv1.ConsoleNotificationInterface
-	ConsolePlugin          consoleclientv1alpha1.ConsolePluginInterface
+	ConsolePluginV1Alpha1  consoleclientv1alpha1.ConsolePluginInterface
+	ConsolePluginV1        consoleclientv1.ConsolePluginInterface
 	ConsoleYAMLSample      consoleclientv1.ConsoleYAMLSampleInterface
 	Operator               operatorclientv1.ConsolesGetter
 	Console                configv1.ConsolesGetter
@@ -92,7 +93,8 @@ func NewClientset(kubeconfig *restclient.Config) (*ClientSet, error) {
 	clientset.ConsoleLink = consoleClient.ConsoleLinks()
 	clientset.ConsoleNotification = consoleClient.ConsoleNotifications()
 	clientset.ConsoleYAMLSample = consoleClient.ConsoleYAMLSamples()
-	clientset.ConsolePlugin = consoleClientAlpha1.ConsolePlugins()
+	clientset.ConsolePluginV1Alpha1 = consoleClientAlpha1.ConsolePlugins()
+	clientset.ConsolePluginV1 = consoleClient.ConsolePlugins()
 
 	policyClient, err := policyv1client.NewForConfig(kubeconfig)
 	if err != nil {

--- a/test/e2e/plugins_test.go
+++ b/test/e2e/plugins_test.go
@@ -6,7 +6,8 @@ import (
 	"testing"
 	"time"
 
-	consolev1alpha "github.com/openshift/api/console/v1alpha1"
+	consolev1 "github.com/openshift/api/console/v1"
+	consolev1alpha1 "github.com/openshift/api/console/v1alpha1"
 	operatorsv1 "github.com/openshift/api/operator/v1"
 	yaml "gopkg.in/yaml.v2"
 	apiErrors "k8s.io/apimachinery/pkg/api/errors"
@@ -22,8 +23,10 @@ import (
 )
 
 const (
-	availablePluginName   = "test-plugin"
-	unavailablePluginName = "missing-test-plugin"
+	availablePluginName     = "test-plugin"
+	unavailablePluginName   = "missing-test-plugin"
+	pluginServiceEndpoint   = "https://test-plugin-service-name.test-plugin-service-namespace.svc.cluster.local:8443/manifest"
+	expectedPluginNamespace = "plugin__test-plugin"
 )
 
 func setupPluginsTestCase(t *testing.T) (*framework.ClientSet, *operatorsv1.Console) {
@@ -31,30 +34,77 @@ func setupPluginsTestCase(t *testing.T) (*framework.ClientSet, *operatorsv1.Cons
 }
 
 func cleanupPluginsTestCase(t *testing.T, client *framework.ClientSet) {
-	err := client.ConsolePlugin.Delete(context.TODO(), availablePluginName, metav1.DeleteOptions{})
+	err := client.ConsolePluginV1.Delete(context.TODO(), availablePluginName, metav1.DeleteOptions{})
 	if err != nil && !apiErrors.IsNotFound(err) {
 		t.Fatalf("could not delete cleanup %q plugin, %v", availablePluginName, err)
 	}
 	framework.StandardCleanup(t, client)
 }
 
-// TestAddPlugins is adding available and unavailable plugin names to the console-operator config.
+// TestAddPlugin is adding available and unavailable plugin names to the console-operator config.
 // Only plugin that is available on the cluster will be set with his endpoint into the console-config ConfigMap.
-func TestAddPlugins(t *testing.T) {
-	expectedPlugins := map[string]string{availablePluginName: "https://test-plugin-service-name.test-plugin-service-namespace.svc.cluster.local:8443/manifest"}
-	expertedI18nNamespaces := []string{"plugin__test-plugin"}
-	currentPlugins := map[string]string{}
+func TestAddV1Plugins(t *testing.T) {
+	expectedPlugins := map[string]string{availablePluginName: pluginServiceEndpoint}
+	expertedI18nNamespaces := []string{expectedPluginNamespace}
 	client, _ := setupPluginsTestCase(t)
 	defer cleanupPluginsTestCase(t, client)
 
-	plugin := &consolev1alpha.ConsolePlugin{
+	plugin := &consolev1.ConsolePlugin{
+		ObjectMeta: v1.ObjectMeta{
+			Name: availablePluginName,
+		},
+		Spec: consolev1.ConsolePluginSpec{
+			DisplayName: "TestPlugin",
+			I18n: consolev1.ConsolePluginI18n{
+				LoadType: consolev1.Preload,
+			},
+			Backend: consolev1.ConsolePluginBackend{
+				Type: consolev1.Service,
+				Service: &consolev1.ConsolePluginService{
+					Name:      "test-plugin-service-name",
+					Namespace: "test-plugin-service-namespace",
+					Port:      8443,
+					BasePath:  "/manifest",
+				},
+			},
+		},
+	}
+
+	_, err := client.ConsolePluginV1.Create(context.TODO(), plugin, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("could not create v1 ConsolePlugin custom resource: %s", err)
+	}
+	enabledPlugins := []string{availablePluginName, unavailablePluginName}
+	setOperatorConfigPlugins(t, client, enabledPlugins)
+
+	err = wait.Poll(1*time.Second, pollTimeout, func() (stop bool, err error) {
+		consoleConfig := getConsoleConfig(t, client)
+		if reflect.DeepEqual(expectedPlugins, consoleConfig.Plugins) && reflect.DeepEqual(expertedI18nNamespaces, consoleConfig.I18nNamespaces) {
+			return true, nil
+		}
+		return false, nil
+	})
+	if err != nil {
+		t.Errorf("error verifying v1alpha1 ConsolePlugin %q was enabled: %s", availablePluginName, err)
+	}
+}
+
+// when a v1alpha1 ConsolePLugin is creating console-operator should be able to get his converted
+// v1 version, due to the conversion webhook.
+func TestAddV1Alpha1Plugins(t *testing.T) {
+	expectedPlugins := map[string]string{availablePluginName: pluginServiceEndpoint}
+	expertedI18nNamespaces := []string{expectedPluginNamespace}
+	client, _ := setupPluginsTestCase(t)
+	defer cleanupPluginsTestCase(t, client)
+
+	plugin := &consolev1alpha1.ConsolePlugin{
 		ObjectMeta: v1.ObjectMeta{
 			Name:        availablePluginName,
-			Annotations: map[string]string{api.PluginI18nAnnotation: "true"},
+			Annotations: map[string]string{api.V1Alpha1PluginI18nAnnotation: "true"},
 		},
-		Spec: consolev1alpha.ConsolePluginSpec{
+		Spec: consolev1alpha1.ConsolePluginSpec{
 			DisplayName: "TestPlugin",
-			Service: consolev1alpha.ConsolePluginService{
+			Service: consolev1alpha1.ConsolePluginService{
 				Name:      "test-plugin-service-name",
 				Namespace: "test-plugin-service-namespace",
 				Port:      8443,
@@ -63,25 +113,22 @@ func TestAddPlugins(t *testing.T) {
 		},
 	}
 
-	_, err := client.ConsolePlugin.Create(context.TODO(), plugin, metav1.CreateOptions{})
+	_, err := client.ConsolePluginV1Alpha1.Create(context.TODO(), plugin, metav1.CreateOptions{})
 	if err != nil {
-		t.Fatalf("could not create ConsolePlugin custom resource: %s", err)
+		t.Fatalf("could not create v1alpha1 ConsolePlugin custom resource: %s", err)
 	}
 	enabledPlugins := []string{availablePluginName, unavailablePluginName}
 	setOperatorConfigPlugins(t, client, enabledPlugins)
 
 	err = wait.Poll(1*time.Second, pollTimeout, func() (stop bool, err error) {
 		consoleConfig := getConsoleConfig(t, client)
-		if reflect.DeepEqual(expectedPlugins, consoleConfig.Plugins) {
-			return true, nil
-		}
-		if reflect.DeepEqual(expertedI18nNamespaces, consoleConfig.I18nNamespaces) {
+		if reflect.DeepEqual(expectedPlugins, consoleConfig.Plugins) && reflect.DeepEqual(expertedI18nNamespaces, consoleConfig.I18nNamespaces) {
 			return true, nil
 		}
 		return false, nil
 	})
 	if err != nil {
-		t.Errorf("error: expected '%v' plugins, got '%v': '%v'", expectedPlugins, currentPlugins, err)
+		t.Errorf("error verifying v1 ConsolePlugin %q was enabled: %s", availablePluginName, err)
 	}
 }
 


### PR DESCRIPTION
This is an additional PR for https://issues.redhat.com/browse/CONSOLE-3069 to swap api towards the new `v1` version of ConsolePlugin CRD.
Updated packages and also tests.

/assign @TheRealJon 