### PR TITLE
OCPBUGS-27335: The console-deployment should set the number of replicas based on the ControlPlaneTopology

### DIFF
--- a/pkg/console/subresource/deployment/deployment.go
+++ b/pkg/console/subresource/deployment/deployment.go
@@ -114,7 +114,7 @@ func DefaultDownloadsDeployment(
 
 func withReplicas(deployment *appsv1.Deployment, infrastructureConfig *configv1.Infrastructure) {
 	replicas := int32(SingleNodeConsoleReplicas)
-	if infrastructureConfig.Status.InfrastructureTopology != configv1.SingleReplicaTopologyMode {
+	if infrastructureConfig.Status.ControlPlaneTopology != configv1.SingleReplicaTopologyMode {
 		replicas = int32(DefaultConsoleReplicas)
 	}
 	deployment.Spec.Replicas = &replicas
@@ -126,7 +126,7 @@ func withAffinity(
 	component string,
 ) {
 	affinity := &corev1.Affinity{}
-	if infrastructureConfig.Status.InfrastructureTopology != configv1.SingleReplicaTopologyMode {
+	if infrastructureConfig.Status.ControlPlaneTopology != configv1.SingleReplicaTopologyMode {
 		affinity = &corev1.Affinity{
 			PodAntiAffinity: &corev1.PodAntiAffinity{
 				RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{{

--- a/pkg/console/subresource/deployment/deployment_test.go
+++ b/pkg/console/subresource/deployment/deployment_test.go
@@ -542,7 +542,7 @@ func TestWithConsoleAnnotations(t *testing.T) {
 			ResourceVersion: "12345",
 		},
 		Status: configv1.InfrastructureStatus{
-			InfrastructureTopology: configv1.SingleReplicaTopologyMode,
+			ControlPlaneTopology: configv1.SingleReplicaTopologyMode,
 		},
 	}
 

--- a/test/e2e/deployment_replicas_test.go
+++ b/test/e2e/deployment_replicas_test.go
@@ -34,7 +34,7 @@ func TestDeploymentsReplicas(t *testing.T) {
 	}
 
 	var expectedReplicas int32
-	if infrastructureConfig.Status.InfrastructureTopology == configv1.SingleReplicaTopologyMode {
+	if infrastructureConfig.Status.ControlPlaneTopology == configv1.SingleReplicaTopologyMode {
 		expectedReplicas = int32(deploymentsub.SingleNodeConsoleReplicas)
 	} else {
 		expectedReplicas = int32(deploymentsub.DefaultConsoleReplicas)


### PR DESCRIPTION
The node selector for the console deployment requires deploying it on the master nodes, The node selector for the console deployment requires deploying it on the master nodes, while the replica count is determined by the infrastructureTopology, which primarily tracks the workers' setup.

When an OpenShift cluster is installed with a single master node and multiple workers, this leads the console deployment to request 2 replicas as infrastructureTopology is set to HighlyAvailable. Instead, ControlPlaneTopology is set to SingleReplica as expected.

This commit makes the operator drive the number of replicas for the console deployment based on the ControlPlaneTopology rather than the InfrastructureTopology.