### PR TITLE
OCPBUGS-7656: Remove service ca controller annotation from console-redirect service.

### DIFF
--- a/bindata/assets/services/console-redirect-service.yaml
+++ b/bindata/assets/services/console-redirect-service.yaml
@@ -10,8 +10,6 @@ metadata:
   namespace: openshift-console
   labels:
     app: console
-  annotations:
-    service.beta.openshift.io/serving-cert-secret-name: console-serving-cert
 spec:
   ports:
     - name: custom-route-redirect


### PR DESCRIPTION
The annotation on the console=redirect service conflicts with the one defined on the console service which can cause the service ca controller not to sync the ca certs correctly. Additionally, the console redirect server does not use TLS so the annotation is not needed.