### PR TITLE
[release-4.10] OCPBUGS-14845: Distinguish between route conditions and remove the old ones

### DIFF
--- a/pkg/console/controllers/route/controller.go
+++ b/pkg/console/controllers/route/controller.go
@@ -123,17 +123,21 @@ func (c *RouteSyncController) Sync(ctx context.Context, controllerContext factor
 	}
 	routeConfig := routesub.NewRouteConfig(updatedOperatorConfig, ingressConfig, c.routeName)
 
+	typePrefix := fmt.Sprintf("%sCustomRouteSync", strings.Title(c.routeName))
 	// try to sync the custom route first. If the sync fails for any reason, error
 	// out the sync loop and inform about this fact instead of putting default
 	// route into inaccessible state.
 	_, customRouteErrReason, customRouteErr := c.SyncCustomRoute(ctx, routeConfig, controllerContext)
-	statusHandler.AddConditions(status.HandleProgressingOrDegraded("CustomRouteSync", customRouteErrReason, customRouteErr))
+	statusHandler.AddConditions(status.HandleProgressingOrDegraded(typePrefix, customRouteErrReason, customRouteErr))
+	statusHandler.AddCondition(status.HandleUpgradable(typePrefix, customRouteErrReason, customRouteErr))
 	if customRouteErr != nil {
 		return statusHandler.FlushAndReturn(customRouteErr)
 	}
 
+	typePrefix = fmt.Sprintf("%sDefaultRouteSync", strings.Title(c.routeName))
 	_, defaultRouteErrReason, defaultRouteErr := c.SyncDefaultRoute(ctx, routeConfig, controllerContext)
-	statusHandler.AddConditions(status.HandleProgressingOrDegraded("DefaultRouteSync", defaultRouteErrReason, defaultRouteErr))
+	statusHandler.AddConditions(status.HandleProgressingOrDegraded(typePrefix, defaultRouteErrReason, defaultRouteErr))
+	statusHandler.AddCondition(status.HandleUpgradable(typePrefix, defaultRouteErrReason, defaultRouteErr))
 
 	// warn if deprecated configuration of custom domain for 'console' route is set on the console-operator config
 	if (len(operatorConfig.Spec.Route.Hostname) != 0 || len(operatorConfig.Spec.Route.Secret.Name) != 0) && c.routeName == api.OpenShiftConsoleRouteName {

--- a/pkg/console/starter/starter.go
+++ b/pkg/console/starter/starter.go
@@ -393,10 +393,12 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 			// "DefaultIngressCertValidation",
 			// in 4.13 we are removing CustomRouteSync and DefaultRouteSync
 			// we are need to backport the removal of these conditions all the way down to 4.10
-			// since we only remove the in https://github.com/openshift/console-operator/pull/662
-			// and its cause upgrade issues to the customers
-			"CustomRouteSync",
-			"DefaultRouteSync",
+			// since we only remove them in https://github.com/openshift/console-operator/pull/662
+			// and its causing upgrade issues to the customers
+			"CustomRouteSyncDegraded",
+			"CustomRouteSyncProgressing",
+			"DefaultRouteSyncDegraded",
+			"DefaultRouteSyncProgressing",
 		},
 		operatorClient,
 		controllerContext.EventRecorder,

--- a/pkg/console/starter/starter.go
+++ b/pkg/console/starter/starter.go
@@ -388,9 +388,15 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 			// "FooDegraded",
 			//
 			// in 4.8 we removed DonwloadsDeploymentSyncDegraded and can remove this in 4.9
-			"DonwloadsDeploymentSyncDegraded",
+			// "DonwloadsDeploymentSyncDegraded",
 			// in 4.9 we replaced DefaultIngressCertValidation with OAuthServingCertValidation and can remove this in 4.10
-			"DefaultIngressCertValidation",
+			// "DefaultIngressCertValidation",
+			// in 4.13 we are removing CustomRouteSync and DefaultRouteSync
+			// we are need to backport the removal of these conditions all the way down to 4.10
+			// since we only remove the in https://github.com/openshift/console-operator/pull/662
+			// and its cause upgrade issues to the customers
+			"CustomRouteSync",
+			"DefaultRouteSync",
 		},
 		operatorClient,
 		controllerContext.EventRecorder,


### PR DESCRIPTION
Backport of:

- https://github.com/openshift/console-operator/pull/745