### PR TITLE
OCPBUGS-25484: OAuthClientsController: Fix warmlooping on status updates

### DIFF
--- a/pkg/console/status/status.go
+++ b/pkg/console/status/status.go
@@ -153,9 +153,7 @@ func (c *StatusHandler) AddCondition(newStatusFunc v1helpers.UpdateStatusFunc) {
 }
 
 func (c *StatusHandler) AddConditions(newStatusFuncs []v1helpers.UpdateStatusFunc) {
-	for _, newStatusFunc := range newStatusFuncs {
-		c.statusFuncs = append(c.statusFuncs, newStatusFunc)
-	}
+	c.statusFuncs = append(c.statusFuncs, newStatusFuncs...)
 }
 
 func (c *StatusHandler) FlushAndReturn(returnErr error) error {


### PR DESCRIPTION
The OAuthClientsController uses a status handler that's not updated on every sync but it's rather re-used. The status handler did not flush the status updating changes in `FlushAndReturn()` and so on every sync there would be updates from all previous loops, too.

/assign @jhadvig 
/cc @deads2k 