### PR TITLE
HOSTEDCP-1250: remove redundant cert check

### DIFF
--- a/pkg/console/operator/sync_v400.go
+++ b/pkg/console/operator/sync_v400.go
@@ -368,16 +368,6 @@ func (co *consoleOperator) SyncConfigMap(
 	}
 	nodeArchitectures, nodeOperatingSystems := getNodeComputeEnvironments(nodeList)
 
-	useDefaultCAFile := false
-	// We are syncing the `oauth-serving-cert` configmap from `openshift-config-managed` to `openshift-console`.
-	// `oauth-serving-cert` is only published in `openshift-config-managed` in OpenShift 4.9.0 and newer.
-	// If the `oauth-serving-cert` configmap in `openshift-console` exists, we should mount that to the console container,
-	// otherwise default to `/var/run/secrets/kubernetes.io/serviceaccount/ca.crt`
-	_, rcaErr := co.configMapClient.ConfigMaps(api.OpenShiftConsoleNamespace).Get(ctx, api.OAuthServingCertConfigMapName, metav1.GetOptions{})
-	if rcaErr != nil && apierrors.IsNotFound(rcaErr) {
-		useDefaultCAFile = true
-	}
-
 	inactivityTimeoutSeconds := 0
 	oauthClient, oacErr := co.oauthClient.OAuthClients().Get(ctx, oauthsub.Stub().Name, metav1.GetOptions{})
 	if oacErr != nil {
@@ -410,7 +400,6 @@ func (co *consoleOperator) SyncConfigMap(
 		monitoringSharedConfig,
 		infrastructureConfig,
 		activeConsoleRoute,
-		useDefaultCAFile,
 		inactivityTimeoutSeconds,
 		availablePlugins,
 		nodeArchitectures,

--- a/pkg/console/subresource/configmap/configmap.go
+++ b/pkg/console/subresource/configmap/configmap.go
@@ -47,7 +47,6 @@ func DefaultConfigMap(
 	monitoringSharedConfig *corev1.ConfigMap,
 	infrastructureConfig *configv1.Infrastructure,
 	activeConsoleRoute *routev1.Route,
-	useDefaultCAFile bool,
 	inactivityTimeoutSeconds int,
 	availablePlugins []*v1.ConsolePlugin,
 	nodeArchitectures []string,
@@ -60,7 +59,6 @@ func DefaultConfigMap(
 		LogoutURL(defaultLogoutURL).
 		Brand(DEFAULT_BRAND).
 		DocURL(DEFAULT_DOC_URL).
-		OAuthServingCert(useDefaultCAFile).
 		APIServerURL(getApiUrl(infrastructureConfig)).
 		Monitoring(monitoringSharedConfig).
 		InactivityTimeout(inactivityTimeoutSeconds).
@@ -80,7 +78,6 @@ func DefaultConfigMap(
 		LogoutURL(consoleConfig.Spec.Authentication.LogoutRedirect).
 		Brand(operatorConfig.Spec.Customization.Brand).
 		DocURL(operatorConfig.Spec.Customization.DocumentationBaseURL).
-		OAuthServingCert(useDefaultCAFile).
 		APIServerURL(getApiUrl(infrastructureConfig)).
 		TopologyMode(infrastructureConfig.Status.ControlPlaneTopology).
 		Monitoring(monitoringSharedConfig).

--- a/pkg/console/subresource/configmap/configmap_test.go
+++ b/pkg/console/subresource/configmap/configmap_test.go
@@ -55,7 +55,6 @@ func TestDefaultConfigMap(t *testing.T) {
 		monitoringSharedConfig   *corev1.ConfigMap
 		infrastructureConfig     *configv1.Infrastructure
 		rt                       *routev1.Route
-		useDefaultCAFile         bool
 		inactivityTimeoutSeconds int
 		availablePlugins         []*v1.ConsolePlugin
 		nodeArchitectures        []string
@@ -88,7 +87,6 @@ func TestDefaultConfigMap(t *testing.T) {
 						Host: host,
 					},
 				},
-				useDefaultCAFile:         true,
 				inactivityTimeoutSeconds: 0,
 			},
 			want: &corev1.ConfigMap{
@@ -107,7 +105,7 @@ apiVersion: console.openshift.io/v1
 auth:
   clientID: console
   clientSecretFile: /var/oauth-config/clientSecret
-  oauthEndpointCAFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+  oauthEndpointCAFile: /var/oauth-serving-cert/ca-bundle.crt
 clusterInfo:
   consoleBaseAddress: https://` + host + `
   masterPublicURL: ` + mockAPIServer + `
@@ -144,7 +142,6 @@ providers: {}
 						Host: host,
 					},
 				},
-				useDefaultCAFile:         false,
 				inactivityTimeoutSeconds: 0,
 			},
 			want: &corev1.ConfigMap{
@@ -207,7 +204,6 @@ customization:
 						Host: host,
 					},
 				},
-				useDefaultCAFile:         true,
 				inactivityTimeoutSeconds: 0,
 				nodeArchitectures:        []string{"amd64", "arm64"},
 			},
