### PR TITLE
OCPBUGS-12990: Update command line tools URL with custom downloads route

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -57,6 +57,7 @@ const (
 	OpenShiftCustomLogoConfigMapName          = "custom-logo"
 	OpenShiftMonitoringConfigMapName          = "monitoring-shared-config"
 	OpenshiftConsoleCustomRouteName           = "console-custom"
+	OpenshiftDownloadsCustomRouteName         = "downloads-custom"
 	OpenshiftConsoleRedirectServiceName       = "console-redirect"
 	RedirectContainerPort                     = 8444
 	RedirectContainerPortName                 = "custom-route-redirect"

--- a/pkg/console/starter/starter.go
+++ b/pkg/console/starter/starter.go
@@ -224,13 +224,16 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 	)
 
 	cliDownloadsController := clidownloads.NewCLIDownloadsSyncController(
+		// top level config
+		configClient.ConfigV1(),
 		// clients
 		operatorClient,
 		operatorConfigClient.OperatorV1(),
 		consoleClient.ConsoleV1().ConsoleCLIDownloads(),
 		routesClient.RouteV1(),
 		// informers
-		operatorConfigInformers.Operator().V1().Consoles(),    // OperatorConfig
+		operatorConfigInformers.Operator().V1().Consoles(), // OperatorConfig
+		configInformers, // Config
 		consoleInformers.Console().V1().ConsoleCLIDownloads(), // ConsoleCliDownloads
 		routesInformersNamespaced.Route().V1().Routes(),       // Routes
 		// events


### PR DESCRIPTION
When the custom downloads route is set we should be updating the ConsoleCLIDownloads link as well.

/assign @spadgett 