### PR TITLE
OCPBUGS-11531: Bump documentationBaseURL to 4.14

### DIFF
--- a/pkg/console/subresource/configmap/brand_ocp.go
+++ b/pkg/console/subresource/configmap/brand_ocp.go
@@ -5,5 +5,5 @@ package configmap
 
 const (
 	DEFAULT_BRAND   = "ocp"
-	DEFAULT_DOC_URL = "https://access.redhat.com/documentation/en-us/openshift_container_platform/4.13/"
+	DEFAULT_DOC_URL = "https://access.redhat.com/documentation/en-us/openshift_container_platform/4.14/"
 )


### PR DESCRIPTION
Bump DEFAULT_DOC_URL to `4.14`