### PR TITLE
OCPBUGS-5059: Make enabled plugins unique

### DIFF
--- a/pkg/console/operator/sync_v400.go
+++ b/pkg/console/operator/sync_v400.go
@@ -41,6 +41,7 @@ import (
 	oauthsub "github.com/openshift/console-operator/pkg/console/subresource/oauthclient"
 	routesub "github.com/openshift/console-operator/pkg/console/subresource/route"
 	secretsub "github.com/openshift/console-operator/pkg/console/subresource/secret"
+	utilsub "github.com/openshift/console-operator/pkg/console/subresource/util"
 )
 
 // The sync loop starts from zero and works its way through the requirements for a running console.
@@ -606,7 +607,7 @@ func (co *consoleOperator) ValidateCustomLogo(ctx context.Context, operatorConfi
 
 func (co *consoleOperator) GetAvailablePlugins(enabledPluginsNames []string) []*v1.ConsolePlugin {
 	var availablePlugins []*v1.ConsolePlugin
-	for _, pluginName := range enabledPluginsNames {
+	for _, pluginName := range utilsub.RemoveDuplicateStr(enabledPluginsNames) {
 		plugin, err := co.consolePluginLister.Get(pluginName)
 		if err != nil {
 			klog.Errorf("failed to get %q plugin: %v", pluginName, err)

--- a/pkg/console/subresource/util/util.go
+++ b/pkg/console/subresource/util/util.go
@@ -143,3 +143,15 @@ func ReadManagedProxyServiceResolverOrDie(objBytes []byte) *proxyv1alpha1.Manage
 	}
 	return resource.(*proxyv1alpha1.ManagedProxyServiceResolver)
 }
+
+func RemoveDuplicateStr(strSlice []string) []string {
+	allKeys := make(map[string]bool)
+	list := []string{}
+	for _, item := range strSlice {
+		if _, value := allKeys[item]; !value {
+			allKeys[item] = true
+			list = append(list, item)
+		}
+	}
+	return list
+}

--- a/pkg/console/subresource/util/util_test.go
+++ b/pkg/console/subresource/util/util_test.go
@@ -181,3 +181,22 @@ func TestHTTPS(t *testing.T) {
 		})
 	}
 }
+
+func TestRemoveDuplicateStr(t *testing.T) {
+	tests := []struct {
+		strSlice []string
+		want     []string
+	}{
+		{
+			strSlice: []string{"plugin1", "plugin2", "plugin3", "plugin1", "plugin2"},
+			want:     []string{"plugin1", "plugin2", "plugin3"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run("RemoveDuplicateStr unit test", func(t *testing.T) {
+			if diff := deep.Equal(RemoveDuplicateStr(tt.strSlice), tt.want); diff != nil {
+				t.Error(diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
When trying to enable single plugin in the console operator's config multiple times the redeployed console will crash.
This PR makes list of plugins unique.

/assign @TheRealJon 