### PR TITLE
PoC: allow configuring console in an external OIDC identity provider environments

### DIFF
--- a/manifests/03-rbac-role-cluster.yaml
+++ b/manifests/03-rbac-role-cluster.yaml
@@ -23,13 +23,19 @@ rules:
     verbs:
       - get
       - list
-      - update
       - watch
+  - apiGroups:
+      - oauth.openshift.io
+    resources:
+      - oauthclients
+    verbs:
+      - update
     resourceNames:
       - console
   - apiGroups:
       - config.openshift.io
     resources:
+      - authentications
       - oauths
       - infrastructures
       - ingresses

--- a/manifests/03-rbac-role-ns-openshift-config-managed.yaml
+++ b/manifests/03-rbac-role-ns-openshift-config-managed.yaml
@@ -24,6 +24,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - configmaps
   resourceNames:
   - console-public

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -1,6 +1,8 @@
 package api
 
 const (
+	AuthServerCAMountDir                = "/var/auth-server-ca"
+	AuthServerCAFileName                = "ca.crt"
 	ClusterOperatorName                 = "console"
 	ConfigResourceName                  = "cluster"
 	ConsoleContainerPort                = 443

--- a/pkg/console/controllers/oauthclients/oauthclients.go
+++ b/pkg/console/controllers/oauthclients/oauthclients.go
@@ -1,0 +1,160 @@
+package oauthclients
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1informers "k8s.io/client-go/informers/core/v1"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+	configv1informers "github.com/openshift/client-go/config/informers/externalversions/config/v1"
+	configv1lister "github.com/openshift/client-go/config/listers/config/v1"
+	oauthv1client "github.com/openshift/client-go/oauth/clientset/versioned/typed/oauth/v1"
+	oauthv1informers "github.com/openshift/client-go/oauth/informers/externalversions/oauth/v1"
+	oauthv1lister "github.com/openshift/client-go/oauth/listers/oauth/v1"
+	operatorv1informers "github.com/openshift/client-go/operator/informers/externalversions/operator/v1"
+	operatorv1listers "github.com/openshift/client-go/operator/listers/operator/v1"
+	routev1informers "github.com/openshift/client-go/route/informers/externalversions/route/v1"
+	routev1listers "github.com/openshift/client-go/route/listers/route/v1"
+	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+
+	"github.com/openshift/console-operator/pkg/api"
+	"github.com/openshift/console-operator/pkg/console/operator"
+	"github.com/openshift/console-operator/pkg/console/status"
+	oauthsub "github.com/openshift/console-operator/pkg/console/subresource/oauthclient"
+	routesub "github.com/openshift/console-operator/pkg/console/subresource/route"
+	secretsub "github.com/openshift/console-operator/pkg/console/subresource/secret"
+	"github.com/openshift/console-operator/pkg/crypto"
+)
+
+type oauthClientsController struct {
+	oauthClient    oauthv1client.OAuthClientsGetter
+	operatorClient v1helpers.OperatorClient
+	secretsClient  corev1client.SecretsGetter
+
+	oauthClientLister     oauthv1lister.OAuthClientLister
+	authnLister           configv1lister.AuthenticationLister
+	consoleOperatorLister operatorv1listers.ConsoleLister
+	routesLister          routev1listers.RouteLister
+	ingressConfigLister   configv1lister.IngressLister
+	targetNSSecretsLister corev1listers.SecretLister
+}
+
+func NewOAuthClientsController(
+	operatorClient v1helpers.OperatorClient,
+	oauthClient oauthv1client.OAuthClientsGetter,
+	secretsClient corev1client.SecretsGetter,
+	oauthClientInformer oauthv1informers.OAuthClientInformer,
+	authnInformer configv1informers.AuthenticationInformer,
+	consoleOperatorInformer operatorv1informers.ConsoleInformer,
+	routeInformer routev1informers.RouteInformer,
+	ingressConfigInformer configv1informers.IngressInformer,
+	targetNSsecretsInformer corev1informers.SecretInformer,
+	recorder events.Recorder,
+) factory.Controller {
+	c := oauthClientsController{
+		oauthClient:    oauthClient,
+		operatorClient: operatorClient,
+		secretsClient:  secretsClient,
+
+		oauthClientLister:     oauthClientInformer.Lister(),
+		authnLister:           authnInformer.Lister(),
+		consoleOperatorLister: consoleOperatorInformer.Lister(),
+		routesLister:          routeInformer.Lister(),
+		ingressConfigLister:   ingressConfigInformer.Lister(),
+		targetNSSecretsLister: targetNSsecretsInformer.Lister(),
+	}
+
+	return factory.New().
+		WithSync(c.sync).
+		WithInformers(
+			oauthClientInformer.Informer(),
+			authnInformer.Informer(),
+			consoleOperatorInformer.Informer(),
+			routeInformer.Informer(),
+			ingressConfigInformer.Informer(),
+			targetNSsecretsInformer.Informer(),
+		).
+		WithSyncDegradedOnError(operatorClient).
+		ToController("OAuthClientsController", recorder.WithComponentSuffix("oauth-clients-controller"))
+}
+
+func (c *oauthClientsController) sync(ctx context.Context, controllerContext factory.SyncContext) error {
+	statusHandler := status.NewStatusHandler(c.operatorClient)
+
+	operatorConfig, err := c.consoleOperatorLister.Get("cluster")
+	if err != nil {
+		return err
+	}
+
+	ingressConfig, err := c.ingressConfigLister.Get(api.ConfigResourceName)
+	if err != nil {
+		return err
+	}
+
+	routeName := api.OpenShiftConsoleRouteName
+	routeConfig := routesub.NewRouteConfig(operatorConfig, ingressConfig, routeName)
+	if routeConfig.IsCustomHostnameSet() {
+		routeName = api.OpenshiftConsoleCustomRouteName
+	}
+
+	_, consoleURL, _, routeErr := operator.GetActiveRouteInfo(ctx, c.routesLister, routeName)
+	if routeErr != nil {
+		return routeErr
+	}
+
+	clientSecret, _, secErr := c.syncSecret(ctx, operatorConfig, controllerContext.Recorder())
+	statusHandler.AddConditions(status.HandleProgressingOrDegraded("OAuthClientSecretSync", "FailedApply", secErr))
+	if secErr != nil {
+		return statusHandler.FlushAndReturn(secErr)
+	}
+
+	oauthErrReason, oauthErr := c.syncOAuthClient(ctx, clientSecret, consoleURL.String())
+	statusHandler.AddConditions(status.HandleProgressingOrDegraded("OAuthClientSync", oauthErrReason, oauthErr))
+	if oauthErr != nil {
+		return statusHandler.FlushAndReturn(oauthErr)
+	}
+
+	return nil
+}
+
+func (c *oauthClientsController) syncSecret(ctx context.Context, operatorConfig *operatorv1.Console, recorder events.Recorder) (*corev1.Secret, bool, error) {
+	secret, err := c.targetNSSecretsLister.Secrets(api.TargetNamespace).Get(secretsub.Stub().Name)
+	if apierrors.IsNotFound(err) || secretsub.GetSecretString(secret) == "" {
+		return resourceapply.ApplySecret(ctx, c.secretsClient, recorder, secretsub.DefaultSecret(operatorConfig, crypto.Random256BitsString()))
+	}
+	// any error should be returned & kill the sync loop
+	if err != nil {
+		return nil, false, err
+	}
+	return secret, false, nil
+}
+
+// applies changes to the oauthclient
+// should not be called until route & secret dependencies are verified
+func (c *oauthClientsController) syncOAuthClient(
+	ctx context.Context,
+	sec *corev1.Secret,
+	consoleURL string,
+) (reason string, err error) {
+	oauthClient, err := c.oauthClient.OAuthClients().Get(ctx, oauthsub.Stub().Name, metav1.GetOptions{})
+	if err != nil {
+		// at this point we must die & wait for someone to fix the lack of an outhclient. there is nothing we can do.
+		return "FailedGet", errors.New(fmt.Sprintf("oauth client for console does not exist and cannot be created (%v)", err))
+	}
+	oauthsub.RegisterConsoleToOAuthClient(oauthClient, consoleURL, secretsub.GetSecretString(sec))
+	_, _, oauthErr := oauthsub.CustomApplyOAuth(c.oauthClient, oauthClient, ctx)
+	if oauthErr != nil {
+		return "FailedRegister", oauthErr
+	}
+	return "", nil
+}

