### PR TITLE
OCPBUGS-5499: Back port on-premise host inventory quick start to OCP 4.11.x

### DIFF
--- a/quickstarts/host-inventory-quickstart.yaml
+++ b/quickstarts/host-inventory-quickstart.yaml
@@ -11,7 +11,8 @@ spec:
   durationMinutes: 20
   description: Configure your host inventory and create a cluster.
   prerequisites: 
-    - "A storage operator is required (example: OpenShift Data Foundation) for the assisted service to run correctly. To install the OpenShift Data Foundation, complete the \"Install OpenShift Data Foundation\" quick start."
+    - 'You have completed the steps to "Get started with multicluster engine" quick start.'
+    - "A storage operator with a default storage class is required, such as OpenShift Data Foundation, in order for the assisted service to run correctly. To install the OpenShift Data Foundation, complete the \"Install OpenShift Data Foundation\" quick start."
   icon: >-
     data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA3MjEuMTUgNzIxLjE1Ij48ZGVmcz48c3R5bGU+LmNscy0xe2ZpbGw6I2RiMzkyNzt9LmNscy0ye2ZpbGw6I2NiMzYyODt9LmNscy0ze2ZpbGw6I2ZmZjt9LmNscy00e2ZpbGw6I2UzZTNlMjt9PC9zdHlsZT48L2RlZnM+PHRpdGxlPlByb2R1Y3RfSWNvbi1SZWRfSGF0QWR2YW5jZWRfQ2x1c3Rlcl9NYW5hZ2VtZW50X2Zvcl9LdWJlcm5ldGVzLVJHQjwvdGl0bGU+PGcgaWQ9IkxheWVyXzEiIGRhdGEtbmFtZT0iTGF5ZXIgMSI+PGNpcmNsZSBjbGFzcz0iY2xzLTEiIGN4PSIzNjAuNTciIGN5PSIzNjAuNTciIHI9IjM1OC41OCIvPjxwYXRoIGNsYXNzPSJjbHMtMiIgZD0iTTYxNC4xMywxMDcsMTA3LDYxNC4xM2MxNDAsMTQwLDM2Ny4wNywxNDAsNTA3LjExLDBTNzU0LjE2LDI0Ny4wNiw2MTQuMTMsMTA3WiIvPjxyZWN0IGNsYXNzPSJjbHMtMyIgeD0iMzMwLjg3IiB5PSIyODAuNiIgd2lkdGg9IjIwMy4xNyIgaGVpZ2h0PSIyMCIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoLTc4LjkgMzkwLjUyKSByb3RhdGUoLTQ0Ljk2KSIvPjxyZWN0IGNsYXNzPSJjbHMtMyIgeD0iMzA2LjYzIiB5PSIxNjcuODMiIHdpZHRoPSIyMCIgaGVpZ2h0PSIyMDQuNDciIHRyYW5zZm9ybT0idHJhbnNsYXRlKC04NS4zMyAxNjIuMjcpIHJvdGF0ZSgtMjUuNDUpIi8+PHJlY3QgY2xhc3M9ImNscy0zIiB4PSIxNjIuOTgiIHk9IjM2NC4xIiB3aWR0aD0iMTk4LjI4IiBoZWlnaHQ9IjIwIiB0cmFuc2Zvcm09InRyYW5zbGF0ZSgtNDIuMzkgMzMuNjEpIHJvdGF0ZSgtNi43OSkiLz48cmVjdCBjbGFzcz0iY2xzLTMiIHg9IjI0NS4xIiB5PSI0NTEuNTQiIHdpZHRoPSIyMDAuNjIiIGhlaWdodD0iMjAiIHRyYW5zZm9ybT0idHJhbnNsYXRlKC0xNjMuMDEgNzMzLjI2KSByb3RhdGUoLTgxLjMxKSIvPjxyZWN0IGNsYXNzPSJjbHMtMyIgeD0iNDQzLjg1IiB5PSIzMDMuNzYiIHdpZHRoPSIyMCIgaGVpZ2h0PSIyMDcuMDQiIHRyYW5zZm9ybT0idHJhbnNsYXRlKC0xMDkuOTcgNjM5LjU4KSByb3RhdGUoLTY0LjMpIi8+PGNpcmNsZSBjbGFzcz0iY2xzLTMiIGN4PSI1MDQuMzQiIGN5PSIyMTguODMiIHI9IjQ0LjA4Ii8+PGNpcmNsZSBjbGFzcz0iY2xzLTMiIGN4PSIyNzIuNyIgY3k9IjE3Ny43NSIgcj0iNDQuMDgiLz48Y2lyY2xlIGNsYXNzPSJjbHMtMyIgY3g9IjU0Ny4xMiIgY3k9IjQ1Mi4xNyIgcj0iNDQuMDgiLz48Y2lyY2xlIGNsYXNzPSJjbHMtMyIgY3g9IjE2My42OCIgY3k9IjM4NS44MiIgcj0iNDQuMDgiLz48Y2lyY2xlIGNsYXNzPSJjbHMtMyIgY3g9IjMzMC4yNiIgY3k9IjU2MC43IiByPSI0NC4wOCIvPjxwYXRoIGNsYXNzPSJjbHMtNCIgZD0iTTQ0NC45NCwyNzkuOTIsMjc2LjE5LDQ0OC42N0ExMTkuMzIsMTE5LjMyLDAsMCwwLDQ0NC45NCwyNzkuOTJaIi8+PHBhdGggY2xhc3M9ImNscy0zIiBkPSJNMzc1LjY4LDI0NS43NmExMTkuMzMsMTE5LjMzLDAsMCwwLTk5LjQ5LDIwMi45MUw0NDQuOTQsMjc5LjkyQTExOC44OSwxMTguODksMCwwLDAsMzc1LjY4LDI0NS43NloiLz48L2c+PC9zdmc+
   introduction: |-
