### PR TITLE
OCPBUGS-2783: Distinguish between route conditions and remove the old ones

### DIFF
--- a/pkg/console/starter/starter.go
+++ b/pkg/console/starter/starter.go
@@ -440,9 +440,15 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 			// "FooDegraded",
 			//
 			// in 4.8 we removed DonwloadsDeploymentSyncDegraded and can remove this in 4.9
-			"DonwloadsDeploymentSyncDegraded",
+			// "DonwloadsDeploymentSyncDegraded",
 			// in 4.9 we replaced DefaultIngressCertValidation with OAuthServingCertValidation and can remove this in 4.10
-			"DefaultIngressCertValidation",
+			// "DefaultIngressCertValidation",
+			// in 4.13 we are removing CustomRouteSync and DefaultRouteSync
+			// we are need to backport the removal of these conditions all the way down to 4.10
+			// since we only remove the in https://github.com/openshift/console-operator/pull/662
+			// and its cause upgrade issues to the customers
+			"CustomRouteSync",
+			"DefaultRouteSync",
 		},
 		operatorClient,
 		controllerContext.EventRecorder,


### PR DESCRIPTION
This issue was introduce by https://github.com/openshift/console-operator/pull/638/files where we only delivered the fix into the 4.9 release and when upgrading to 4.10 the new conditions havent been cleaned out by the `staleConditionsController`.
Due to that issue we will need to backport to release-4.10

/assign @TheRealJon @stlaz 

ccing @palonsoro 