### PR TITLE
CONSOLE-3804: Reapply separation of the oauthclients controller

### DIFF
--- a/manifests/03-rbac-role-cluster.yaml
+++ b/manifests/03-rbac-role-cluster.yaml
@@ -23,8 +23,13 @@ rules:
     verbs:
       - get
       - list
-      - update
       - watch
+  - apiGroups:
+      - oauth.openshift.io
+    resources:
+      - oauthclients
+    verbs:
+      - update
     resourceNames:
       - console
   - apiGroups:

--- a/pkg/console/controllers/oauthclients/oauthclients.go
+++ b/pkg/console/controllers/oauthclients/oauthclients.go
@@ -127,11 +127,8 @@ func (c *oauthClientsController) sync(ctx context.Context, controllerContext fac
 
 	oauthErrReason, oauthErr := c.syncOAuthClient(ctx, clientSecret, consoleURL.String())
 	c.statusHandler.AddConditions(status.HandleProgressingOrDegraded("OAuthClientSync", oauthErrReason, oauthErr))
-	if oauthErr != nil {
-		return c.statusHandler.FlushAndReturn(oauthErr)
-	}
 
-	return nil
+	return c.statusHandler.FlushAndReturn(oauthErr)
 }
 
 // handleStatus returns whether sync should happen and any error encountering

--- a/pkg/console/controllers/oauthclients/oauthclients.go
+++ b/pkg/console/controllers/oauthclients/oauthclients.go
@@ -179,8 +179,9 @@ func (c *oauthClientsController) syncOAuthClient(
 		// at this point we must die & wait for someone to fix the lack of an outhclient. there is nothing we can do.
 		return "FailedGet", fmt.Errorf("oauth client for console does not exist and cannot be created (%w)", err)
 	}
-	oauthsub.RegisterConsoleToOAuthClient(oauthClient, consoleURL, secretsub.GetSecretString(sec))
-	_, _, oauthErr := oauthsub.CustomApplyOAuth(c.oauthClient, oauthClient, ctx)
+	clientCopy := oauthClient.DeepCopy()
+	oauthsub.RegisterConsoleToOAuthClient(clientCopy, consoleURL, secretsub.GetSecretString(sec))
+	_, _, oauthErr := oauthsub.CustomApplyOAuth(c.oauthClient, clientCopy, ctx)
 	if oauthErr != nil {
 		return "FailedRegister", oauthErr
 	}