--- a/pkg/console/starter/starter.go
+++ b/pkg/console/starter/starter.go
@@ -53,7 +53,6 @@ import (
 	consolev1client "github.com/openshift/client-go/console/clientset/versioned"
 	consoleinformers "github.com/openshift/client-go/console/informers/externalversions"
 
-	"github.com/openshift/console-operator/pkg/console/clientwrapper"
 	"github.com/openshift/console-operator/pkg/console/operator"
 	"github.com/openshift/library-go/pkg/operator/loglevel"
 )
@@ -156,7 +155,7 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 
 	versionGetter := status.NewVersionGetter()
 
-	resourceSyncerInformers, resourceSyncer := getResourceSyncer(controllerContext, clientwrapper.WithoutSecret(kubeClient), operatorClient)
+	resourceSyncerInformers, resourceSyncer := getResourceSyncer(controllerContext, kubeClient, operatorClient)
 
 	err = startStaticResourceSyncing(resourceSyncer)
 	if err != nil {
@@ -499,6 +498,14 @@ func startStaticResourceSyncing(resourceSyncer *resourcesynccontroller.ResourceS
 	err := resourceSyncer.SyncConfigMap(
 		resourcesynccontroller.ResourceLocation{Name: api.OAuthServingCertConfigMapName, Namespace: api.OpenShiftConsoleNamespace},
 		resourcesynccontroller.ResourceLocation{Name: api.OAuthServingCertConfigMapName, Namespace: api.OpenShiftConfigManagedNamespace},
+	)
+	if err != nil {
+		return err
+	}
+
+	err = resourceSyncer.SyncSecret(
+		resourcesynccontroller.ResourceLocation{Name: "console-client-config", Namespace: api.TargetNamespace},
+		resourcesynccontroller.ResourceLocation{Name: "console-client-config", Namespace: api.OpenShiftConfigNamespace},
 	)
 	if err != nil {
 		return err

--- a/pkg/console/starter/starter.go
+++ b/pkg/console/starter/starter.go
@@ -204,6 +204,7 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 		routesInformersNamespaced.Route().V1().Routes(),
 		configInformers.Config().V1().Ingresses(),
 		kubeInformersNamespaced.Core().V1().Secrets(),
+		kubeInformersConfigNamespaced.Core().V1().Secrets(),
 		recorder,
 	)
 

--- a/pkg/console/subresource/configmap/configmap.go
+++ b/pkg/console/subresource/configmap/configmap.go
@@ -44,7 +44,7 @@ func DefaultConfigMap(
 	operatorConfig *operatorv1.Console,
 	consoleConfig *configv1.Console,
 	authConfig *configv1.Authentication,
-	oauthClientSecret *corev1.Secret,
+	oidcConfig *corev1.Secret,
 	managedConfig *corev1.ConfigMap,
 	monitoringSharedConfig *corev1.ConfigMap,
 	infrastructureConfig *configv1.Infrastructure,
@@ -100,7 +100,8 @@ func DefaultConfigMap(
 		ReleaseVersion().
 		NodeArchitectures(nodeArchitectures).
 		NodeOperatingSystems(nodeOperatingSystems).
-		OAuthClientID(authConfig, oauthClientSecret).
+		OAuthClientID(authConfig, oidcConfig).
+		AuthServerCA(authConfig, oidcConfig).
 		ConfigYAML()
 	if err != nil {
 		klog.Errorf("failed to generate user defined console-config config: %v", err)

--- a/pkg/console/subresource/configmap/configmap.go
+++ b/pkg/console/subresource/configmap/configmap.go
@@ -43,6 +43,8 @@ func statusPageId(operatorConfig *operatorv1.Console) string {
 func DefaultConfigMap(
 	operatorConfig *operatorv1.Console,
 	consoleConfig *configv1.Console,
+	authConfig *configv1.Authentication,
+	oauthClientSecret *corev1.Secret,
 	managedConfig *corev1.ConfigMap,
 	monitoringSharedConfig *corev1.ConfigMap,
 	infrastructureConfig *configv1.Infrastructure,
@@ -98,6 +100,7 @@ func DefaultConfigMap(
 		ReleaseVersion().
 		NodeArchitectures(nodeArchitectures).
 		NodeOperatingSystems(nodeOperatingSystems).
+		OAuthClientID(authConfig, oauthClientSecret).
 		ConfigYAML()
 	if err != nil {
 		klog.Errorf("failed to generate user defined console-config config: %v", err)

--- a/pkg/console/subresource/configmap/configmap.go
+++ b/pkg/console/subresource/configmap/configmap.go
@@ -100,7 +100,7 @@ func DefaultConfigMap(
 		ReleaseVersion().
 		NodeArchitectures(nodeArchitectures).
 		NodeOperatingSystems(nodeOperatingSystems).
-		OAuthClientID(authConfig, oidcConfig).
+		OAuthClientConfig(authConfig, oidcConfig).
 		AuthServerCA(authConfig, oidcConfig).
 		ConfigYAML()
 	if err != nil {

--- a/pkg/console/subresource/configmap/configmap_test.go
+++ b/pkg/console/subresource/configmap/configmap_test.go
@@ -50,9 +50,11 @@ nV5cXbp9W1bC12Tc8nnNXn4ypLE2JTQAvyp51zoZ8hQoSnRVx/VCY55Yu+br8gQZ
 func TestDefaultConfigMap(t *testing.T) {
 	type args struct {
 		operatorConfig           *operatorv1.Console
+		authConfig               *configv1.Authentication
 		consoleConfig            *configv1.Console
 		managedConfig            *corev1.ConfigMap
 		monitoringSharedConfig   *corev1.ConfigMap
+		oauthClientSecret        *corev1.Secret
 		infrastructureConfig     *configv1.Infrastructure
 		rt                       *routev1.Route
 		inactivityTimeoutSeconds int
@@ -70,6 +72,7 @@ func TestDefaultConfigMap(t *testing.T) {
 		{
 			name: "Test default configmap, no customization",
 			args: args{
+				authConfig:     &configv1.Authentication{},
 				operatorConfig: &operatorv1.Console{},
 				consoleConfig:  &configv1.Console{},
 				managedConfig:  &corev1.ConfigMap{},
@@ -126,6 +129,7 @@ providers: {}
 		{
 			name: "Test configmap with oauth-serving-cert",
 			args: args{
+				authConfig:     &configv1.Authentication{},
 				operatorConfig: &operatorv1.Console{},
 				consoleConfig:  &configv1.Console{},
 				managedConfig:  &corev1.ConfigMap{},
@@ -180,6 +184,7 @@ providers: {}
 		{
 			name: "Test managed config to override default config",
 			args: args{
+				authConfig:     &configv1.Authentication{},
 				operatorConfig: &operatorv1.Console{},
 				consoleConfig:  &configv1.Console{},
 				managedConfig: &corev1.ConfigMap{
@@ -246,6 +251,7 @@ providers: {}
 		{
 			name: "Test nodeOperatingSystems config",
 			args: args{
+				authConfig:     &configv1.Authentication{},
 				operatorConfig: &operatorv1.Console{},
 				consoleConfig:  &configv1.Console{},
 				managedConfig: &corev1.ConfigMap{
@@ -312,6 +318,7 @@ providers: {}
 		{
 			name: "Test operator config overriding default config and managed config",
 			args: args{
+				authConfig: &configv1.Authentication{},
 				operatorConfig: &operatorv1.Console{
 					Spec: operatorv1.ConsoleSpec{
 						OperatorSpec: operatorv1.OperatorSpec{},
@@ -383,6 +390,7 @@ providers: {}
 		{
 			name: "Test operator config with Custom Branding Values",
 			args: args{
+				authConfig: &configv1.Authentication{},
 				operatorConfig: &operatorv1.Console{
 					Spec: operatorv1.ConsoleSpec{
 						OperatorSpec: operatorv1.OperatorSpec{},
@@ -461,6 +469,7 @@ providers: {}
 		{
 			name: "Test operator config with Statuspage pageID",
 			args: args{
+				authConfig: &configv1.Authentication{},
 				operatorConfig: &operatorv1.Console{
 					Spec: operatorv1.ConsoleSpec{
 						OperatorSpec: operatorv1.OperatorSpec{},
@@ -538,6 +547,7 @@ providers:
 		{
 			name: "Test operator config with custom route hostname",
 			args: args{
+				authConfig: &configv1.Authentication{},
 				operatorConfig: &operatorv1.Console{
 					Spec: operatorv1.ConsoleSpec{
 						Route: operatorv1.ConsoleConfigRoute{
@@ -599,6 +609,7 @@ providers: {}
 		{
 			name: "Test operator config, with inactivityTimeoutSeconds set",
 			args: args{
+				authConfig:     &configv1.Authentication{},
 				operatorConfig: &operatorv1.Console{},
 				consoleConfig:  &configv1.Console{},
 				managedConfig:  &corev1.ConfigMap{},
@@ -654,6 +665,7 @@ providers: {}
 		{
 			name: "Test operator config, with enabledPlugins set",
 			args: args{
+				authConfig:     &configv1.Authentication{},
 				operatorConfig: &operatorv1.Console{},
 				consoleConfig:  &configv1.Console{},
 				managedConfig:  &corev1.ConfigMap{},
@@ -757,6 +769,7 @@ nV5cXbp9W1bC12Tc8nnNXn4ypLE2JTQAvyp51zoZ8hQoSnRVx/VCY55Yu+br8gQZ` + "\n" + `
 		{
 			name: "Test operator config, with 'External' ControlPlaneTopology",
 			args: args{
+				authConfig:     &configv1.Authentication{},
 				operatorConfig: &operatorv1.Console{},
 				consoleConfig:  &configv1.Console{},
 				managedConfig:  &corev1.ConfigMap{},
@@ -813,6 +826,7 @@ providers: {}
 		{
 			name: "Test operator config, with CopiedCSVsDisabled",
 			args: args{
+				authConfig:     &configv1.Authentication{},
 				operatorConfig: &operatorv1.Console{},
 				consoleConfig:  &configv1.Console{},
 				managedConfig:  &corev1.ConfigMap{},
@@ -871,6 +885,7 @@ providers: {}
 		{
 			name: "Test default configmap with monitoring config",
 			args: args{
+				authConfig:     &configv1.Authentication{},
 				operatorConfig: &operatorv1.Console{},
 				consoleConfig:  &configv1.Console{},
 				managedConfig:  &corev1.ConfigMap{},
@@ -939,6 +954,8 @@ providers: {}
 			cm, _, _ := DefaultConfigMap(
 				tt.args.operatorConfig,
 				tt.args.consoleConfig,
+				tt.args.authConfig,
+				tt.args.oauthClientSecret,
 				tt.args.managedConfig,
 				tt.args.monitoringSharedConfig,
 				tt.args.infrastructureConfig,

--- a/pkg/console/subresource/consoleserver/config_builder_test.go
+++ b/pkg/console/subresource/consoleserver/config_builder_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/go-test/deep"
+	configv1 "github.com/openshift/api/config/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	v1 "github.com/openshift/api/operator/v1"
 	"github.com/openshift/console-operator/pkg/api"
@@ -754,6 +755,27 @@ auth:
   clientID: console
   clientSecretFile: /var/oauth-config/clientSecret
   oauthEndpointCAFile: /var/oauth-serving-cert/ca-bundle.crt
+customization: {}
+providers: {}
+`,
+		},
+		{
+			name: "Config builder should return modified client ID if overriden by user",
+			input: func() ([]byte, error) {
+				b := &ConsoleServerCLIConfigBuilder{}
+				return b.OAuthClientID(&configv1.Authentication{Spec: configv1.AuthenticationSpec{Type: "OIDC"}}, &corev1.Secret{Data: map[string][]byte{"client-id": []byte("testing-id")}}).ConfigYAML()
+			},
+			output: `apiVersion: console.openshift.io/v1
+kind: ConsoleConfig
+servingInfo:
+  bindAddress: https://[::]:8443
+  certFile: /var/serving-cert/tls.crt
+  keyFile: /var/serving-cert/tls.key
+clusterInfo: {}
+auth:
+  clientID: testing-id
+  clientSecretFile: /var/oauth-config/clientSecret
+  oauthEndpointCAFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
 customization: {}
 providers: {}
 `,

--- a/pkg/console/subresource/consoleserver/config_builder_test.go
+++ b/pkg/console/subresource/consoleserver/config_builder_test.go
@@ -781,7 +781,7 @@ providers: {}
 			name: "Config builder should return modified client ID if overriden by user",
 			input: func() ([]byte, error) {
 				b := &ConsoleServerCLIConfigBuilder{}
-				return b.OAuthClientID(&configv1.Authentication{Spec: configv1.AuthenticationSpec{Type: "OIDC"}}, &corev1.Secret{Data: map[string][]byte{"client-id": []byte("testing-id")}}).ConfigYAML()
+				return b.OAuthClientConfig(&configv1.Authentication{Spec: configv1.AuthenticationSpec{Type: "OIDC"}}, &corev1.Secret{Data: map[string][]byte{"client-id": []byte("testing-id")}}).ConfigYAML()
 			},
 			output: `apiVersion: console.openshift.io/v1
 kind: ConsoleConfig
@@ -791,6 +791,7 @@ servingInfo:
   keyFile: /var/serving-cert/tls.key
 clusterInfo: {}
 auth:
+  authType: oidc
   clientID: testing-id
   clientSecretFile: /var/oauth-config/clientSecret
 customization: {}
@@ -1331,7 +1332,6 @@ servingInfo:
   keyFile: /var/serving-cert/tls.key
 clusterInfo: {}
 auth:
-  authType: oidc
   clientID: console
   clientSecretFile: /var/oauth-config/clientSecret
 customization: {}

--- a/pkg/console/subresource/consoleserver/config_merger_test.go
+++ b/pkg/console/subresource/consoleserver/config_merger_test.go
@@ -3,7 +3,7 @@ package consoleserver
 import (
 	"testing"
 
-	"github.com/go-test/deep"
+	"github.com/google/go-cmp/cmp"
 	v1 "github.com/openshift/api/operator/v1"
 )
 
@@ -44,7 +44,6 @@ auth:
   clientID: console
   clientSecretFile: /var/oauth-config/clientSecret
   logoutRedirect: https://foobar.com/logout
-  oauthEndpointCAFile: /var/oauth-serving-cert/ca-bundle.crt
 clusterInfo:
   consoleBaseAddress: https://console-openshift-console.apps.foobar.com
   masterPublicURL: https://foobar.com/api
@@ -65,7 +64,7 @@ servingInfo:
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			input, _ := tt.input()
-			if diff := deep.Equal(string(input), tt.output); diff != nil {
+			if diff := cmp.Diff(tt.output, string(input)); len(diff) > 0 {
 				t.Error(diff)
 			}
 		})

--- a/pkg/console/subresource/consoleserver/types.go
+++ b/pkg/console/subresource/consoleserver/types.go
@@ -80,11 +80,14 @@ type MonitoringInfo struct {
 
 // Auth holds configuration for authenticating with OpenShift. The auth method is assumed to be "openshift".
 type Auth struct {
-	ClientID                 string `yaml:"clientID,omitempty"`
-	ClientSecretFile         string `yaml:"clientSecretFile,omitempty"`
-	OAuthEndpointCAFile      string `yaml:"oauthEndpointCAFile,omitempty"`
-	LogoutRedirect           string `yaml:"logoutRedirect,omitempty"`
-	InactivityTimeoutSeconds int    `yaml:"inactivityTimeoutSeconds,omitempty"`
+	AuthType                 string   `yaml:"authType,omitempty"`
+	OIDCIssuer               string   `yaml:"oidcIssuer,omitempty"`
+	OIDCExtraScopes          []string `yaml:"oidcExtraScopes,omitempty"`
+	ClientID                 string   `yaml:"clientID,omitempty"`
+	ClientSecretFile         string   `yaml:"clientSecretFile,omitempty"`
+	OAuthEndpointCAFile      string   `yaml:"oauthEndpointCAFile,omitempty"`
+	LogoutRedirect           string   `yaml:"logoutRedirect,omitempty"`
+	InactivityTimeoutSeconds int      `yaml:"inactivityTimeoutSeconds,omitempty"`
 }
 
 // Customization holds configuration such as what logo to use.

--- a/pkg/console/subresource/deployment/deployment_test.go
+++ b/pkg/console/subresource/deployment/deployment_test.go
@@ -39,11 +39,13 @@ func TestDefaultDeployment(t *testing.T) {
 		consoleConfig                  *corev1.ConfigMap
 		serviceCAConfigMap             *corev1.ConfigMap
 		localOAuthServingCertConfigMap *corev1.ConfigMap
+		authServerCAConfigMap          *corev1.Secret
 		trustedCAConfigMap             *corev1.ConfigMap
 		oAuthClientSecret              *corev1.Secret
 		proxyConfig                    *configv1.Proxy
-		infrastructureConfig           *configv1.Infrastructure
-		canMountCustomLogo             bool
+		// authnConfig                    *configv1.Authentication // FIXME: unused, add unit tests around this config
+		infrastructureConfig *configv1.Infrastructure
+		canMountCustomLogo   bool
 	}
 
 	consoleOperatorConfig := &operatorsv1.Console{
@@ -168,10 +170,14 @@ func TestDefaultDeployment(t *testing.T) {
 	infrastructureConfigExternalTopologyMode := infrastructureConfigWithTopology(configv1.ExternalTopologyMode)
 	consoleDeploymentTemplate := resourceread.ReadDeploymentV1OrDie(bindata.MustAsset("assets/deployments/console-deployment.yaml"))
 	withConsoleContainerImage(consoleDeploymentTemplate, consoleOperatorConfig, proxyConfig)
-	withConsoleVolumes(consoleDeploymentTemplate, trustedCAConfigMapEmpty, false)
+	withConsoleVolumes(consoleDeploymentTemplate, &corev1.ConfigMap{
+		Data: map[string]string{"ca-bundle.crt": "test"},
+	}, nil, trustedCAConfigMapEmpty, false)
 	consoleDeploymentContainer := consoleDeploymentTemplate.Spec.Template.Spec.Containers[0]
 	consoleDeploymentVolumes := consoleDeploymentTemplate.Spec.Template.Spec.Volumes
-	withConsoleVolumes(consoleDeploymentTemplate, trustedCAConfigMapSet, false)
+	withConsoleVolumes(consoleDeploymentTemplate, &corev1.ConfigMap{
+		Data: map[string]string{"ca-bundle.crt": "test"},
+	}, nil, trustedCAConfigMapSet, false)
 	consoleDeploymentContainerTrusted := consoleDeploymentTemplate.Spec.Template.Spec.Containers[0]
 	consoleDeploymentVolumesTrusted := consoleDeploymentTemplate.Spec.Template.Spec.Volumes
 
@@ -503,6 +509,7 @@ func TestDefaultDeployment(t *testing.T) {
 				tt.args.consoleConfig,
 				tt.args.localOAuthServingCertConfigMap,
 				tt.args.consoleConfig,
+				tt.args.authServerCAConfigMap,
 				tt.args.trustedCAConfigMap,
 				tt.args.oAuthClientSecret,
 				tt.args.proxyConfig,
@@ -863,20 +870,6 @@ func TestWithConsoleVolumes(t *testing.T) {
 		},
 	}
 
-	oauthServingCertVolume := corev1.Volume{
-		Name: api.OAuthServingCertConfigMapName,
-		VolumeSource: corev1.VolumeSource{
-			ConfigMap: &corev1.ConfigMapVolumeSource{
-				LocalObjectReference: corev1.LocalObjectReference{
-					Name: api.OAuthServingCertConfigMapName,
-				},
-				Items:       nil,
-				DefaultMode: nil,
-				Optional:    nil,
-			},
-		},
-	}
-
 	customLogoVolume := corev1.Volume{
 		Name: api.OpenShiftCustomLogoConfigMapName,
 		VolumeSource: corev1.VolumeSource{
@@ -916,7 +909,6 @@ func TestWithConsoleVolumes(t *testing.T) {
 		consoleOauthConfigVolume,
 		consoleConfigVolume,
 		serviceCAVolume,
-		oauthServingCertVolume,
 	}
 	trustedVolumes := append(defaultVolumes, trustedCAVolume)
 	customLogoVolumes := append(defaultVolumes, customLogoVolume)
@@ -946,12 +938,6 @@ func TestWithConsoleVolumes(t *testing.T) {
 		MountPath: "/var/service-ca",
 	}
 
-	oauthServingCertVolumeMount := corev1.VolumeMount{
-		Name:      api.OAuthServingCertConfigMapName,
-		ReadOnly:  true,
-		MountPath: "/var/oauth-serving-cert",
-	}
-
 	trustedCAVolumeMount := corev1.VolumeMount{
 		Name:      api.TrustedCAConfigMapName,
 		ReadOnly:  true,
@@ -969,7 +955,6 @@ func TestWithConsoleVolumes(t *testing.T) {
 		consoleOauthConfigVolumeMount,
 		consoleConfigVolumeMount,
 		serviceCAVolumeMount,
-		oauthServingCertVolumeMount,
 	}
 	trustedVolumeMounts := append(defaultVolumeMounts, trustedCAVolumeMount)
 	customLogoVolumeMounts := append(defaultVolumeMounts, customLogoVolumeMount)
@@ -1077,6 +1062,8 @@ func TestWithConsoleVolumes(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			withConsoleVolumes(
 				tt.args.deployment,
+				nil,
+				nil,
 				tt.args.trustedCAConfigMap,
 				tt.args.canMountCustomLogo,
 			)


### PR DESCRIPTION
/cc @sjenning @deads2k @liouk 

/hold
This is currently a PoC, final version should use actual API instead of grabbing config from a secret.

TODOs:
- [x] don't look for oauth-server-cert if authn=None | OIDC, make it possible to configure the CA via the secret

Allows client ID/secret and OIDC CA config via secret:
```
openshift-config/console-client-config

.data:
  issuer
  client-id
  client-secret
  ca.crt
  extra-scopes
```