### PR TITLE
OCPBUGS-20129: Fix triggering `upgradenotification` in the cluster installation time

### DIFF
--- a/pkg/console/controllers/upgradenotification/controller.go
+++ b/pkg/console/controllers/upgradenotification/controller.go
@@ -117,7 +117,7 @@ func (c *UpgradeNotificationController) syncClusterUpgradeNotification(ctx conte
 		}
 		desiredVersion := clusterVersionConfig.Status.Desired.Version
 
-		if currentVersion == desiredVersion {
+		if currentVersion == "" || desiredVersion == "" || currentVersion == desiredVersion {
 			return "", nil
 		}
 


### PR DESCRIPTION
- Check the `currentVersion` and `desiredVersion` variable before triggering the notification.

![image](https://github.com/openshift/console-operator/assets/31133195/a30c62a6-c736-428e-8001-f59eb597508f)