@@ -227,7 +223,7 @@ apiVersion: console.openshift.io/v1
 auth:
   clientID: console
   clientSecretFile: /var/oauth-config/clientSecret
-  oauthEndpointCAFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+  oauthEndpointCAFile: /var/oauth-serving-cert/ca-bundle.crt
 clusterInfo:
   consoleBaseAddress: https://` + host + `
   masterPublicURL: ` + mockAPIServer + `
@@ -274,7 +270,6 @@ customization:
 						Host: host,
 					},
 				},
-				useDefaultCAFile:         true,
 				inactivityTimeoutSeconds: 0,
 				nodeOperatingSystems:     []string{"foo", "bar"},
 			},
@@ -294,7 +289,7 @@ apiVersion: console.openshift.io/v1
 auth:
   clientID: console
   clientSecretFile: /var/oauth-config/clientSecret
-  oauthEndpointCAFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+  oauthEndpointCAFile: /var/oauth-serving-cert/ca-bundle.crt
 clusterInfo:
   consoleBaseAddress: https://` + host + `
   masterPublicURL: ` + mockAPIServer + `
@@ -350,7 +345,6 @@ customization:
 						Host: host,
 					},
 				},
-				useDefaultCAFile:         true,
 				inactivityTimeoutSeconds: 0,
 			},
 			want: &corev1.ConfigMap{
@@ -369,7 +363,7 @@ apiVersion: console.openshift.io/v1
 auth:
   clientID: console
   clientSecretFile: /var/oauth-config/clientSecret
-  oauthEndpointCAFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+  oauthEndpointCAFile: /var/oauth-serving-cert/ca-bundle.crt
 clusterInfo:
   consoleBaseAddress: https://` + host + `
   masterPublicURL: ` + mockAPIServer + `
@@ -427,7 +421,6 @@ customization:
 						Host: host,
 					},
 				},
-				useDefaultCAFile:         true,
 				inactivityTimeoutSeconds: 0,
 			},
 			want: &corev1.ConfigMap{
@@ -446,7 +439,7 @@ apiVersion: console.openshift.io/v1
 auth:
   clientID: console
   clientSecretFile: /var/oauth-config/clientSecret
-  oauthEndpointCAFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+  oauthEndpointCAFile: /var/oauth-serving-cert/ca-bundle.crt
 clusterInfo:
   consoleBaseAddress: https://` + host + `
   masterPublicURL: ` + mockAPIServer + `
@@ -506,7 +499,6 @@ customization:
 						Host: host,
 					},
 				},
-				useDefaultCAFile:         true,
 				inactivityTimeoutSeconds: 0,
 			},
 			want: &corev1.ConfigMap{
@@ -525,7 +517,7 @@ apiVersion: console.openshift.io/v1
 auth:
   clientID: console
   clientSecretFile: /var/oauth-config/clientSecret
-  oauthEndpointCAFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+  oauthEndpointCAFile: /var/oauth-serving-cert/ca-bundle.crt
 clusterInfo:
   consoleBaseAddress: https://` + host + `
   masterPublicURL: ` + mockAPIServer + `
@@ -568,7 +560,6 @@ providers:
 						Host: customHostname,
 					},
 				},
