### PR TITLE
NO-JIRA:(chore) remove unused loglevel

### DIFF
--- a/manifests/07-operator-ibm-cloud-managed.yaml
+++ b/manifests/07-operator-ibm-cloud-managed.yaml
@@ -21,7 +21,6 @@ spec:
     spec:
       containers:
       - args:
-        - -v=2
         - --config=/var/run/configmaps/config/controller-config.yaml
         command:
         - console

--- a/manifests/07-operator.yaml
+++ b/manifests/07-operator.yaml
@@ -56,7 +56,6 @@ spec:
             - console
             - operator
           args:
-            - "-v=2"
             - "--config=/var/run/configmaps/config/controller-config.yaml"
           imagePullPolicy: IfNotPresent
           volumeMounts:


### PR DESCRIPTION
As the operator loglevel is controlled by the cr operatorLogLevel, and the --v in the deployment has no effect anymore, we should remove the redundant flag