### PR TITLE
CONSOLE-3912: OIDC: setup the volume name properly when custom CA is configured

### DIFF
--- a/pkg/console/subresource/deployment/deployment.go
+++ b/pkg/console/subresource/deployment/deployment.go
@@ -238,7 +238,7 @@ func withConsoleVolumes(
 	}
 
 	if authServerCAConfigMap != nil {
-		volumeConfig = append(volumeConfig, authServerCAVolumeConfig())
+		volumeConfig = append(volumeConfig, authServerCAVolumeConfig(authServerCAConfigMap.Name))
 	}
 
 	if sessionSecret != nil {
@@ -500,9 +500,9 @@ func oauthServingCertVolumeConfig() volumeConfig {
 	}
 }
 
-func authServerCAVolumeConfig() volumeConfig {
+func authServerCAVolumeConfig(cmName string) volumeConfig {
 	return volumeConfig{
-		name:        api.AuthServerCAFileName,
+		name:        cmName,
 		path:        api.AuthServerCAMountDir,
 		readOnly:    true,
 		isConfigMap: true,


### PR DESCRIPTION
This fixes
```
E0126 10:06:49.815021       1 base_controller.go:268] ConsoleOperator reconciliation failed: Deployment.apps "console" is invalid: [spec.template.spec.volumes[5].name: Invalid value: "ca-bundle.crt": must not contain dots, spec.template.spec.containers[0].volumeMounts[5].name: Not found: "ca-bundle.crt"]
```
when custom CA config map is set for the OIDC provider.

/assign @jhadvig 
/cc @liouk 
/cc @yanpzhan 