-				useDefaultCAFile:         false,
 				inactivityTimeoutSeconds: 0,
 			},
 			want: &corev1.ConfigMap{
@@ -624,7 +615,6 @@ providers: {}
 						Host: host,
 					},
 				},
-				useDefaultCAFile:         true,
 				inactivityTimeoutSeconds: 60,
 			},
 			want: &corev1.ConfigMap{
@@ -644,7 +634,7 @@ auth:
   clientID: console
   clientSecretFile: /var/oauth-config/clientSecret
   inactivityTimeoutSeconds: 60
-  oauthEndpointCAFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+  oauthEndpointCAFile: /var/oauth-serving-cert/ca-bundle.crt
 clusterInfo:
   consoleBaseAddress: https://` + host + `
   masterPublicURL: ` + mockAPIServer + `
@@ -680,7 +670,6 @@ providers: {}
 						Host: host,
 					},
 				},
-				useDefaultCAFile:         true,
 				inactivityTimeoutSeconds: 0,
 				availablePlugins: []*v1.ConsolePlugin{
 					testPluginsWithProxy("plugin1", "service1", "service-namespace1"),
@@ -704,7 +693,7 @@ apiVersion: console.openshift.io/v1
 auth:
   clientID: console
   clientSecretFile: /var/oauth-config/clientSecret
-  oauthEndpointCAFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+  oauthEndpointCAFile: /var/oauth-serving-cert/ca-bundle.crt
 clusterInfo:
   consoleBaseAddress: https://` + host + `
   masterPublicURL: ` + mockAPIServer + `
@@ -785,7 +774,6 @@ nV5cXbp9W1bC12Tc8nnNXn4ypLE2JTQAvyp51zoZ8hQoSnRVx/VCY55Yu+br8gQZ` + "\n" + `
 						Host: host,
 					},
 				},
-				useDefaultCAFile:         true,
 				inactivityTimeoutSeconds: 0,
 			},
 			want: &corev1.ConfigMap{
@@ -804,7 +792,7 @@ apiVersion: console.openshift.io/v1
 auth:
   clientID: console
   clientSecretFile: /var/oauth-config/clientSecret
-  oauthEndpointCAFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+  oauthEndpointCAFile: /var/oauth-serving-cert/ca-bundle.crt
 clusterInfo:
   consoleBaseAddress: https://` + host + `
   masterPublicURL: ` + mockAPIServer + `
@@ -843,7 +831,6 @@ providers: {}
 						Host: host,
 					},
 				},
-				useDefaultCAFile:         true,
 				inactivityTimeoutSeconds: 0,
 			},
 			want: &corev1.ConfigMap{
@@ -862,7 +849,7 @@ apiVersion: console.openshift.io/v1
 auth:
   clientID: console
   clientSecretFile: /var/oauth-config/clientSecret
-  oauthEndpointCAFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+  oauthEndpointCAFile: /var/oauth-serving-cert/ca-bundle.crt
 clusterInfo:
   consoleBaseAddress: https://` + host + `
   masterPublicURL: ` + mockAPIServer + `
@@ -901,7 +888,6 @@ providers: {}
 						Host: host,
 					},
 				},
