### PR TITLE
[release-4.11] OCPBUGS-11343: Distinguish between route conditions and remove the old ones

### DIFF
--- a/pkg/console/starter/starter.go
+++ b/pkg/console/starter/starter.go
@@ -390,9 +390,15 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 			// "FooDegraded",
 			//
 			// in 4.8 we removed DonwloadsDeploymentSyncDegraded and can remove this in 4.9
-			"DonwloadsDeploymentSyncDegraded",
+			// "DonwloadsDeploymentSyncDegraded",
 			// in 4.9 we replaced DefaultIngressCertValidation with OAuthServingCertValidation and can remove this in 4.10
-			"DefaultIngressCertValidation",
+			// "DefaultIngressCertValidation",
+			// in 4.13 we are removing CustomRouteSync and DefaultRouteSync
+			// we are need to backport the removal of these conditions all the way down to 4.10
+			// since we only remove the in https://github.com/openshift/console-operator/pull/662
+			// and its cause upgrade issues to the customers
+			"CustomRouteSync",
+			"DefaultRouteSync",
 		},
 		operatorClient,
 		controllerContext.EventRecorder,

--- a/pkg/console/starter/starter.go
+++ b/pkg/console/starter/starter.go
@@ -395,10 +395,12 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 			// "DefaultIngressCertValidation",
 			// in 4.13 we are removing CustomRouteSync and DefaultRouteSync
 			// we are need to backport the removal of these conditions all the way down to 4.10
-			// since we only remove the in https://github.com/openshift/console-operator/pull/662
-			// and its cause upgrade issues to the customers
-			"CustomRouteSync",
-			"DefaultRouteSync",
+			// since we only remove them in https://github.com/openshift/console-operator/pull/662
+			// and its causing upgrade issues to the customers
+			"CustomRouteSyncDegraded",
+			"CustomRouteSyncProgressing",
+			"DefaultRouteSyncDegraded",
+			"DefaultRouteSyncProgressing",
 		},
 		operatorClient,
 		controllerContext.EventRecorder,


### PR DESCRIPTION
Backport of:
- https://github.com/openshift/console-operator/pull/735

/assign @TheRealJon 