### PR TITLE
CONSOLE-3624: Add haproxy timeout annotation to console routes

### DIFF
--- a/bindata/routes/console-custom-route.yaml
+++ b/bindata/routes/console-custom-route.yaml
@@ -1,12 +1,14 @@
 # This route 'console-custom' manifest is used in case a custom console route is set
 # either on the ingress config or console-operator config.
-# The 'console-custom' route will be pointing to the 'console' service. 
+# The 'console-custom' route will be pointing to the 'console' service.
 # Only a single custom console route is supported.
 kind: Route
 apiVersion: route.openshift.io/v1
 metadata:
   name: console-custom
   namespace: openshift-console
+  annotations:
+    haproxy.router.openshift.io/timeout: 5m
   labels:
     app: console
 spec:

--- a/bindata/routes/console-route.yaml
+++ b/bindata/routes/console-route.yaml
@@ -1,10 +1,12 @@
 # Default 'console' route manifest.
-# The 'console' route will be pointing to the 'console' service. 
+# The 'console' route will be pointing to the 'console' service.
 kind: Route
 apiVersion: route.openshift.io/v1
 metadata:
   name: console
   namespace: openshift-console
+  annotations:
+    haproxy.router.openshift.io/timeout: 5m
   labels:
     app: console
 spec:

--- a/pkg/console/assets/bindata.go
+++ b/pkg/console/assets/bindata.go
@@ -631,13 +631,15 @@ func pdbDownloadsPdbYaml() (*asset, error) {
 
 var _routesConsoleCustomRouteYaml = []byte(`# This route 'console-custom' manifest is used in case a custom console route is set
 # either on the ingress config or console-operator config.
-# The 'console-custom' route will be pointing to the 'console' service. 
+# The 'console-custom' route will be pointing to the 'console' service.
 # Only a single custom console route is supported.
 kind: Route
 apiVersion: route.openshift.io/v1
 metadata:
   name: console-custom
   namespace: openshift-console
+  annotations:
+    haproxy.router.openshift.io/timeout: 5m
   labels:
     app: console
 spec:
@@ -709,12 +711,14 @@ func routesConsoleRedirectRouteYaml() (*asset, error) {
 }
 
 var _routesConsoleRouteYaml = []byte(`# Default 'console' route manifest.
-# The 'console' route will be pointing to the 'console' service. 
+# The 'console' route will be pointing to the 'console' service.
 kind: Route
 apiVersion: route.openshift.io/v1
 metadata:
   name: console
   namespace: openshift-console
+  annotations:
+    haproxy.router.openshift.io/timeout: 5m
   labels:
     app: console
 spec:


### PR DESCRIPTION
Add 5 minute haproxy timeout annotation to console route to match most browsers' maximum timeout.