### PR TITLE
OCPBUGS-15834: Dockerfile: Shift ConsolePlugin CRD after the operator Deployment

### DIFF
--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -16,8 +16,13 @@ COPY manifests /manifests/
 COPY quickstarts/*.yaml /manifests/
 
 # extensions manifests generated from openshift/api types
-COPY vendor/github.com/openshift/api/console/v1/*.crd.yaml /manifests/
-COPY vendor/github.com/openshift/api/console/v1alpha1/*.crd.yaml /manifests/
+COPY vendor/github.com/openshift/api/console/v1/0000_10_consoleclidownload.crd.yaml /manifests/
+COPY vendor/github.com/openshift/api/console/v1/0000_10_consoleexternalloglink.crd.yaml /manifests/
+COPY vendor/github.com/openshift/api/console/v1/0000_10_consolelink.crd.yaml /manifests/
+COPY vendor/github.com/openshift/api/console/v1/0000_10_consolenotification.crd.yaml /manifests/
+COPY vendor/github.com/openshift/api/console/v1/0000_10_consoleplugin.crd.yaml /manifests/08-a-consoleplugin.crd.yaml
+COPY vendor/github.com/openshift/api/console/v1/0000_10_consolequickstart.crd.yaml /manifests/
+COPY vendor/github.com/openshift/api/console/v1/0000_10_consoleyamlsample.crd.yaml /manifests/
 COPY vendor/github.com/openshift/api/operator/v1/0000_70_console-operator.crd.yaml /manifests/
 COPY vendor/github.com/openshift/api/helm/v1beta1/0000_10-helm-chart-repository.crd.yaml /manifests/
 COPY vendor/github.com/openshift/api/helm/v1beta1/0000_10-project-helm-chart-repository.crd.yaml /manifests/


### PR DESCRIPTION
Removing the explicit `0000_10_` runlevel will allow these resources to go in with the other console resources in the default runlevel 50 ([docs][1], [implementation][2].  I'm prefixing ConsolePlugin with ~`90_` to sort it towards the back~ `08-a` sort it after [`07-operator.yaml`][3], because [the operator is what serves the `/crdconvert` webhook defined in that CRD][4], but to sort it before `08-clusteroperator.yaml`, to [avoid][5]:
    
      level=error msg=Cluster operator console Available is False with RouteHealth_FailedLoadCA: RouteHealthAvailable: failed to read CA to check route health: configmaps "trusted-ca-bundle" not found
    
although I'm not entirely clear on why that `trusted-ca-bundle` issue would be related to the positioning of the ConsolePlugin CRD.  Still, even without a clear relationship, console operator health might depend on having the CRD in place, so positioning between the Deployment and the ClusterOperator seems safest.

This is a part of what shifted in openshift/api@9e3e820a70 (openshift/api#1541), but pulled back to 4.12 to address [the 4.11-to-4.12 update race][4].  We don't need to patch 4.13 or later this way, because for 4.12-to-4.13 and later updates, the console deployment is already serving the conversion webhook.  And because this is a one-off just for 4.12.z, I'm using the expanded-`COPY` hack instead of updating the API and vendor-bumping like we're doing in #782 for the development  branch.

[1]: https://github.com/openshift/enhancements/blob/cafeb5c3cba7f8c9e261b2aabffa92e34dd76be6/dev-guide/cluster-version-operator/dev/operators.md#what-is-the-order-that-resources-get-createdupdated-in
[2]: https://github.com/openshift/oc/blob/13225e00caf1ad2d3603e1d1cc8651833f2effcb/pkg/cli/admin/release/new.go#L1412-L1416
[3]: https://github.com/openshift/console-operator/blob/cb08a319271b2f4676d1faae96a5ab10440facb0/manifests/07-operator.yaml
[4]: https://issues.redhat.com/browse/OCPBUGS-15834
[5]: https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_console-operator/791/pull-ci-openshift-console-operator-release-4.12-e2e-gcp-ovn/1699372255974264832#1:build-log.txt%3A6648