### PR TITLE
OCPBUGS-3109: Change text colour for ConsoleNotification that notifies user that the cluster is being

### DIFF
--- a/pkg/console/controllers/upgradenotification/controller.go
+++ b/pkg/console/controllers/upgradenotification/controller.go
@@ -128,7 +128,7 @@ func (c *UpgradeNotificationController) syncClusterUpgradeNotification(ctx conte
 			Spec: consolev1.ConsoleNotificationSpec{
 				Text:            fmt.Sprintf("This cluster is updating from %s to %s", currentVersion, desiredVersion),
 				Location:        "BannerTop",
-				Color:           "#FFFFFF",
+				Color:           "#000000",
 				BackgroundColor: "#F0AB00",
 			},
 		}


### PR DESCRIPTION
Before:
<img width="1885" alt="before" src="https://user-images.githubusercontent.com/1668218/199529182-4820e880-2d42-4b12-8fd2-e29fe0c083aa.png">

After:
<img width="1880" alt="after" src="https://user-images.githubusercontent.com/1668218/199529176-a404a10c-13a4-4f04-ae6e-60fee304f51b.png">

/assign @spadgett 

/cherry-pick release-4.12