### PR TITLE
ODC-7333: Add consolesamples to ClusterRole console-extensions-reader to give all users readonly access

### DIFF
--- a/manifests/03-rbac-role-cluster-extensions.yaml
+++ b/manifests/03-rbac-role-cluster-extensions.yaml
@@ -13,13 +13,14 @@ rules:
 - apiGroups:
   - console.openshift.io
   resources:
+  - consoleclidownloads
+  - consoleexternalloglinks
   - consolelinks
   - consolenotifications
-  - consoleexternalloglinks
-  - consoleclidownloads
-  - consoleyamlsamples
-  - consolequickstarts
   - consoleplugins
+  - consolequickstarts
+  - consolesamples
+  - consoleyamlsamples
   verbs:
   - get
   - list


### PR DESCRIPTION
**Fixes:**
Epic: [ODC-7241: Include Serverless Function Samples in our Sample Catalog](https://issues.redhat.com/browse/ODC-7241) 
Story: [ODC-7333: Update console-operator to latest API to provide the ConsoleSample CRD, add RBAC permissions](https://issues.redhat.com/browse/ODC-7333)

**Related issues:**
* https://github.com/openshift/enhancements/pull/1429
  * Rendered preview: https://github.com/jerolimov/openshift-enhancements/blob/console-samples/enhancements/console/samples.md
* https://github.com/openshift/api/pull/1503

**Changes**
Just add `consolesamples` as new resource type to the `ClusterRole` "console-extensions-reader".

**CRD**
To automatically add the CRD it's also required to update the `openshift/api` dependency to the latest version. We can do this as soon as https://github.com/openshift/api/pull/1503 is merged with one of these two PRs:

* https://github.com/openshift/console-operator/pull/769
* https://github.com/openshift/console-operator/pull/771

To add the test the CRD you can apply it with this command to your cluster:

```
oc apply -f https://raw.githubusercontent.com/jerolimov/api/console-samples/console/v1/0000_10_consolesample.crd.yaml
```

Some ConsoleSamples could be found here: https://gist.github.com/jerolimov/2e557df4ea95961dd64a5c32268daadf

```
oc apply -f https://gist.githubusercontent.com/jerolimov/2e557df4ea95961dd64a5c32268daadf/raw/30707b4c1d0001ac5cdde448a109cde7068bf908/knative-console-samples.yaml
oc apply -f https://gist.githubusercontent.com/jerolimov/2e557df4ea95961dd64a5c32268daadf/raw/30707b4c1d0001ac5cdde448a109cde7068bf908/nodeinfo-console-samples.yaml
```
