### PR TITLE
OCPBUGS-15893: Add missing watch permission for helm-chartrepos-viewers

### DIFF
--- a/manifests/03-rbac-role-cluster.yaml
+++ b/manifests/03-rbac-role-cluster.yaml
@@ -165,6 +165,7 @@ rules:
     verbs:
       - get
       - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole


### PR DESCRIPTION
**Fixes**: 
https://issues.redhat.com/browse/OCPBUGS-15893

**Analysis / Root cause**: 
While analyzing the bug on a 4.10 cluster, we found two issues:

1. When a user with limited permissions ("a developer"), we could the see a canceled websocket API call to watch HelmChartRepositories
    `wss://.../api/kubernetes/apis/helm.openshift.io/v1beta1/helmchartrepositories?watch=true&resourceVersion=70319`
   
   The console (backend) log shows:

   ```
   2023/07/10 12:31:03 Failed to dial backend: 'websocket: bad handshake' Status: '403 Forbidden' URL: 'https://kubernetes.default.svc/apis/helm.openshift.io/v1beta1/helmchartrepositories?watch=true&resourceVersion=44805'
   2023/07/10 12:31:19 Failed to dial backend: 'websocket: bad handshake' Status: '403 Forbidden' URL: 'https://kubernetes.default.svc/apis/helm.openshift.io/v1beta1/helmchartrepositories?watch=true&resourceVersion=44901'
   2023/07/10 12:31:34 Failed to dial backend: 'websocket: bad handshake' Status: '403 Forbidden' URL: 'https://kubernetes.default.svc/apis/helm.openshift.io/v1beta1/helmchartrepositories?watch=true&resourceVersion=44961'
   2023/07/10 12:31:50 Failed to dial backend: 'websocket: bad handshake' Status: '403 Forbidden' URL: 'https://kubernetes.default.svc/apis/helm.openshift.io/v1beta1/helmchartrepositories?watch=true&resourceVersion=45066'
   ```

   The `ClusterRoleBinding` "helm-chartrepos-viewer" gives the user permissions to list these resources, but not to watch them.

2. We created a project/namespace with 300 Deployments and opened the topology. It warns in the used version that this project has many resources. When I continued, I could see ~300 API calls to check the permissions.

   `https://.../api/kubernetes/apis/authorization.k8s.io/v1/selfsubjectaccessreviews`

**Solution Description**: 
1. Added the missing "watch" permission to the `ClusterRoleBinding` "helm-chartrepos-viewer". (This PR.)
2. We reduced the number of API calls in a newer version and will check if we can backport or fix this also in 4.10. (Seperate PR.)

**Screen shots / Gifs for design review**: 
<!-- If change affects UI in any way, tag @openshift/team-devconsole-ux and add screenshots/gifs  -->

**Unit test coverage report**: 
Untouched

**Test setup:**
1. Create a developer / test user
2. Login with this user, open the browser network inspector and filter for "helmchart"
3. Switch to the developer perspective and Navigate to Add > Helm charts

The network inspector should show two GET calls, one to list, one to watch the resources.

If the Status column shows **Finished** this network call **failed** (before):

![image](https://github.com/openshift/console-operator/assets/139310/d8fb2b9d-83bc-4e96-a014-e9dd555a539b)

If the Status column shows **101** Switching Protocols, the network call was successful (with this PR):

![image](https://github.com/openshift/console-operator/assets/139310/6aa4f606-45d6-4cbf-be6f-5aec45d008ea)

**Browser conformance**: 
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