-				useDefaultCAFile:         true,
 				inactivityTimeoutSeconds: 0,
 				monitoringSharedConfig: &corev1.ConfigMap{
 					Data: map[string]string{
@@ -926,7 +912,7 @@ apiVersion: console.openshift.io/v1
 auth:
   clientID: console
   clientSecretFile: /var/oauth-config/clientSecret
-  oauthEndpointCAFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+  oauthEndpointCAFile: /var/oauth-serving-cert/ca-bundle.crt
 clusterInfo:
   consoleBaseAddress: https://` + host + `
   masterPublicURL: ` + mockAPIServer + `
@@ -957,7 +943,6 @@ providers: {}
 				tt.args.monitoringSharedConfig,
 				tt.args.infrastructureConfig,
 				tt.args.rt,
-				tt.args.useDefaultCAFile,
 				tt.args.inactivityTimeoutSeconds,
 				tt.args.availablePlugins,
 				tt.args.nodeArchitectures,

--- a/pkg/console/subresource/consoleserver/config_builder.go
+++ b/pkg/console/subresource/consoleserver/config_builder.go
@@ -17,7 +17,6 @@ import (
 const (
 	clientSecretFilePath     = "/var/oauth-config/clientSecret"
 	oauthServingCertFilePath = "/var/oauth-serving-cert/ca-bundle.crt"
-	oauthEndpointCAFilePath  = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
 	// serving info
 	certFilePath = "/var/serving-cert/tls.crt"
 	keyFilePath  = "/var/serving-cert/tls.key"
@@ -136,11 +135,7 @@ func (b *ConsoleServerCLIConfigBuilder) StatusPageID(id string) *ConsoleServerCL
 	return b
 }
 
-func (b *ConsoleServerCLIConfigBuilder) OAuthServingCert(useDefaultCAFile bool) *ConsoleServerCLIConfigBuilder {
-	if useDefaultCAFile {
-		b.CAFile = oauthEndpointCAFilePath
-		return b
-	}
+func (b *ConsoleServerCLIConfigBuilder) OAuthServingCert() *ConsoleServerCLIConfigBuilder {
 	b.CAFile = oauthServingCertFilePath
 	return b
 }
@@ -298,7 +293,7 @@ func (b *ConsoleServerCLIConfigBuilder) auth() Auth {
 	// we need this fallback due to the way our unit test are structured,
 	// where the ConsoleServerCLIConfigBuilder object is being instantiated empty
 	if b.CAFile == "" {
-		b.CAFile = oauthEndpointCAFilePath
+		b.CAFile = oauthServingCertFilePath
 	}
 	conf := Auth{
 		ClientID:                 api.OpenShiftConsoleName,

--- a/pkg/console/subresource/consoleserver/config_builder_test.go
+++ b/pkg/console/subresource/consoleserver/config_builder_test.go
@@ -40,7 +40,7 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 				Auth: Auth{
 					ClientID:            api.OpenShiftConsoleName,
 					ClientSecretFile:    clientSecretFilePath,
-					OAuthEndpointCAFile: oauthEndpointCAFilePath,
+					OAuthEndpointCAFile: oauthServingCertFilePath,
 				},
 				Customization: Customization{},
 				Providers:     Providers{},
@@ -53,7 +53,7 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 					APIServerURL("https://foobar.com/api").
 					Host("https://foobar.com/host").
 					LogoutURL("https://foobar.com/logout").
-					OAuthServingCert(false).
+					OAuthServingCert().
 					Config()
 			},
 			output: Config{
@@ -86,7 +86,7 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 					APIServerURL("https://foobar.com/api").
 					Host("https://foobar.com/host").
 					LogoutURL("https://foobar.com/logout").
-					OAuthServingCert(false).
+					OAuthServingCert().
 					Config()
 			},
 			output: Config{
@@ -131,7 +131,7 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 				Auth: Auth{
 					ClientID:            api.OpenShiftConsoleName,
 					ClientSecretFile:    clientSecretFilePath,
-					OAuthEndpointCAFile: oauthEndpointCAFilePath,
+					OAuthEndpointCAFile: oauthServingCertFilePath,
 				},
 				Customization: Customization{},
 				Providers: Providers{
@@ -160,7 +160,7 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 				Auth: Auth{
 					ClientID:            api.OpenShiftConsoleName,
 					ClientSecretFile:    clientSecretFilePath,
-					OAuthEndpointCAFile: oauthEndpointCAFilePath,
+					OAuthEndpointCAFile: oauthServingCertFilePath,
 				},
 				Customization: Customization{},
 				Providers:     Providers{},
@@ -189,7 +189,7 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 				Auth: Auth{
 					ClientID:            api.OpenShiftConsoleName,
 					ClientSecretFile:    clientSecretFilePath,
-					OAuthEndpointCAFile: oauthEndpointCAFilePath,
+					OAuthEndpointCAFile: oauthServingCertFilePath,
 				},
 				Customization: Customization{
 					DeveloperCatalog: &DeveloperConsoleCatalogCustomization{
@@ -243,7 +243,7 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 				Auth: Auth{
 					ClientID:            api.OpenShiftConsoleName,
 					ClientSecretFile:    clientSecretFilePath,
-					OAuthEndpointCAFile: oauthEndpointCAFilePath,
+					OAuthEndpointCAFile: oauthServingCertFilePath,
 				},
 				Customization: Customization{
 					DeveloperCatalog: &DeveloperConsoleCatalogCustomization{
@@ -297,7 +297,7 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 				Auth: Auth{
 					ClientID:            api.OpenShiftConsoleName,
 					ClientSecretFile:    clientSecretFilePath,
-					OAuthEndpointCAFile: oauthEndpointCAFilePath,
+					OAuthEndpointCAFile: oauthServingCertFilePath,
 				},
 				Customization: Customization{
 					DeveloperCatalog: &DeveloperConsoleCatalogCustomization{
@@ -331,7 +331,7 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 				Auth: Auth{
 					ClientID:            api.OpenShiftConsoleName,
 					ClientSecretFile:    clientSecretFilePath,
-					OAuthEndpointCAFile: oauthEndpointCAFilePath,
+					OAuthEndpointCAFile: oauthServingCertFilePath,
 				},
 				Customization: Customization{
 					DeveloperCatalog: &DeveloperConsoleCatalogCustomization{
@@ -365,7 +365,7 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 				Auth: Auth{
 					ClientID:            api.OpenShiftConsoleName,
 					ClientSecretFile:    clientSecretFilePath,
-					OAuthEndpointCAFile: oauthEndpointCAFilePath,
+					OAuthEndpointCAFile: oauthServingCertFilePath,
 				},
 				Customization: Customization{
 					ProjectAccess: ProjectAccess{
@@ -398,7 +398,7 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 				Auth: Auth{
 					ClientID:            api.OpenShiftConsoleName,
 					ClientSecretFile:    clientSecretFilePath,
-					OAuthEndpointCAFile: oauthEndpointCAFilePath,
+					OAuthEndpointCAFile: oauthServingCertFilePath,
 				},
 				Customization: Customization{
 					QuickStarts: QuickStarts{
@@ -445,7 +445,7 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 				Auth: Auth{
 					ClientID:            api.OpenShiftConsoleName,
 					ClientSecretFile:    clientSecretFilePath,
-					OAuthEndpointCAFile: oauthEndpointCAFilePath,
+					OAuthEndpointCAFile: oauthServingCertFilePath,
 				},
 				Customization: Customization{
 					Perspectives: []Perspective{
@@ -510,7 +510,7 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 				Auth: Auth{
 					ClientID:            api.OpenShiftConsoleName,
 					ClientSecretFile:    clientSecretFilePath,
-					OAuthEndpointCAFile: oauthEndpointCAFilePath,
+					OAuthEndpointCAFile: oauthServingCertFilePath,
 				},
 				Customization: Customization{
 					Perspectives: []Perspective{
@@ -574,7 +574,7 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 				Auth: Auth{
 					ClientID:            api.OpenShiftConsoleName,
 					ClientSecretFile:    clientSecretFilePath,
-					OAuthEndpointCAFile: oauthEndpointCAFilePath,
+					OAuthEndpointCAFile: oauthServingCertFilePath,
 				},
 				Customization: Customization{
 					Perspectives: []Perspective{
@@ -630,7 +630,7 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 				Auth: Auth{
 					ClientID:            api.OpenShiftConsoleName,
 					ClientSecretFile:    clientSecretFilePath,
-					OAuthEndpointCAFile: oauthEndpointCAFilePath,
+					OAuthEndpointCAFile: oauthServingCertFilePath,
 					LogoutRedirect:      "https://foobar.com/logout",
 				},
 				Customization: Customization{
@@ -670,7 +670,7 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 				Auth: Auth{
 					ClientID:            api.OpenShiftConsoleName,
 					ClientSecretFile:    clientSecretFilePath,
-					OAuthEndpointCAFile: oauthEndpointCAFilePath,
+					OAuthEndpointCAFile: oauthServingCertFilePath,
 				},
 				Customization: Customization{},
 				Providers:     Providers{},
@@ -705,7 +705,7 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 				Auth: Auth{
 					ClientID:            api.OpenShiftConsoleName,
 					ClientSecretFile:    clientSecretFilePath,
-					OAuthEndpointCAFile: oauthEndpointCAFilePath,
+					OAuthEndpointCAFile: oauthServingCertFilePath,
 				},
 				Customization: Customization{},
 				Providers:     Providers{},
@@ -753,7 +753,7 @@ clusterInfo: {}
 auth:
   clientID: console
   clientSecretFile: /var/oauth-config/clientSecret
-  oauthEndpointCAFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+  oauthEndpointCAFile: /var/oauth-serving-cert/ca-bundle.crt
 customization: {}
 providers: {}
 `,
@@ -766,7 +766,7 @@ providers: {}
 					APIServerURL("https://foobar.com/api").
 					Host("https://foobar.com/host").
 					LogoutURL("https://foobar.com/logout").
-					OAuthServingCert(false).
+					OAuthServingCert().
 					ConfigYAML()
 			},
 			output: `apiVersion: console.openshift.io/v1
@@ -803,7 +803,7 @@ clusterInfo: {}
 auth:
   clientID: console
   clientSecretFile: /var/oauth-config/clientSecret
-  oauthEndpointCAFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+  oauthEndpointCAFile: /var/oauth-serving-cert/ca-bundle.crt
 customization: {}
 providers:
   statuspageID: status-12345
@@ -826,7 +826,7 @@ clusterInfo: {}
 auth:
   clientID: console
   clientSecretFile: /var/oauth-config/clientSecret
-  oauthEndpointCAFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+  oauthEndpointCAFile: /var/oauth-serving-cert/ca-bundle.crt
 customization: {}
 providers: {}
 `,
@@ -850,7 +850,7 @@ clusterInfo: {}
 auth:
   clientID: console
   clientSecretFile: /var/oauth-config/clientSecret
-  oauthEndpointCAFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+  oauthEndpointCAFile: /var/oauth-serving-cert/ca-bundle.crt
 customization:
   developerCatalog:
     categories: []
@@ -898,7 +898,7 @@ clusterInfo: {}
 auth:
   clientID: console
   clientSecretFile: /var/oauth-config/clientSecret
-  oauthEndpointCAFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+  oauthEndpointCAFile: /var/oauth-serving-cert/ca-bundle.crt
 customization:
   developerCatalog:
     categories:
@@ -938,7 +938,7 @@ clusterInfo: {}
 auth:
   clientID: console
   clientSecretFile: /var/oauth-config/clientSecret
-  oauthEndpointCAFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+  oauthEndpointCAFile: /var/oauth-serving-cert/ca-bundle.crt
 customization:
   developerCatalog:
     categories: null
@@ -969,7 +969,7 @@ clusterInfo: {}
 auth:
   clientID: console
   clientSecretFile: /var/oauth-config/clientSecret
-  oauthEndpointCAFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+  oauthEndpointCAFile: /var/oauth-serving-cert/ca-bundle.crt
 customization:
   developerCatalog:
     categories: null
@@ -1001,7 +1001,7 @@ clusterInfo: {}
 auth:
   clientID: console
   clientSecretFile: /var/oauth-config/clientSecret
-  oauthEndpointCAFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+  oauthEndpointCAFile: /var/oauth-serving-cert/ca-bundle.crt
 customization:
   addPage:
     disabledActions:
@@ -1026,7 +1026,7 @@ providers: {}
 						"plugin2": "plugin2_url",
 					}).
 					I18nNamespaces([]string{"plugin__plugin1"}).
-					OAuthServingCert(true)
+					OAuthServingCert()
 				return b.ConfigYAML()
 			},
 			output: `apiVersion: console.openshift.io/v1
@@ -1041,7 +1041,7 @@ clusterInfo:
 auth:
   clientID: console
   clientSecretFile: /var/oauth-config/clientSecret
-  oauthEndpointCAFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+  oauthEndpointCAFile: /var/oauth-serving-cert/ca-bundle.crt
   logoutRedirect: https://foobar.com/logout
 customization:
   branding: okd
@@ -1077,7 +1077,7 @@ clusterInfo: {}
 auth:
   clientID: console
   clientSecretFile: /var/oauth-config/clientSecret
-  oauthEndpointCAFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+  oauthEndpointCAFile: /var/oauth-serving-cert/ca-bundle.crt
 customization:
   quickStarts:
     disabled:
@@ -1119,7 +1119,7 @@ clusterInfo: {}
 auth:
   clientID: console
   clientSecretFile: /var/oauth-config/clientSecret
-  oauthEndpointCAFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+  oauthEndpointCAFile: /var/oauth-serving-cert/ca-bundle.crt
 customization:
   perspectives:
   - id: perspective1
@@ -1185,7 +1185,7 @@ clusterInfo: {}
 auth:
   clientID: console
   clientSecretFile: /var/oauth-config/clientSecret
-  oauthEndpointCAFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+  oauthEndpointCAFile: /var/oauth-serving-cert/ca-bundle.crt
 customization:
   perspectives:
   - id: perspective1
@@ -1255,7 +1255,7 @@ clusterInfo: {}
 auth:
   clientID: console
   clientSecretFile: /var/oauth-config/clientSecret
-  oauthEndpointCAFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+  oauthEndpointCAFile: /var/oauth-serving-cert/ca-bundle.crt
 customization:
   perspectives:
   - id: perspective1
@@ -1305,7 +1305,7 @@ clusterInfo: {}
 auth:
   clientID: console
   clientSecretFile: /var/oauth-config/clientSecret
-  oauthEndpointCAFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+  oauthEndpointCAFile: /var/oauth-serving-cert/ca-bundle.crt
 customization: {}
 providers: {}
 telemetry:

--- a/pkg/console/subresource/consoleserver/config_merger_test.go
+++ b/pkg/console/subresource/consoleserver/config_merger_test.go
@@ -44,7 +44,7 @@ auth:
   clientID: console
   clientSecretFile: /var/oauth-config/clientSecret
   logoutRedirect: https://foobar.com/logout
-  oauthEndpointCAFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+  oauthEndpointCAFile: /var/oauth-serving-cert/ca-bundle.crt
 clusterInfo:
   consoleBaseAddress: https://console-openshift-console.apps.foobar.com
   masterPublicURL: https://foobar.com/api

--- a/pkg/console/subresource/deployment/deployment.go
+++ b/pkg/console/subresource/deployment/deployment.go
@@ -458,15 +458,6 @@ func customLogoVolume() volumeConfig {
 		isConfigMap: true}
 }
 
-func managedClusterVolumeConfig() volumeConfig {
-	return volumeConfig{
-		name:        api.ManagedClusterConfigMapName,
-		path:        api.ManagedClusterConfigMountDir,
-		readOnly:    true,
-		isConfigMap: true,
-	}
-}
-
 func apiServerCertVolumeConfig(configMap corev1.ConfigMap) volumeConfig {
 	name := configMap.GetName()
 	return volumeConfig{


### PR DESCRIPTION
The oauth-serving-cert is now present in all supported OpenShift versions.

The SA CA bundle would've never been a good choice to get the certs from :|

Removes additional unused function that I randomly found.

The original configurable CA logic is kept as it's going to get reused in #800 

/assign @jhadvig 