### PR TITLE
CONSOLE-3286: Set disabledCopiedCSVs in console

### DIFF
--- a/manifests/03-rbac-role-cluster.yaml
+++ b/manifests/03-rbac-role-cluster.yaml
@@ -9,13 +9,13 @@ metadata:
     capability.openshift.io/name: Console
 rules:
   - apiGroups:
-    - ""
+      - ""
     resources:
-    - nodes
+      - nodes
     verbs:
-    - get
-    - list
-    - watch
+      - get
+      - list
+      - watch
   - apiGroups:
       - oauth.openshift.io
     resources:
@@ -82,6 +82,14 @@ rules:
       - cluster.open-cluster-management.io
     resources:
       - managedclusters
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - operators.coreos.com
+    resources:
+      - olmconfigs
     verbs:
       - get
       - list
@@ -183,15 +191,15 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
 rules:
-- apiGroups:
-  - helm.openshift.io
-  resources:
-  - projecthelmchartrepositories
-  verbs:
-  - get
-  - list
-  - update
-  - create
-  - watch 
-  - patch
-  - delete
+  - apiGroups:
+      - helm.openshift.io
+    resources:
+      - projecthelmchartrepositories
+    verbs:
+      - get
+      - list
+      - update
+      - create
+      - watch
+      - patch
+      - delete