@@ -20,13 +21,29 @@ spec:
 
 
   tasks:
-    - description: >-
+    - description: |-
 
-        1.  Configure your host inventory settings. View [documentation](https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.5/html-single/clusters/index#enable-cim) to follow the steps to configure your host inventory settings.
+        1.  Configure your host inventory settings.
+
+          a. From the **All Clusters** view of the OpenShift Container Platform web console, navigate to the host inventory by clicking **Infrastructure** > **Host inventory**
+
+          b. Select **Configure host inventory settings**.
+
+        1. Enter the required values for **Database storage**, **System Storage**, and **Image Storage** in the modal that opens. 
+
+          **Note**: The modal is for connected environments only. For disconnected environments, follow the steps for [configuring your host inventory settings documentation](https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.5/html-single/clusters/index#enable-cim).
+
+          a. If your cluster is running on AWS and you have not configured your load balancer, select the 'Configure load balancer on Amazon Web Services for me' checkbox.
+
+        1. Then click configure.
+
+          **Note**: Storage sizes cannot be changed after they are configured. Configuring the load balancer on AWS cannot be reverted.
+        
+        1. The configuration will take time. You will be notified when the configuration is successfully complete. Now your host inventory settings are successfully configured and you can create your first infrastructure environment.
 
         1. Create an infrastructure environment for your host inventory.
 
-          a. Go to **Host inventory**.
+          a. From the **All Clusters** view of the OpenShift Container Platform web console, navigate to the host inventory by clicking **Infrastructure** > **Host inventory**
 
           b. Select **Create infrastructure environment**.
 
@@ -35,6 +52,7 @@ spec:
           a. In the infrastructure that you created, choose one of the **Add hosts** options.
 
           b. After you successfully added your hosts, ensure the status of each host is available for cluster creation.
+
 
       review:
         failedTaskHelp: This task isn’t verified yet. Try the task again.

--- a/quickstarts/install-multicluster-engine.yaml
+++ b/quickstarts/install-multicluster-engine.yaml
@@ -6,7 +6,6 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    capability.openshift.io/name: Console
 spec:
   displayName: Get started with multicluster engine
   durationMinutes: 10

--- a/quickstarts/install-multicluster-engine.yaml
+++ b/quickstarts/install-multicluster-engine.yaml
@@ -1,0 +1,49 @@
+apiVersion: console.openshift.io/v1
+kind: ConsoleQuickStart
+metadata:
+  name: install-multicluster-engine
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    capability.openshift.io/name: Console
+spec:
+  displayName: Get started with multicluster engine
+  durationMinutes: 10
+  icon: data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA3MjEuMTUgNzIxLjE1Ij48ZGVmcz48c3R5bGU+LmNscy0xe2ZpbGw6I2RiMzkyNzt9LmNscy0ye2ZpbGw6I2NiMzYyODt9LmNscy0ze2ZpbGw6I2ZmZjt9LmNscy00e2ZpbGw6I2UzZTNlMjt9PC9zdHlsZT48L2RlZnM+PHRpdGxlPlByb2R1Y3RfSWNvbi1SZWRfSGF0QWR2YW5jZWRfQ2x1c3Rlcl9NYW5hZ2VtZW50X2Zvcl9LdWJlcm5ldGVzLVJHQjwvdGl0bGU+PGcgaWQ9IkxheWVyXzEiIGRhdGEtbmFtZT0iTGF5ZXIgMSI+PGNpcmNsZSBjbGFzcz0iY2xzLTEiIGN4PSIzNjAuNTciIGN5PSIzNjAuNTciIHI9IjM1OC41OCIvPjxwYXRoIGNsYXNzPSJjbHMtMiIgZD0iTTYxNC4xMywxMDcsMTA3LDYxNC4xM2MxNDAsMTQwLDM2Ny4wNywxNDAsNTA3LjExLDBTNzU0LjE2LDI0Ny4wNiw2MTQuMTMsMTA3WiIvPjxyZWN0IGNsYXNzPSJjbHMtMyIgeD0iMzMwLjg3IiB5PSIyODAuNiIgd2lkdGg9IjIwMy4xNyIgaGVpZ2h0PSIyMCIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoLTc4LjkgMzkwLjUyKSByb3RhdGUoLTQ0Ljk2KSIvPjxyZWN0IGNsYXNzPSJjbHMtMyIgeD0iMzA2LjYzIiB5PSIxNjcuODMiIHdpZHRoPSIyMCIgaGVpZ2h0PSIyMDQuNDciIHRyYW5zZm9ybT0idHJhbnNsYXRlKC04NS4zMyAxNjIuMjcpIHJvdGF0ZSgtMjUuNDUpIi8+PHJlY3QgY2xhc3M9ImNscy0zIiB4PSIxNjIuOTgiIHk9IjM2NC4xIiB3aWR0aD0iMTk4LjI4IiBoZWlnaHQ9IjIwIiB0cmFuc2Zvcm09InRyYW5zbGF0ZSgtNDIuMzkgMzMuNjEpIHJvdGF0ZSgtNi43OSkiLz48cmVjdCBjbGFzcz0iY2xzLTMiIHg9IjI0NS4xIiB5PSI0NTEuNTQiIHdpZHRoPSIyMDAuNjIiIGhlaWdodD0iMjAiIHRyYW5zZm9ybT0idHJhbnNsYXRlKC0xNjMuMDEgNzMzLjI2KSByb3RhdGUoLTgxLjMxKSIvPjxyZWN0IGNsYXNzPSJjbHMtMyIgeD0iNDQzLjg1IiB5PSIzMDMuNzYiIHdpZHRoPSIyMCIgaGVpZ2h0PSIyMDcuMDQiIHRyYW5zZm9ybT0idHJhbnNsYXRlKC0xMDkuOTcgNjM5LjU4KSByb3RhdGUoLTY0LjMpIi8+PGNpcmNsZSBjbGFzcz0iY2xzLTMiIGN4PSI1MDQuMzQiIGN5PSIyMTguODMiIHI9IjQ0LjA4Ii8+PGNpcmNsZSBjbGFzcz0iY2xzLTMiIGN4PSIyNzIuNyIgY3k9IjE3Ny43NSIgcj0iNDQuMDgiLz48Y2lyY2xlIGNsYXNzPSJjbHMtMyIgY3g9IjU0Ny4xMiIgY3k9IjQ1Mi4xNyIgcj0iNDQuMDgiLz48Y2lyY2xlIGNsYXNzPSJjbHMtMyIgY3g9IjE2My42OCIgY3k9IjM4NS44MiIgcj0iNDQuMDgiLz48Y2lyY2xlIGNsYXNzPSJjbHMtMyIgY3g9IjMzMC4yNiIgY3k9IjU2MC43IiByPSI0NC4wOCIvPjxwYXRoIGNsYXNzPSJjbHMtNCIgZD0iTTQ0NC45NCwyNzkuOTIsMjc2LjE5LDQ0OC42N0ExMTkuMzIsMTE5LjMyLDAsMCwwLDQ0NC45NCwyNzkuOTJaIi8+PHBhdGggY2xhc3M9ImNscy0zIiBkPSJNMzc1LjY4LDI0NS43NmExMTkuMzMsMTE5LjMzLDAsMCwwLTk5LjQ5LDIwMi45MUw0NDQuOTQsMjc5LjkyQTExOC44OSwxMTguODksMCwwLDAsMzc1LjY4LDI0NS43NloiLz48L2c+PC9zdmc+
+  description: |-
+    Take the first step in the multicluster journey with multicluster engine.
+  introduction: Follow this quick start to enable the multicluster engine for Kubernetes operator, which comes with your OpenShift entitlement.
+  tasks:
+  - title: Install the multicluster engine for Kubernetes operator
+    description: |-
+      ### To install the multicluster engine for Kubernetes operator:
+
+      1. In the OpenShift Container Platform web console, check the navigation in the upper-left corner to ensure that you are in the **Administrator** perspective.
+
+      2. Click **Operators > OperatorHub**.
+
+      3. To start with basic cluster lifecycle management, search for **multicluster engine for Kubernetes**. This operator support is included in the OpenShift subscription you've already purchased.
+
+      4. Click **Install**.
+
+      5. On the Install Operator page, leave the default settings as is and click **Install**. 
+
+      6. After the operator is installed, you are prompted to install the MultiClusterEngine. Click **Create MultiClusterEngine**.
+
+      7. On the Create MulticlusterEngine page, click **Create**. The default settings will be applied. After the installation is completed, you are prompted to refresh your web console.
+
+      8. Refresh your web console. The cluster switcher is displayed in the upper-left corner of the navigation.
+
+      9. In the upper-left corner of the navigation, from the cluster switcher, click **All Clusters** to go to the new cluster management interface.
+
+    review:
+      instructions: |-
+        #### Verify that the Operator you chose was successfully installed:
+        From the navigation menu, click **Operators > Installed Operators**.
+
+        Does the Status column indicate that the installation succeeded?
+      failedTaskHelp: This task isn't verified yet. Try the task again.
+  conclusion: |-
+    You are now ready to create your first cluster.
+  nextQuickStart: ['']


### PR DESCRIPTION
…4.12.z (#730)

* Create install-multicluster-engine.yaml

Signed-off-by: Maggie Chen <magchen@redhat.com>

* [ACM-2360](https://issues.redhat.com//browse/ACM-2360): Add more steps to host inventory quick start (#703)

* Add more steps to host inventory quick start

Signed-off-by: Maggie Chen <magchen@redhat.com>

* fix texts

Signed-off-by: Maggie Chen <magchen@redhat.com>

* fix 2 issues

Signed-off-by: Maggie Chen <magchen@redhat.com>

Signed-off-by: Maggie Chen <magchen@redhat.com>

* [ACM-2781](https://issues.redhat.com//browse/ACM-2781): Have operator as a prerequisite

Signed-off-by: Maggie Chen <magchen@redhat.com>

* refactor the line

Signed-off-by: Maggie Chen <magchen@redhat.com>

---------

Signed-off-by: Maggie Chen <magchen@redhat.com>
Co-authored-by: Joachim Schuler <jdh.schuler@gmail.com>
Signed-off-by: Maggie Chen <magchen@redhat.com>