--- a/pkg/console/controllers/oauthclients/oauthclients.go
+++ b/pkg/console/controllers/oauthclients/oauthclients.go
@@ -1,0 +1,207 @@
+package oauthclients
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1informers "k8s.io/client-go/informers/core/v1"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+	"k8s.io/klog/v2"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+	configv1informers "github.com/openshift/client-go/config/informers/externalversions/config/v1"
+	configv1lister "github.com/openshift/client-go/config/listers/config/v1"
+	oauthv1client "github.com/openshift/client-go/oauth/clientset/versioned/typed/oauth/v1"
+	oauthv1informers "github.com/openshift/client-go/oauth/informers/externalversions/oauth/v1"
+	oauthv1lister "github.com/openshift/client-go/oauth/listers/oauth/v1"
+	operatorv1informers "github.com/openshift/client-go/operator/informers/externalversions/operator/v1"
+	operatorv1listers "github.com/openshift/client-go/operator/listers/operator/v1"
+	routev1informers "github.com/openshift/client-go/route/informers/externalversions/route/v1"
+	routev1listers "github.com/openshift/client-go/route/listers/route/v1"
+	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+
+	"github.com/openshift/console-operator/pkg/api"
+	"github.com/openshift/console-operator/pkg/console/operator"
+	"github.com/openshift/console-operator/pkg/console/status"
+	oauthsub "github.com/openshift/console-operator/pkg/console/subresource/oauthclient"
+	routesub "github.com/openshift/console-operator/pkg/console/subresource/route"
+	secretsub "github.com/openshift/console-operator/pkg/console/subresource/secret"
+	"github.com/openshift/console-operator/pkg/crypto"
+)
+
+type oauthClientsController struct {
+	oauthClient    oauthv1client.OAuthClientsGetter
+	operatorClient v1helpers.OperatorClient
+	secretsClient  corev1client.SecretsGetter
+
+	oauthClientLister     oauthv1lister.OAuthClientLister
+	consoleOperatorLister operatorv1listers.ConsoleLister
+	routesLister          routev1listers.RouteLister
+	ingressConfigLister   configv1lister.IngressLister
+	targetNSSecretsLister corev1listers.SecretLister
+
+	statusHandler status.StatusHandler
+}
+
+func NewOAuthClientsController(
+	operatorClient v1helpers.OperatorClient,
+	oauthClient oauthv1client.OAuthClientsGetter,
+	secretsClient corev1client.SecretsGetter,
+	oauthClientInformer oauthv1informers.OAuthClientInformer,
+	consoleOperatorInformer operatorv1informers.ConsoleInformer,
+	routeInformer routev1informers.RouteInformer,
+	ingressConfigInformer configv1informers.IngressInformer,
+	targetNSsecretsInformer corev1informers.SecretInformer,
+	recorder events.Recorder,
+) factory.Controller {
+	c := oauthClientsController{
+		oauthClient:    oauthClient,
+		operatorClient: operatorClient,
+		secretsClient:  secretsClient,
+
+		oauthClientLister:     oauthClientInformer.Lister(),
+		consoleOperatorLister: consoleOperatorInformer.Lister(),
+		routesLister:          routeInformer.Lister(),
+		ingressConfigLister:   ingressConfigInformer.Lister(),
+		targetNSSecretsLister: targetNSsecretsInformer.Lister(),
+
+		statusHandler: status.NewStatusHandler(operatorClient),
+	}
+
+	return factory.New().
+		WithSync(c.sync).
+		WithInformers(
+			consoleOperatorInformer.Informer(),
+			routeInformer.Informer(),
+			ingressConfigInformer.Informer(),
+			targetNSsecretsInformer.Informer(),
+		).
+		WithFilteredEventsInformers(
+			factory.NamesFilter(api.OAuthClientName),
+			oauthClientInformer.Informer(),
+		).
+		WithSyncDegradedOnError(operatorClient).
+		ToController("OAuthClientsController", recorder.WithComponentSuffix("oauth-clients-controller"))
+}
+
+func (c *oauthClientsController) sync(ctx context.Context, controllerContext factory.SyncContext) error {
+	if shouldSync, err := c.handleStatus(ctx); err != nil {
+		return err
+	} else if !shouldSync {
+		return nil
+	}
+
+	operatorConfig, err := c.consoleOperatorLister.Get("cluster")
+	if err != nil {
+		return err
+	}
+
+	ingressConfig, err := c.ingressConfigLister.Get("cluster")
+	if err != nil {
+		return err
+	}
+
+	routeName := api.OpenShiftConsoleRouteName
+	routeConfig := routesub.NewRouteConfig(operatorConfig, ingressConfig, routeName)
+	if routeConfig.IsCustomHostnameSet() {
+		routeName = api.OpenshiftConsoleCustomRouteName
+	}
+
+	_, consoleURL, _, routeErr := operator.GetActiveRouteInfo(ctx, c.routesLister, routeName)
+	if routeErr != nil {
+		return routeErr
+	}
+
+	clientSecret, _, secErr := c.syncSecret(ctx, operatorConfig, controllerContext.Recorder())
+	c.statusHandler.AddConditions(status.HandleProgressingOrDegraded("OAuthClientSecretSync", "FailedApply", secErr))
+	if secErr != nil {
+		return c.statusHandler.FlushAndReturn(secErr)
+	}
+
+	oauthErrReason, oauthErr := c.syncOAuthClient(ctx, clientSecret, consoleURL.String())
+	c.statusHandler.AddConditions(status.HandleProgressingOrDegraded("OAuthClientSync", oauthErrReason, oauthErr))
+	if oauthErr != nil {
+		return c.statusHandler.FlushAndReturn(oauthErr)
+	}
+
+	return nil
+}
+
+// handleStatus returns whether sync should happen and any error encountering
+// determining the operator's management state
+// TODO: extract this logic to where it can be used for all controllers
+func (c *oauthClientsController) handleStatus(ctx context.Context) (bool, error) {
+	operatorSpec, _, _, err := c.operatorClient.GetOperatorState()
+	if err != nil {
+		return false, fmt.Errorf("failed to retrieve operator config: %w", err)
+	}
+
+	switch managementState := operatorSpec.ManagementState; managementState {
+	case operatorv1.Managed:
+		klog.V(4).Infoln("console is in a managed state.")
+		return true, nil
+	case operatorv1.Unmanaged:
+		klog.V(4).Infoln("console is in an unmanaged state.")
+		return false, nil
+	case operatorv1.Removed:
+		klog.V(4).Infoln("console has been removed.")
+		return false, c.deregisterClient(ctx)
+	default:
+		return false, fmt.Errorf("console is in an unknown state: %v", managementState)
+	}
+}
+
+func (c *oauthClientsController) syncSecret(ctx context.Context, operatorConfig *operatorv1.Console, recorder events.Recorder) (*corev1.Secret, bool, error) {
+	secret, err := c.targetNSSecretsLister.Secrets(api.TargetNamespace).Get(secretsub.Stub().Name)
+	if apierrors.IsNotFound(err) || secretsub.GetSecretString(secret) == "" {
+		return resourceapply.ApplySecret(ctx, c.secretsClient, recorder, secretsub.DefaultSecret(operatorConfig, crypto.Random256BitsString()))
+	}
+	// any error should be returned & kill the sync loop
+	if err != nil {
+		return nil, false, err
+	}
+	return secret, false, nil
+}
+
+// applies changes to the oauthclient
+// should not be called until route & secret dependencies are verified
+func (c *oauthClientsController) syncOAuthClient(
+	ctx context.Context,
+	sec *corev1.Secret,
+	consoleURL string,
+) (reason string, err error) {
+	oauthClient, err := c.oauthClientLister.Get(oauthsub.Stub().Name)
+	if err != nil {
+		// at this point we must die & wait for someone to fix the lack of an outhclient. there is nothing we can do.
+		return "FailedGet", fmt.Errorf("oauth client for console does not exist and cannot be created (%w)", err)
+	}
+	oauthsub.RegisterConsoleToOAuthClient(oauthClient, consoleURL, secretsub.GetSecretString(sec))
+	_, _, oauthErr := oauthsub.CustomApplyOAuth(c.oauthClient, oauthClient, ctx)
+	if oauthErr != nil {
+		return "FailedRegister", oauthErr
+	}
+	return "", nil
+}
+
+func (c *oauthClientsController) deregisterClient(ctx context.Context) error {
+	// existingOAuthClient is not a delete, it is a deregister/neutralize
+	existingOAuthClient, err := c.oauthClient.OAuthClients().Get(ctx, oauthsub.Stub().Name, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	if len(existingOAuthClient.RedirectURIs) == 0 {
+		return nil
+	}
+
+	_, err = c.oauthClient.OAuthClients().Update(ctx, oauthsub.DeRegisterConsoleFromOAuthClient(existingOAuthClient), metav1.UpdateOptions{})
+	return err
+
+}

--- a/pkg/console/operator/operator.go
+++ b/pkg/console/operator/operator.go
@@ -320,7 +320,7 @@ func (c *consoleOperator) Sync(ctx context.Context, controllerContext factory.Sy
 }
 
 func (c *consoleOperator) handleSync(ctx context.Context, controllerContext factory.SyncContext, configs configSet) error {
-	updatedStatus := configs.Operator.DeepCopy()
+	updatedStatus := configs.Operator
 
 	switch updatedStatus.Spec.ManagementState {
 	case operatorsv1.Managed:

--- a/pkg/console/operator/operator.go
+++ b/pkg/console/operator/operator.go
@@ -18,6 +18,7 @@ import (
 	corev1 "k8s.io/client-go/informers/core/v1"
 	appsclientv1 "k8s.io/client-go/kubernetes/typed/apps/v1"
 	coreclientv1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	corev1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/klog/v2"
 
 	// openshift
@@ -27,12 +28,13 @@ import (
 	configinformer "github.com/openshift/client-go/config/informers/externalversions"
 	consoleinformersv1 "github.com/openshift/client-go/console/informers/externalversions/console/v1"
 	listerv1 "github.com/openshift/client-go/console/listers/console/v1"
-	oauthclientv1 "github.com/openshift/client-go/oauth/clientset/versioned/typed/oauth/v1"
 	oauthinformersv1 "github.com/openshift/client-go/oauth/informers/externalversions/oauth/v1"
+	oauthlistersv1 "github.com/openshift/client-go/oauth/listers/oauth/v1"
 	operatorclientv1 "github.com/openshift/client-go/operator/clientset/versioned/typed/operator/v1"
 	operatorinformerv1 "github.com/openshift/client-go/operator/informers/externalversions/operator/v1"
 	routeclientv1 "github.com/openshift/client-go/route/clientset/versioned/typed/route/v1"
 	routesinformersv1 "github.com/openshift/client-go/route/informers/externalversions/route/v1"
+	routev1listers "github.com/openshift/client-go/route/listers/route/v1"
 	"github.com/openshift/console-operator/pkg/api"
 	"github.com/openshift/console-operator/pkg/console/controllers/util"
 	consolestatus "github.com/openshift/console-operator/pkg/console/status"
@@ -47,7 +49,6 @@ import (
 	// operator
 	"github.com/openshift/console-operator/pkg/console/subresource/configmap"
 	"github.com/openshift/console-operator/pkg/console/subresource/deployment"
-	"github.com/openshift/console-operator/pkg/console/subresource/oauthclient"
 	"github.com/openshift/console-operator/pkg/console/subresource/secret"
 )
 
@@ -63,14 +64,16 @@ type consoleOperator struct {
 	dynamicClient              dynamic.Interface
 	// core kube
 	secretsClient    coreclientv1.SecretsGetter
+	secretsLister    corev1listers.SecretLister
 	configMapClient  coreclientv1.ConfigMapsGetter
 	serviceClient    coreclientv1.ServicesGetter
 	nodeClient       coreclientv1.NodesGetter
 	deploymentClient appsclientv1.DeploymentsGetter
 	// openshift
-	routeClient   routeclientv1.RoutesGetter
-	oauthClient   oauthclientv1.OAuthClientsGetter
-	versionGetter status.VersionGetter
+	oauthClientLister oauthlistersv1.OAuthClientLister
+	routeClient       routeclientv1.RoutesGetter
+	routeLister       routev1listers.RouteLister
+	versionGetter     status.VersionGetter
 	// lister
 	consolePluginLister listerv1.ConsolePluginLister
 
@@ -96,12 +99,11 @@ func NewConsoleOperator(
 	// deployments
 	deploymentClient appsclientv1.DeploymentsGetter,
 	deploymentInformer appsinformersv1.DeploymentInformer,
+	// oauth API
+	oauthClientInformer oauthinformersv1.OAuthClientInformer,
 	// routes
 	routev1Client routeclientv1.RoutesGetter,
 	routeInformer routesinformersv1.RouteInformer,
-	// oauth
-	oauthv1Client oauthclientv1.OAuthClientsGetter,
-	oauthClients oauthinformersv1.OAuthClientInformer,
 	// plugins
 	consolePluginInformer consoleinformersv1.ConsolePluginInformer,
 	// openshift managed
@@ -111,6 +113,16 @@ func NewConsoleOperator(
 	recorder events.Recorder,
 	resourceSyncer resourcesynccontroller.ResourceSyncer,
 ) factory.Controller {
+
+	secretsInformer := coreV1.Secrets()
+	configMapInformer := coreV1.ConfigMaps()
+	managedConfigMapInformer := managedCoreV1.ConfigMaps()
+	serviceInformer := coreV1.Services()
+	nodeInformer := coreV1.Nodes()
+	configV1Informers := configInformer.Config().V1()
+	configNameFilter := util.IncludeNamesFilter(api.ConfigResourceName)
+	targetNameFilter := util.IncludeNamesFilter(api.OpenShiftConsoleName)
+
 	c := &consoleOperator{
 		// configs
 		operatorClient:             operatorClient,
@@ -123,29 +135,22 @@ func NewConsoleOperator(
 		// console resources
 		// core kube
 		secretsClient:    corev1Client,
+		secretsLister:    secretsInformer.Lister(),
 		configMapClient:  corev1Client,
 		serviceClient:    corev1Client,
 		nodeClient:       corev1Client,
 		deploymentClient: deploymentClient,
 		dynamicClient:    dynamicClient,
 		// openshift
-		routeClient:   routev1Client,
-		oauthClient:   oauthv1Client,
-		versionGetter: versionGetter,
+		oauthClientLister: oauthClientInformer.Lister(),
+		routeClient:       routev1Client,
+		routeLister:       routeInformer.Lister(),
+		versionGetter:     versionGetter,
 		// plugins
 		consolePluginLister: consolePluginInformer.Lister(),
 
 		resourceSyncer: resourceSyncer,
 	}
-
-	secretsInformer := coreV1.Secrets()
-	configMapInformer := coreV1.ConfigMaps()
-	managedConfigMapInformer := managedCoreV1.ConfigMaps()
-	serviceInformer := coreV1.Services()
-	nodeInformer := coreV1.Nodes()
-	configV1Informers := configInformer.Config().V1()
-	configNameFilter := util.IncludeNamesFilter(api.ConfigResourceName)
-	targetNameFilter := util.IncludeNamesFilter(api.OpenShiftConsoleName)
 
 	informers := []factory.Informer{
 		configV1Informers.Consoles().Informer(),
@@ -180,7 +185,6 @@ func NewConsoleOperator(
 		deploymentInformer.Informer(),
 		routeInformer.Informer(),
 		serviceInformer.Informer(),
-		oauthClients.Informer(),
 	).WithInformers(
 		nodeInformer.Informer(),
 		consolePluginInformer.Informer(),
@@ -190,6 +194,9 @@ func NewConsoleOperator(
 	).WithFilteredEventsInformers(
 		util.IncludeNamesFilter(api.OpenShiftConsoleConfigMapName, api.OpenShiftConsolePublicConfigMapName),
 		managedConfigMapInformer.Informer(),
+	).WithFilteredEventsInformers(
+		factory.NamesFilter(api.OAuthClientName),
+		oauthClientInformer.Informer(),
 	).WithFilteredEventsInformers(
 		util.IncludeNamesFilter(deployment.ConsoleOauthConfigName),
 		secretsInformer.Informer(),
@@ -336,13 +343,7 @@ func (c *consoleOperator) removeConsole(ctx context.Context, operatorConfig *ope
 	errs = append(errs, c.configMapClient.ConfigMaps(api.TargetNamespace).Delete(ctx, configmap.ServiceCAStub().Name, metav1.DeleteOptions{}))
 	// secret
 	errs = append(errs, c.secretsClient.Secrets(api.TargetNamespace).Delete(ctx, secret.Stub().Name, metav1.DeleteOptions{}))
-	// existingOAuthClient is not a delete, it is a deregister/neutralize
-	existingOAuthClient, getAuthErr := c.oauthClient.OAuthClients().Get(ctx, oauthclient.Stub().Name, metav1.GetOptions{})
-	errs = append(errs, getAuthErr)
-	if len(existingOAuthClient.RedirectURIs) != 0 {
-		_, updateAuthErr := c.oauthClient.OAuthClients().Update(ctx, oauthclient.DeRegisterConsoleFromOAuthClient(existingOAuthClient), metav1.UpdateOptions{})
-		errs = append(errs, updateAuthErr)
-	}
+
 	// deployment
 	// NOTE: CVO controls the deployment for downloads, console-operator cannot delete it.
 	errs = append(errs, c.deploymentClient.Deployments(api.TargetNamespace).Delete(ctx, deployment.Stub().Name, metav1.DeleteOptions{}))

--- a/pkg/console/operator/sync_v400.go
+++ b/pkg/console/operator/sync_v400.go
@@ -20,11 +20,10 @@ import (
 	// openshift
 	configv1 "github.com/openshift/api/config/v1"
 	v1 "github.com/openshift/api/console/v1"
-	oauthv1 "github.com/openshift/api/oauth/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	routev1 "github.com/openshift/api/route/v1"
+	routev1listers "github.com/openshift/client-go/route/listers/route/v1"
 	"github.com/openshift/console-operator/pkg/api"
-	"github.com/openshift/console-operator/pkg/crypto"
 	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
@@ -62,7 +61,7 @@ func (co *consoleOperator) sync_v400(ctx context.Context, controllerContext fact
 		routeName = api.OpenshiftConsoleCustomRouteName
 	}
 
-	route, consoleURL, routeReasoneErr, routeErr := co.GetActiveRouteInfo(ctx, routeName)
+	route, consoleURL, routeReasoneErr, routeErr := GetActiveRouteInfo(ctx, co.routeLister, routeName)
 	// TODO: this controller is no longer responsible for syncing the route.
 	//   however, the route is essential for several of the components below.
 	//   - the loop should exit early and wait until the RouteSyncController creates the route.
@@ -119,18 +118,10 @@ func (co *consoleOperator) sync_v400(ctx context.Context, controllerContext fact
 		return statusHandler.FlushAndReturn(oauthServingCertErr)
 	}
 
-	sec, secChanged, secErr := co.SyncSecret(ctx, set.Operator, controllerContext.Recorder())
-	toUpdate = toUpdate || secChanged
-	statusHandler.AddConditions(status.HandleProgressingOrDegraded("OAuthClientSecretSync", "FailedApply", secErr))
+	clientSecret, secErr := co.secretsLister.Secrets(api.TargetNamespace).Get(secretsub.Stub().Name)
+	statusHandler.AddConditions(status.HandleProgressingOrDegraded("OAuthClientSecretSync", "FailedGet", secErr))
 	if secErr != nil {
 		return statusHandler.FlushAndReturn(secErr)
-	}
-
-	oauthClient, oauthChanged, oauthErrReason, oauthErr := co.SyncOAuthClient(ctx, set.Operator, sec, consoleURL.String())
-	toUpdate = toUpdate || oauthChanged
-	statusHandler.AddConditions(status.HandleProgressingOrDegraded("OAuthClientSync", oauthErrReason, oauthErr))
-	if oauthErr != nil {
-		return statusHandler.FlushAndReturn(oauthErr)
 	}
 
 	actualDeployment, depChanged, depErrReason, depErr := co.SyncDeployment(
@@ -140,7 +131,7 @@ func (co *consoleOperator) sync_v400(ctx context.Context, controllerContext fact
 		serviceCAConfigMap,
 		oauthServingCertConfigMap,
 		trustedCAConfigMap,
-		sec,
+		clientSecret,
 		set.Proxy,
 		set.Infrastructure,
 		customLogoCanMount,
@@ -210,12 +201,6 @@ func (co *consoleOperator) sync_v400(ctx context.Context, controllerContext fact
 		if serviceCAChanged {
 			klog.V(4).Infof("\t service-ca configmap changed: %v", serviceCAConfigMap.GetResourceVersion())
 		}
-		if secChanged {
-			klog.V(4).Infof("\t secret changed: %v", sec.GetResourceVersion())
-		}
-		if oauthChanged {
-			klog.V(4).Infof("\t oauth changed: %v", oauthClient.GetResourceVersion())
-		}
 		if depChanged {
 			klog.V(4).Infof("\t deployment changed: %v", actualDeployment.GetResourceVersion())
 		}
@@ -224,8 +209,8 @@ func (co *consoleOperator) sync_v400(ctx context.Context, controllerContext fact
 	return statusHandler.FlushAndReturn(nil)
 }
 
-func (co *consoleOperator) GetActiveRouteInfo(ctx context.Context, activeRouteName string) (route *routev1.Route, routeURL *url.URL, reason string, err error) {
-	route, routeErr := co.routeClient.Routes(api.TargetNamespace).Get(ctx, activeRouteName, metav1.GetOptions{})
+func GetActiveRouteInfo(ctx context.Context, routeClient routev1listers.RouteLister, activeRouteName string) (route *routev1.Route, routeURL *url.URL, reason string, err error) {
+	route, routeErr := routeClient.Routes(api.TargetNamespace).Get(activeRouteName)
 	if routeErr != nil {
 		return nil, nil, "FailedGet", routeErr
 	}
@@ -300,39 +285,6 @@ func (co *consoleOperator) SyncDeployment(
 	return deployment, deploymentChanged, "", nil
 }
 
-// applies changes to the oauthclient
-// should not be called until route & secret dependencies are verified
-func (co *consoleOperator) SyncOAuthClient(
-	ctx context.Context,
-	operatorConfig *operatorv1.Console,
-	sec *corev1.Secret,
-	consoleURL string,
-) (consoleoauthclient *oauthv1.OAuthClient, changed bool, reason string, err error) {
-	oauthClient, err := co.oauthClient.OAuthClients().Get(ctx, oauthsub.Stub().Name, metav1.GetOptions{})
-	if err != nil {
-		// at this point we must die & wait for someone to fix the lack of an outhclient. there is nothing we can do.
-		return nil, false, "FailedGet", errors.New(fmt.Sprintf("oauth client for console does not exist and cannot be created (%v)", err))
-	}
-	oauthsub.RegisterConsoleToOAuthClient(oauthClient, consoleURL, secretsub.GetSecretString(sec))
-	oauthClient, oauthChanged, oauthErr := oauthsub.CustomApplyOAuth(co.oauthClient, oauthClient, ctx)
-	if oauthErr != nil {
-		return nil, false, "FailedRegister", oauthErr
-	}
-	return oauthClient, oauthChanged, "", nil
-}
-
-func (co *consoleOperator) SyncSecret(ctx context.Context, operatorConfig *operatorv1.Console, recorder events.Recorder) (*corev1.Secret, bool, error) {
-	secret, err := co.secretsClient.Secrets(api.TargetNamespace).Get(ctx, secretsub.Stub().Name, metav1.GetOptions{})
-	if apierrors.IsNotFound(err) || secretsub.GetSecretString(secret) == "" {
-		return resourceapply.ApplySecret(ctx, co.secretsClient, recorder, secretsub.DefaultSecret(operatorConfig, crypto.Random256BitsString()))
-	}
-	// any error should be returned & kill the sync loop
-	if err != nil {
-		return nil, false, err
-	}
-	return secret, false, nil
-}
-
 // apply configmap (needs route)
 // by the time we get to the configmap, we can assume the route exits & is configured properly
 // therefore no additional error handling is needed here.
@@ -358,7 +310,7 @@ func (co *consoleOperator) SyncConfigMap(
 	nodeArchitectures, nodeOperatingSystems := getNodeComputeEnvironments(nodeList)
 
 	inactivityTimeoutSeconds := 0
-	oauthClient, oacErr := co.oauthClient.OAuthClients().Get(ctx, oauthsub.Stub().Name, metav1.GetOptions{})
+	oauthClient, oacErr := co.oauthClientLister.Get(oauthsub.Stub().Name)
 	if oacErr != nil {
 		return nil, false, "FailedGetOAuthClient", oacErr
 	}

--- a/pkg/console/starter/starter.go
+++ b/pkg/console/starter/starter.go
@@ -24,6 +24,7 @@ import (
 	"github.com/openshift/console-operator/pkg/console/controllers/clidownloads"
 	"github.com/openshift/console-operator/pkg/console/controllers/downloadsdeployment"
 	"github.com/openshift/console-operator/pkg/console/controllers/healthcheck"
+	"github.com/openshift/console-operator/pkg/console/controllers/oauthclients"
 	pdb "github.com/openshift/console-operator/pkg/console/controllers/poddisruptionbudget"
 	"github.com/openshift/console-operator/pkg/console/controllers/route"
 	"github.com/openshift/console-operator/pkg/console/controllers/service"
@@ -188,12 +189,11 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 		// deployments
 		kubeClient.AppsV1(),
 		kubeInformersNamespaced.Apps().V1().Deployments(), // Deployments
+		// oauth
+		oauthInformers.Oauth().V1().OAuthClients(),
 		// routes
 		routesClient.RouteV1(),
 		routesInformersNamespaced.Route().V1().Routes(), // Route
-		// oauth
-		oauthClient.OauthV1(),
-		oauthInformers.Oauth().V1().OAuthClients(), // OAuth clients
 		// plugins
 		consoleInformers.Console().V1().ConsolePlugins(),
 		// openshift managed
@@ -202,6 +202,18 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 		versionGetter,
 		recorder,
 		resourceSyncer,
+	)
+
+	oauthClientController := oauthclients.NewOAuthClientsController(
+		operatorClient,
+		oauthClient.OauthV1(),
+		kubeClient.CoreV1(),
+		oauthInformers.Oauth().V1().OAuthClients(),
+		operatorConfigInformers.Operator().V1().Consoles(),
+		routesInformersNamespaced.Route().V1().Routes(),
+		configInformers.Config().V1().Ingresses(),
+		kubeInformersNamespaced.Core().V1().Secrets(),
+		recorder,
 	)
 
 	downloadsDeploymentController := downloadsdeployment.NewDownloadsDeploymentSyncController(
@@ -478,6 +490,7 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 		consoleRouteHealthCheckController,
 		consolePDBController,
 		downloadsPDBController,
+		oauthClientController,
 		upgradeNotificationController,
 		staleConditionsController,
 	} {

--- a/pkg/console/starter/starter.go
+++ b/pkg/console/starter/starter.go
@@ -217,11 +217,8 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 	)
 
 	downloadsDeploymentController := downloadsdeployment.NewDownloadsDeploymentSyncController(
-		// top level config
-		configClient.ConfigV1(),
 		// clients
 		operatorClient,
-		operatorConfigClient.OperatorV1().Consoles(),
 		configInformers,
 		// operator
 		operatorConfigInformers.Operator().V1().Consoles(),


### PR DESCRIPTION
Includes two fixes, one to status handling, another is an oversight of a cache write.

/assign @rhamilto 
/cc @csrwng @dgoodwin 