--- a/manifests/03-rbac-role-ns-operator.yaml
+++ b/manifests/03-rbac-role-ns-operator.yaml
@@ -9,60 +9,68 @@ metadata:
     include.release.openshift.io/single-node-developer: "true"
     capability.openshift.io/name: Console
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  - events
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - delete
-  - patch
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - apps
-  resources:
-  - deployments
-  - replicasets
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - config.openshift.io
-  resources:
-  - infrastructures
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - "coordination.k8s.io"
-  resources:
-  - leases
-  verbs:
-  - get
-  - create
-  - update
-- apiGroups:
-    - console.openshift.io
-  resources:
-    - consolenotifications
-  verbs:
-    - get
-    - list
-    - watch
-    - create
-    - update
-    - delete
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - events
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - delete
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+      - replicasets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - config.openshift.io
+    resources:
+      - infrastructures
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "coordination.k8s.io"
+    resources:
+      - leases
+    verbs:
+      - get
+      - create
+      - update
+  - apiGroups:
+      - console.openshift.io
+    resources:
+      - consolenotifications
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - delete
+  - apiGroups:
+      - operators.coreos.com
+    resources:
+      - olmconfigs
+    verbs:
+      - get
+      - list
+      - watch

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -73,6 +73,10 @@ const (
 	ManagedClusterClaimVersionAnnotation = "version.openshift.io"
 	ManagedClusterClaimProductAnnotation = "product.open-cluster-management.io"
 
+	OLMConfigGroup    = "operators.coreos.com"
+	OLMConfigVersion  = "v1"
+	OLMConfigResource = "olmconfigs"
+
 	ConsoleContainerPortName    = "https"
 	ConsoleContainerPort        = 443
 	ConsoleContainerTargetPort  = 8443

--- a/pkg/console/operator/sync_v400.go
+++ b/pkg/console/operator/sync_v400.go
@@ -12,6 +12,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
 
@@ -408,6 +410,11 @@ func (co *consoleOperator) SyncConfigMap(
 		return nil, false, "FailedGetMonitoringSharedConfig", mscErr
 	}
 
+	copiedCSVsDisabled, ccdErr := co.isCopiedCSVsDisabled(ctx)
+	if ccdErr != nil {
+		return nil, false, "FailedGetOLMConfig", ccdErr
+	}
+
 	defaultConfigmap, _, err := configmapsub.DefaultConfigMap(
 		operatorConfig,
 		consoleConfig,
@@ -420,6 +427,7 @@ func (co *consoleOperator) SyncConfigMap(
 		availablePlugins,
 		managedClusterConfigFile,
 		nodeArchitectures,
+		copiedCSVsDisabled,
 	)
 	if err != nil {
 		return nil, false, "FailedConsoleConfigBuilder", err
@@ -616,4 +624,17 @@ func getNodeArchitectures(nodes *corev1.NodeList) []string {
 		nodeArchitecturesSet.Insert(nodeArch)
 	}
 	return nodeArchitecturesSet.List()
+}
+
+func (co *consoleOperator) isCopiedCSVsDisabled(ctx context.Context) (bool, error) {
+	olmConfig, err := co.dynamicClient.Resource(schema.GroupVersionResource{Group: api.OLMConfigGroup, Version: api.OLMConfigVersion, Resource: api.OLMConfigResource}).Get(ctx, api.ConfigResourceName, metav1.GetOptions{})
+	if err != nil {
+		return false, err
+	}
+	copiedCSVsDisabled, found, err := unstructured.NestedBool(olmConfig.Object, "spec", "features", "disableCopiedCSVs")
+	if err != nil || !found {
+		return false, err
+	}
+
+	return copiedCSVsDisabled, nil
 }

--- a/pkg/console/starter/starter.go
+++ b/pkg/console/starter/starter.go
@@ -189,6 +189,8 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 		// top level config
 		configClient.ConfigV1(),
 		configInformers,
+		dynamicClient,
+		dynamicInformers,
 		// operator
 		operatorClient,
 		operatorConfigClient.OperatorV1(),

--- a/pkg/console/subresource/configmap/configmap.go
+++ b/pkg/console/subresource/configmap/configmap.go
@@ -52,6 +52,7 @@ func DefaultConfigMap(
 	availablePlugins []*v1.ConsolePlugin,
 	managedClusterConfigFile string,
 	nodeArchitectures []string,
+	copiedCSVsDisabled bool,
 ) (consoleConfigMap *corev1.ConfigMap, unsupportedOverridesHaveMerged bool, err error) {
 
 	defaultBuilder := &consoleserver.ConsoleServerCLIConfigBuilder{}
@@ -65,6 +66,7 @@ func DefaultConfigMap(
 		InactivityTimeout(inactivityTimeoutSeconds).
 		ReleaseVersion().
 		NodesArchitecture(nodeArchitectures).
+		CopiedCSVsDisabled(copiedCSVsDisabled).
 		ConfigYAML()
 	if err != nil {
 		klog.Errorf("failed to generate default console-config config: %v", err)

--- a/pkg/console/subresource/consoleserver/config_builder.go
+++ b/pkg/console/subresource/consoleserver/config_builder.go
@@ -64,6 +64,7 @@ type ConsoleServerCLIConfigBuilder struct {
 	telemetry                  map[string]string
 	releaseVersion             string
 	nodeArchitectures          []string
+	copiedCSVsDisabled         bool
 }
 
 func (b *ConsoleServerCLIConfigBuilder) Host(host string) *ConsoleServerCLIConfigBuilder {
@@ -190,6 +191,11 @@ func (b *ConsoleServerCLIConfigBuilder) NodesArchitecture(architectures []string
 	return b
 }
 
+func (b *ConsoleServerCLIConfigBuilder) CopiedCSVsDisabled(copiedCSVsDisabled bool) *ConsoleServerCLIConfigBuilder {
+	b.copiedCSVsDisabled = copiedCSVsDisabled
+	return b
+}
+
 func (b *ConsoleServerCLIConfigBuilder) Config() Config {
 	return Config{
 		Kind:                     "ConsoleConfig",
@@ -252,6 +258,7 @@ func (b *ConsoleServerCLIConfigBuilder) clusterInfo() ClusterInfo {
 	if len(b.nodeArchitectures) > 0 {
 		conf.NodeArchitectures = b.nodeArchitectures
 	}
+	conf.CopiedCSVsDisabled = b.copiedCSVsDisabled
 	return conf
 }
 

--- a/pkg/console/subresource/consoleserver/types.go
+++ b/pkg/console/subresource/consoleserver/types.go
@@ -68,6 +68,7 @@ type ClusterInfo struct {
 	ControlPlaneToplogy configv1.TopologyMode `yaml:"controlPlaneTopology,omitempty"`
 	ReleaseVersion      string                `yaml:"releaseVersion,omitempty"`
 	NodeArchitectures   []string              `yaml:"nodeArchitectures,omitempty"`
+	CopiedCSVsDisabled  bool                  `yaml:"copiedCSVsDisabled,omitempty"`
 }
 
 // MonitoringInfo holds configuration for monitoring related services


### PR DESCRIPTION
Console-Operator: Set disabledCopiedCSVs for console using console config
Also added RBAC commands so we can access the OLM config file

https://issues.redhat.com/browse/CONSOLE-3286