### PR TITLE
OCPBUGS-4008: Add `app: console` label to managed-clusters configmap

### DIFF
--- a/pkg/console/subresource/configmap/managed_clusters.go
+++ b/pkg/console/subresource/configmap/managed_clusters.go
@@ -30,6 +30,7 @@ func DefaultManagedClustersConfigMap(operatorConfig *operatorv1.Console, managed
 func ManagedClustersConfigMapStub() *corev1.ConfigMap {
 	configMap := ConsoleConfigMapStub()
 	configMap.Name = api.ManagedClusterConfigMapName
+	configMap.Labels = util.SharedLabels()
 	configMap.Labels[api.ManagedClusterLabel] = ""
 	return configMap
 }


### PR DESCRIPTION
Ensure main console sync loop is re-run when managed-cluster config changes