### PR TITLE
update to release.openshift.io/feature-set to match OCP 4.12 

### DIFF
--- a/manifests/03-rbac-role-cluster.yaml
+++ b/manifests/03-rbac-role-cluster.yaml
@@ -142,7 +142,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: console-operator-tech-preview-only
   annotations:
-    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"
+    release.openshift.io/feature-set: "TechPreviewNoUpgrade"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"

--- a/manifests/04-rbac-rolebinding-cluster.yaml
+++ b/manifests/04-rbac-rolebinding-cluster.yaml
@@ -120,7 +120,7 @@ kind: ClusterRoleBinding
 metadata:
   name: console-operator-tech-preview-only
   annotations:
-    release.openshift.io/feature-gate: "TechPreviewNoUpgrade"
+    release.openshift.io/feature-set: "TechPreviewNoUpgrade"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"


### PR DESCRIPTION
This was added in https://github.com/openshift/cluster-version-operator/pull/821 to allow more featuresets and allow for a future migration to include actual gates. Because usage of this manifest would prevent upgrades, there are not upgrade concerns for this change.