### PR TITLE
CONSOLE-3337: Dynamic plugin proxy reference issue

### DIFF
--- a/pkg/cmd/crdconversionwebhook/converter/converter.go
+++ b/pkg/cmd/crdconversionwebhook/converter/converter.go
@@ -20,7 +20,6 @@ func convertCRD(object *unstructured.Unstructured, toVersion string) (*unstructu
 	if toVersion == fromVersion {
 		return nil, statusErrorWithMessage("conversion from a version to itself should not call the webhook: %s", toVersion)
 	}
-
 	switch object.GetAPIVersion() {
 	case "console.openshift.io/v1alpha1":
 		switch toVersion {
@@ -165,12 +164,12 @@ func convertPluginV1alpha1ToV1(convertedObject *unstructured.Unstructured) (*uns
 	// proxy
 	// v1alpha1 endpoint can only be type 'Service'
 	v1Proxies := []v1.ConsolePluginProxy{}
-	for _, proxy := range v1alpha1Plugin.Spec.Proxy {
+	for i, proxy := range v1alpha1Plugin.Spec.Proxy {
 		v1Proxy := v1.ConsolePluginProxy{
 			Alias:         proxy.Alias,
 			CACertificate: proxy.CACertificate,
 			Endpoint: v1.ConsolePluginProxyEndpoint{
-				Service: (*v1.ConsolePluginProxyServiceConfig)(&proxy.Service),
+				Service: (*v1.ConsolePluginProxyServiceConfig)(&v1alpha1Plugin.Spec.Proxy[i].Service),
 				Type:    v1.ProxyTypeService,
 			},
 		}

--- a/pkg/cmd/crdconversionwebhook/converter/converter_test.go
+++ b/pkg/cmd/crdconversionwebhook/converter/converter_test.go
@@ -43,6 +43,14 @@ spec:
       name: thanos-querier
       namespace: openshift-monitoring
       port: 9091
+  - type: Service
+    alias: loky-querier
+    authorize: true
+    caCertificate: certContent
+    service:
+      name: loky-querier
+      namespace: openshift-monitoring
+      port: 9092
 `,
 			wantedObject: `apiVersion: console.openshift.io/v1
 kind: ConsolePlugin
@@ -72,6 +80,15 @@ spec:
         name: thanos-querier
         namespace: openshift-monitoring
         port: 9091
+      type: Service
+  - alias: loky-querier
+    authorization: UserToken
+    caCertificate: certContent
+    endpoint:
+      service:
+        name: loky-querier
+        namespace: openshift-monitoring
+        port: 9092
       type: Service
 `,
 		},
@@ -165,6 +182,15 @@ spec:
         namespace: openshift-monitoring
         port: 9091
       type: Service
+  - alias: loky-querier
+    authorization: UserToken
+    caCertificate: certContent
+    endpoint:
+      service:
+        name: loky-querier
+        namespace: openshift-monitoring
+        port: 9092
+      type: Service
 `,
 			wantedObject: `apiVersion: console.openshift.io/v1alpha1
 kind: ConsolePlugin
@@ -185,6 +211,14 @@ spec:
       name: thanos-querier
       namespace: openshift-monitoring
       port: 9091
+    type: Service
+  - alias: loky-querier
+    authorize: true
+    caCertificate: certContent
+    service:
+      name: loky-querier
+      namespace: openshift-monitoring
+      port: 9092
     type: Service
   service:
     basePath: /
@@ -248,7 +282,8 @@ spec:
     namespace: console-demo-plugin
     port: 9001
 `,
-		}}
+		},
+	}
 	for _, tc := range cases {
 		t.Run("ConsolePlugin version convertion test", func(t *testing.T) {
 			t.Logf("Running %q test", tc.testCaseName)

--- a/pkg/console/subresource/configmap/configmap_test.go
+++ b/pkg/console/subresource/configmap/configmap_test.go
@@ -680,7 +680,7 @@ managedClusterConfigFile: 'test'
 				useDefaultCAFile:         true,
 				inactivityTimeoutSeconds: 0,
 				availablePlugins: []*v1.ConsolePlugin{
-					testPlugins("plugin1", "service1", "service-namespace1"),
+					testPluginsWithProxy("plugin1", "service1", "service-namespace1"),
 					testPluginsWithProxy("plugin2", "service2", "service-namespace2"),
 					testPluginsWithI18nPreloadType("plugin3", "service3", "service-namespace3"),
 				},
@@ -739,7 +739,25 @@ HQ4EFgQU0vhI4OPGEOqT+VAWwxdhVvcmgdIwHwYDVR0jBBgwFoAU0vhI4OPGEOqT` + "\n" + `
 nV5cXbp9W1bC12Tc8nnNXn4ypLE2JTQAvyp51zoZ8hQoSnRVx/VCY55Yu+br8gQZ` + "\n" + `
 +tW+O/PoE7B3tuY=` + "\n" + `
 -----END CERTIFICATE-----'
-    consoleAPIPath: /api/proxy/plugin/plugin2/test-alias/
+    consoleAPIPath: /api/proxy/plugin/plugin1/plugin1-alias/
+    endpoint: https://proxy-service1.proxy-service-namespace1.svc.cluster.local:9991
+  - authorize: true
+    caCertificate: '-----BEGIN CERTIFICATE-----` + "\n" + `
+MIICRzCCAfGgAwIBAgIJAIydTIADd+yqMA0GCSqGSIb3DQEBCwUAMH4xCzAJBgNV` + "\n" + `
+BAYTAkdCMQ8wDQYDVQQIDAZMb25kb24xDzANBgNVBAcMBkxvbmRvbjEYMBYGA1UE` + "\n" + `
+CgwPR2xvYmFsIFNlY3VyaXR5MRYwFAYDVQQLDA1JVCBEZXBhcnRtZW50MRswGQYD` + "\n" + `
+VQQDDBJ0ZXN0LWNlcnRpZmljYXRlLTIwIBcNMTcwNDI2MjMyNDU4WhgPMjExNzA0` + "\n" + `
+MDIyMzI0NThaMH4xCzAJBgNVBAYTAkdCMQ8wDQYDVQQIDAZMb25kb24xDzANBgNV` + "\n" + `
+BAcMBkxvbmRvbjEYMBYGA1UECgwPR2xvYmFsIFNlY3VyaXR5MRYwFAYDVQQLDA1J` + "\n" + `
+VCBEZXBhcnRtZW50MRswGQYDVQQDDBJ0ZXN0LWNlcnRpZmljYXRlLTIwXDANBgkq` + "\n" + `
+hkiG9w0BAQEFAANLADBIAkEAuiRet28DV68Dk4A8eqCaqgXmymamUEjW/DxvIQqH` + "\n" + `
+3lbhtm8BwSnS9wUAajSLSWiq3fci2RbRgaSPjUrnbOHCLQIDAQABo1AwTjAdBgNV` + "\n" + `
+HQ4EFgQU0vhI4OPGEOqT+VAWwxdhVvcmgdIwHwYDVR0jBBgwFoAU0vhI4OPGEOqT` + "\n" + `
++VAWwxdhVvcmgdIwDAYDVR0TBAUwAwEB/zANBgkqhkiG9w0BAQsFAANBALNeJGDe` + "\n" + `
+nV5cXbp9W1bC12Tc8nnNXn4ypLE2JTQAvyp51zoZ8hQoSnRVx/VCY55Yu+br8gQZ` + "\n" + `
++tW+O/PoE7B3tuY=` + "\n" + `
+-----END CERTIFICATE-----'
+    consoleAPIPath: /api/proxy/plugin/plugin2/plugin2-alias/
     endpoint: https://proxy-service2.proxy-service-namespace2.svc.cluster.local:9991
 `,
 				},
@@ -950,7 +968,7 @@ func testPluginsWithProxy(pluginName, serviceName, serviceNamespace string) *v1.
 	plugin := testPlugins(pluginName, serviceName, serviceNamespace)
 	plugin.Spec.Proxy = []v1.ConsolePluginProxy{
 		{
-			Alias:         "test-alias",
+			Alias:         fmt.Sprintf("%s-alias", pluginName),
 			CACertificate: validCertificate,
 			Authorization: v1.UserToken,
 			Endpoint: v1.ConsolePluginProxyEndpoint{


### PR DESCRIPTION
We should be using an array entry reference rather then a memory address, while casting the object into a variable.

Also adding couple of unit tests to back case where there are multiple proxy services defined in a single plugin.

/assign @TheRealJon 