### PR TITLE
[4.15] pick of OCPBUGS-27221: make it impossible double set conditions in a single loop

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/openshift/api v0.0.0-20231129134630-a782d1c1541c
 	github.com/openshift/build-machinery-go v0.0.0-20220913142420-e25cf57ea46d
 	github.com/openshift/client-go v0.0.0-20230926161409-848405da69e1
-	github.com/openshift/library-go v0.0.0-20240117151256-95b334bccb5d
+	github.com/openshift/library-go v0.0.0-20240126152712-771c6734dc24
 	github.com/spf13/cobra v1.7.0
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.28.2

--- a/go.sum
+++ b/go.sum
@@ -138,8 +138,8 @@ github.com/openshift/build-machinery-go v0.0.0-20220913142420-e25cf57ea46d h1:RR
 github.com/openshift/build-machinery-go v0.0.0-20220913142420-e25cf57ea46d/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20230926161409-848405da69e1 h1:W1N/3nVciqmjPjn2xldHjb0AwwCQzlGxLvX5BCgE8H4=
 github.com/openshift/client-go v0.0.0-20230926161409-848405da69e1/go.mod h1:ihUJrhBcYAGYQrJu/gP2OMgfVds5f5z5kbeLNBqjHLo=
-github.com/openshift/library-go v0.0.0-20240117151256-95b334bccb5d h1:jDgYsLszzWSgxr0Tas9+L0F2pIu0mngCLv6BA5vubQ4=
-github.com/openshift/library-go v0.0.0-20240117151256-95b334bccb5d/go.mod h1:0q1UIvboZXfSlUaK+08wsXYw4N6OUo2b/z3a1EWNGyw=
+github.com/openshift/library-go v0.0.0-20240126152712-771c6734dc24 h1:FtiYXirJn37d/Fw4fbI2Mk3knELENskyhJHkNfq/HYg=
+github.com/openshift/library-go v0.0.0-20240126152712-771c6734dc24/go.mod h1:0q1UIvboZXfSlUaK+08wsXYw4N6OUo2b/z3a1EWNGyw=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/profile v1.7.0 h1:hnbDkaNWPCLMO9wGLdBFTIZvzDrDfBM2072E1S9gJkA=

