### PR TITLE
OCPBUGS-25618: Bump documentationBaseURL to 4.16

### DIFF
--- a/pkg/console/subresource/configmap/brand_ocp.go
+++ b/pkg/console/subresource/configmap/brand_ocp.go
@@ -5,5 +5,5 @@ package configmap
 
 const (
 	DEFAULT_BRAND   = "ocp"
-	DEFAULT_DOC_URL = "https://access.redhat.com/documentation/en-us/openshift_container_platform/4.14/"
+	DEFAULT_DOC_URL = "https://access.redhat.com/documentation/en-us/openshift_container_platform/4.16/"
 )


### PR DESCRIPTION
/assign @TheRealJon 
We need to get this one in to merge https://github.com/openshift/console-operator/pull/807