### PR TITLE
OCPBUGS-5836: Incorrect redirection when user try to download windows oc binary

### DIFF
--- a/bindata/deployments/downloads-deployment.yaml
+++ b/bindata/deployments/downloads-deployment.yaml
@@ -130,7 +130,7 @@ spec:
                   ('ppc64le', 'linux', '/usr/share/openshift/linux_ppc64le/oc'),
                   ('s390x', 'linux', '/usr/share/openshift/linux_s390x/oc'),
                   ]:
-                basename = os.path.basename(os.path.splitext(path)[0])
+                basename = os.path.basename(path)
                 target_path = os.path.join(arch, operating_system, basename)
                 os.mkdir(os.path.join(arch, operating_system))
                 os.symlink(path, target_path)
@@ -140,7 +140,11 @@ spec:
                   tar.add(path, basename)
                 with zipfile.ZipFile('{}.zip'.format(archive_path_root), 'w') as zip:
                   zip.write(path, basename)
-                content.append('<a href="{0}">oc ({1} {2})</a> (<a href="{0}.tar">tar</a> <a href="{0}.zip">zip</a>)'.format(target_path, arch, operating_system))
+                content.append(
+                  '<a href="{0}">oc ({1} {2})</a> (<a href="{3}.tar">tar</a> <a href="{3}.zip">zip</a>)'.format(
+                    target_path, arch, operating_system, archive_path_root
+                  )
+                )
 
               for root, directories, filenames in os.walk(temp_dir):
                 root_link = os.path.relpath(temp_dir, os.path.join(root, 'child')).replace(os.path.sep, '/')

--- a/bindata/deployments/downloads-deployment.yaml
+++ b/bindata/deployments/downloads-deployment.yaml
@@ -130,7 +130,7 @@ spec:
                   ('ppc64le', 'linux', '/usr/share/openshift/linux_ppc64le/oc'),
                   ('s390x', 'linux', '/usr/share/openshift/linux_s390x/oc'),
                   ]:
-                basename = os.path.basename(path)
+                basename = os.path.basename(os.path.splitext(path)[0])
                 target_path = os.path.join(arch, operating_system, basename)
                 os.mkdir(os.path.join(arch, operating_system))
                 os.symlink(path, target_path)

--- a/pkg/console/assets/bindata.go
+++ b/pkg/console/assets/bindata.go
@@ -359,7 +359,7 @@ spec:
                   ('ppc64le', 'linux', '/usr/share/openshift/linux_ppc64le/oc'),
                   ('s390x', 'linux', '/usr/share/openshift/linux_s390x/oc'),
                   ]:
-                basename = os.path.basename(path)
+                basename = os.path.basename(os.path.splitext(path)[0])
                 target_path = os.path.join(arch, operating_system, basename)
                 os.mkdir(os.path.join(arch, operating_system))
                 os.symlink(path, target_path)


### PR DESCRIPTION
`os.path.basename()` did not remove windows executable extension `.exe`, was replaced by `os.path.basename(os.path.splitext(path)[0])` which first splits the path, takes the part before `.` and then passes it to the original `basename()` function.

/assign @jhadvig 
Signed-off-by: Pavel Kratochvil <pakratoc@redhat.com>