### PR TITLE
[release-4.12] OCPBUGS-18563: OLM Pages work when copied CSVs are disabled

### DIFF
--- a/manifests/03-rbac-role-cluster.yaml
+++ b/manifests/03-rbac-role-cluster.yaml
@@ -9,13 +9,13 @@ metadata:
     capability.openshift.io/name: Console
 rules:
   - apiGroups:
-    - ""
+      - ""
     resources:
-    - nodes
+      - nodes
     verbs:
-    - get
-    - list
-    - watch
+      - get
+      - list
+      - watch
   - apiGroups:
       - oauth.openshift.io
     resources:
@@ -82,6 +82,14 @@ rules:
       - cluster.open-cluster-management.io
     resources:
       - managedclusters
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - operators.coreos.com
+    resources:
+      - olmconfigs
     verbs:
       - get
       - list
@@ -183,15 +191,15 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
 rules:
-- apiGroups:
-  - helm.openshift.io
-  resources:
-  - projecthelmchartrepositories
-  verbs:
-  - get
-  - list
-  - update
-  - create
-  - watch 
-  - patch
-  - delete
+  - apiGroups:
+      - helm.openshift.io
+    resources:
+      - projecthelmchartrepositories
+    verbs:
+      - get
+      - list
+      - update
+      - create
+      - watch
+      - patch
+      - delete

--- a/manifests/03-rbac-role-ns-operator.yaml
+++ b/manifests/03-rbac-role-ns-operator.yaml
@@ -9,60 +9,68 @@ metadata:
     include.release.openshift.io/single-node-developer: "true"
     capability.openshift.io/name: Console
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  - events
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - delete
-  - patch
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - apps
-  resources:
-  - deployments
-  - replicasets
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - config.openshift.io
-  resources:
-  - infrastructures
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - "coordination.k8s.io"
-  resources:
-  - leases
-  verbs:
-  - get
-  - create
-  - update
-- apiGroups:
-    - console.openshift.io
-  resources:
-    - consolenotifications
-  verbs:
-    - get
-    - list
-    - watch
-    - create
-    - update
-    - delete
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - events
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - delete
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+      - replicasets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - config.openshift.io
+    resources:
+      - infrastructures
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "coordination.k8s.io"
+    resources:
+      - leases
+    verbs:
+      - get
+      - create
+      - update
+  - apiGroups:
+      - console.openshift.io
+    resources:
+      - consolenotifications
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - delete
+  - apiGroups:
+      - operators.coreos.com
+    resources:
+      - olmconfigs
+    verbs:
+      - get
+      - list
+      - watch

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -73,6 +73,10 @@ const (
 	ManagedClusterClaimVersionAnnotation = "version.openshift.io"
 	ManagedClusterClaimProductAnnotation = "product.open-cluster-management.io"
 
+	OLMConfigGroup    = "operators.coreos.com"
+	OLMConfigVersion  = "v1"
+	OLMConfigResource = "olmconfigs"
+
 	ConsoleContainerPortName    = "https"
 	ConsoleContainerPort        = 443
 	ConsoleContainerTargetPort  = 8443

--- a/pkg/console/starter/starter.go
+++ b/pkg/console/starter/starter.go
@@ -189,6 +189,8 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 		// top level config
 		configClient.ConfigV1(),
 		configInformers,
+		dynamicClient,
+		dynamicInformers,
 		// operator
 		operatorClient,
 		operatorConfigClient.OperatorV1(),

--- a/pkg/console/subresource/configmap/configmap.go
+++ b/pkg/console/subresource/configmap/configmap.go
@@ -52,6 +52,7 @@ func DefaultConfigMap(
 	availablePlugins []*v1.ConsolePlugin,
 	managedClusterConfigFile string,
 	nodeArchitectures []string,
+	copiedCSVsDisabled bool,
 ) (consoleConfigMap *corev1.ConfigMap, unsupportedOverridesHaveMerged bool, err error) {
 
 	defaultBuilder := &consoleserver.ConsoleServerCLIConfigBuilder{}
@@ -65,6 +66,7 @@ func DefaultConfigMap(
 		InactivityTimeout(inactivityTimeoutSeconds).
 		ReleaseVersion().
 		NodesArchitecture(nodeArchitectures).
+		CopiedCSVsDisabled(copiedCSVsDisabled).
 		ConfigYAML()
 	if err != nil {
 		klog.Errorf("failed to generate default console-config config: %v", err)

--- a/pkg/console/subresource/consoleserver/config_builder.go
+++ b/pkg/console/subresource/consoleserver/config_builder.go
@@ -64,6 +64,7 @@ type ConsoleServerCLIConfigBuilder struct {
 	telemetry                  map[string]string
 	releaseVersion             string
 	nodeArchitectures          []string
+	copiedCSVsDisabled         bool
 }
 
 func (b *ConsoleServerCLIConfigBuilder) Host(host string) *ConsoleServerCLIConfigBuilder {
@@ -190,6 +191,11 @@ func (b *ConsoleServerCLIConfigBuilder) NodesArchitecture(architectures []string
 	return b
 }
 
+func (b *ConsoleServerCLIConfigBuilder) CopiedCSVsDisabled(copiedCSVsDisabled bool) *ConsoleServerCLIConfigBuilder {
+	b.copiedCSVsDisabled = copiedCSVsDisabled
+	return b
+}
+
 func (b *ConsoleServerCLIConfigBuilder) Config() Config {
 	return Config{
 		Kind:                     "ConsoleConfig",
@@ -252,6 +258,7 @@ func (b *ConsoleServerCLIConfigBuilder) clusterInfo() ClusterInfo {
 	if len(b.nodeArchitectures) > 0 {
 		conf.NodeArchitectures = b.nodeArchitectures
 	}
+	conf.CopiedCSVsDisabled = b.copiedCSVsDisabled
 	return conf
 }
 

--- a/pkg/console/subresource/consoleserver/types.go
+++ b/pkg/console/subresource/consoleserver/types.go
@@ -68,6 +68,7 @@ type ClusterInfo struct {
 	ControlPlaneToplogy configv1.TopologyMode `yaml:"controlPlaneTopology,omitempty"`
 	ReleaseVersion      string                `yaml:"releaseVersion,omitempty"`
 	NodeArchitectures   []string              `yaml:"nodeArchitectures,omitempty"`
+	CopiedCSVsDisabled  bool                  `yaml:"copiedCSVsDisabled,omitempty"`
 }
 
 // MonitoringInfo holds configuration for monitoring related services


### PR DESCRIPTION
Backport disable copied CSV fix to 4.12

Blocks https://github.com/openshift/console/pull/13055