--- a/pkg/console/status/status.go
+++ b/pkg/console/status/status.go
@@ -40,32 +40,44 @@ import (
 //     Message: error string value is used as message
 //
 // all degraded suffix conditions will be aggregated into a final "Degraded" status that will be set on the console ClusterOperator
-func HandleDegraded(typePrefix string, reason string, err error) v1helpers.UpdateStatusFunc {
+func HandleDegraded(typePrefix string, reason string, err error) ConditionUpdate {
 	conditionType := typePrefix + operatorsv1.OperatorStatusTypeDegraded
 	condition := handleCondition(conditionType, reason, err)
-	return v1helpers.UpdateConditionFn(condition)
+	return ConditionUpdate{
+		ConditionType:  conditionType,
+		StatusUpdateFn: v1helpers.UpdateConditionFn(condition),
+	}
 }
 
-func HandleProgressing(typePrefix string, reason string, err error) v1helpers.UpdateStatusFunc {
+func HandleProgressing(typePrefix string, reason string, err error) ConditionUpdate {
 	conditionType := typePrefix + operatorsv1.OperatorStatusTypeProgressing
 	condition := handleCondition(conditionType, reason, err)
-	return v1helpers.UpdateConditionFn(condition)
+	return ConditionUpdate{
+		ConditionType:  conditionType,
+		StatusUpdateFn: v1helpers.UpdateConditionFn(condition),
+	}
 }
 
-func HandleAvailable(typePrefix string, reason string, err error) v1helpers.UpdateStatusFunc {
+func HandleAvailable(typePrefix string, reason string, err error) ConditionUpdate {
 	conditionType := typePrefix + operatorsv1.OperatorStatusTypeAvailable
 	condition := handleCondition(conditionType, reason, err)
-	return v1helpers.UpdateConditionFn(condition)
+	return ConditionUpdate{
+		ConditionType:  conditionType,
+		StatusUpdateFn: v1helpers.UpdateConditionFn(condition),
+	}
 }
 
-func HandleUpgradable(typePrefix string, reason string, err error) v1helpers.UpdateStatusFunc {
+func HandleUpgradable(typePrefix string, reason string, err error) ConditionUpdate {
 	conditionType := typePrefix + operatorsv1.OperatorStatusTypeUpgradeable
 	condition := handleCondition(conditionType, reason, err)
-	return v1helpers.UpdateConditionFn(condition)
+	return ConditionUpdate{
+		ConditionType:  conditionType,
+		StatusUpdateFn: v1helpers.UpdateConditionFn(condition),
+	}
 }
 
-func (c *StatusHandler) ResetConditions(conditions []operatorsv1.OperatorCondition) []v1helpers.UpdateStatusFunc {
-	updateStatusFuncs := []v1helpers.UpdateStatusFunc{}
+func (c *StatusHandler) ResetConditions(conditions []operatorsv1.OperatorCondition) []ConditionUpdate {
+	updateStatusFuncs := []ConditionUpdate{}
 	for _, condition := range conditions {
 		klog.V(2).Info("\nresetting condition: ", condition.Type)
 		if strings.HasSuffix(condition.Type, operatorsv1.OperatorStatusTypeDegraded) {
@@ -101,8 +113,8 @@ func (c *StatusHandler) ResetConditions(conditions []operatorsv1.OperatorConditi
 // - Type suffix will be set to Degraded
 // TODO: when we eliminate the special case SyncError, this helper can go away.
 // When we do that, however, we must make sure to register deprecated conditions with NewRemoveStaleConditions()
-func HandleProgressingOrDegraded(typePrefix string, reason string, err error) []v1helpers.UpdateStatusFunc {
-	updateStatusFuncs := []v1helpers.UpdateStatusFunc{}
+func HandleProgressingOrDegraded(typePrefix string, reason string, err error) []ConditionUpdate {
+	updateStatusFuncs := []ConditionUpdate{}
 	if errors.IsSyncError(err) {
 		updateStatusFuncs = append(updateStatusFuncs, HandleDegraded(typePrefix, reason, nil))
 		updateStatusFuncs = append(updateStatusFuncs, HandleProgressing(typePrefix, reason, err))

--- a/vendor/github.com/openshift/library-go/pkg/operator/v1helpers/helpers.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/v1helpers/helpers.go
@@ -9,6 +9,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ghodss/yaml"
+	"github.com/google/go-cmp/cmp"
+	configv1 "github.com/openshift/api/config/v1"
+	operatorv1 "github.com/openshift/api/operator/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -17,11 +21,6 @@ import (
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
-
-	"github.com/ghodss/yaml"
-
-	configv1 "github.com/openshift/api/config/v1"
-	operatorv1 "github.com/openshift/api/operator/v1"
 )
 
 // SetOperandVersion sets the new version and returns the previous value.
@@ -161,6 +160,7 @@ func UpdateStatus(ctx context.Context, client OperatorClient, updateFuncs ...Upd
 	updated := false
 	var updatedOperatorStatus *operatorv1.OperatorStatus
 	numberOfAttempts := 0
+	previousResourceVersion := ""
 	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 		defer func() {
 			numberOfAttempts++
@@ -169,15 +169,21 @@ func UpdateStatus(ctx context.Context, client OperatorClient, updateFuncs ...Upd
 		var resourceVersion string
 		var err error
 
-		if numberOfAttempts < 1 { // prefer lister if we haven't already failed.
-			_, oldStatus, resourceVersion, err = client.GetOperatorState()
-
-		} else { // if we have failed enough times (chose 1 as a starting point, do a live GET
-			_, oldStatus, resourceVersion, err = client.GetOperatorStateWithQuorum(ctx)
-		}
+		// prefer lister if we haven't already failed.
+		_, oldStatus, resourceVersion, err = client.GetOperatorState()
 		if err != nil {
 			return err
 		}
+		if resourceVersion == previousResourceVersion {
+			listerResourceVersion := resourceVersion
+			// this indicates that we've had a conflict and the lister has not caught up, so do a live GET
+			_, oldStatus, resourceVersion, err = client.GetOperatorStateWithQuorum(ctx)
+			if err != nil {
+				return err
+			}
+			klog.V(2).Infof("lister was stale at resourceVersion=%v, live get showed resourceVersion=%v", listerResourceVersion, resourceVersion)
+		}
+		previousResourceVersion = resourceVersion
 
 		newStatus := oldStatus.DeepCopy()
 		for _, update := range updateFuncs {
@@ -191,6 +197,9 @@ func UpdateStatus(ctx context.Context, client OperatorClient, updateFuncs ...Upd
 			updatedOperatorStatus = newStatus
 			return nil
 		}
+		if klog.V(4).Enabled() {
+			klog.Infof("Operator status changed: %v", operatorStatusJSONPatchNoError(oldStatus, newStatus))
+		}
 
 		updatedOperatorStatus, err = client.UpdateOperatorStatus(ctx, resourceVersion, newStatus)
 		updated = err == nil
@@ -198,6 +207,17 @@ func UpdateStatus(ctx context.Context, client OperatorClient, updateFuncs ...Upd
 	})
 
 	return updatedOperatorStatus, updated, err
+}
+
+func operatorStatusJSONPatchNoError(original, modified *operatorv1.OperatorStatus) string {
+	if original == nil {
+		return "original object is nil"
+	}
+	if modified == nil {
+		return "modified object is nil"
+	}
+
+	return cmp.Diff(original, modified)
 }
 
 // UpdateConditionFn returns a func to update a condition.
@@ -216,6 +236,7 @@ func UpdateStaticPodStatus(ctx context.Context, client StaticPodOperatorClient, 
 	updated := false
 	var updatedOperatorStatus *operatorv1.StaticPodOperatorStatus
 	numberOfAttempts := 0
+	previousResourceVersion := ""
 	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 		defer func() {
 			numberOfAttempts++
@@ -224,16 +245,22 @@ func UpdateStaticPodStatus(ctx context.Context, client StaticPodOperatorClient, 
 		var resourceVersion string
 		var err error
 
-		if numberOfAttempts < 1 { // prefer lister if we haven't already failed.
-			_, oldStatus, resourceVersion, err = client.GetStaticPodOperatorState()
-
-		} else { // if we have failed enough times (chose 1 as a starting point, do a live GET
-			_, oldStatus, resourceVersion, err = client.GetStaticPodOperatorStateWithQuorum(ctx)
-		}
+		// prefer lister if we haven't already failed.
+		_, oldStatus, resourceVersion, err = client.GetStaticPodOperatorState()
 		if err != nil {
 			return err
 		}
-		klog.V(2).Infof("status.LatestAvailableRevision: %v, resourceVersion: %v", oldStatus.LatestAvailableRevision, resourceVersion)
+		if resourceVersion == previousResourceVersion {
+			listerResourceVersion := resourceVersion
+			// this indicates that we've had a conflict and the lister has not caught up, so do a live GET
+			_, oldStatus, resourceVersion, err = client.GetStaticPodOperatorStateWithQuorum(ctx)
+			if err != nil {
+				return err
+			}
+			klog.V(2).Infof("lister was stale at resourceVersion=%v, live get showed resourceVersion=%v", listerResourceVersion, resourceVersion)
+		}
+		previousResourceVersion = resourceVersion
+
 		newStatus := oldStatus.DeepCopy()
 		for _, update := range updateFuncs {
 			if err := update(newStatus); err != nil {
@@ -246,6 +273,9 @@ func UpdateStaticPodStatus(ctx context.Context, client StaticPodOperatorClient, 
 			updatedOperatorStatus = newStatus
 			return nil
 		}
+		if klog.V(4).Enabled() {
+			klog.Infof("Operator status changed: %v", staticPodOperatorStatusJSONPatchNoError(oldStatus, newStatus))
+		}
 
 		updatedOperatorStatus, err = client.UpdateStaticPodOperatorStatus(ctx, resourceVersion, newStatus)
 		updated = err == nil
@@ -253,6 +283,16 @@ func UpdateStaticPodStatus(ctx context.Context, client StaticPodOperatorClient, 
 	})
 
 	return updatedOperatorStatus, updated, err
+}
+
+func staticPodOperatorStatusJSONPatchNoError(original, modified *operatorv1.StaticPodOperatorStatus) string {
+	if original == nil {
+		return "original object is nil"
+	}
+	if modified == nil {
+		return "modified object is nil"
+	}
+	return cmp.Diff(original, modified)
 }
 
 // UpdateStaticPodConditionFn returns a func to update a condition.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -319,7 +319,7 @@ github.com/openshift/client-go/route/informers/externalversions/internalinterfac
 github.com/openshift/client-go/route/informers/externalversions/route
 github.com/openshift/client-go/route/informers/externalversions/route/v1
 github.com/openshift/client-go/route/listers/route/v1
-# github.com/openshift/library-go v0.0.0-20240117151256-95b334bccb5d
+# github.com/openshift/library-go v0.0.0-20240126152712-771c6734dc24
 ## explicit; go 1.20
 github.com/openshift/library-go/pkg/authorization/hardcodedauthorizer
 github.com/openshift/library-go/pkg/certs


### PR DESCRIPTION
/assign @stlaz @jhadvig 

This updates to 4.15 HEAD library-go which contains required fixes and deconflicts the oauthclient changes.