### PR TITLE
[4.15] ouathclients: further split oidc and integrated oauth handling

### DIFF
--- a/pkg/console/controllers/oauthclients/oauthclients.go
+++ b/pkg/console/controllers/oauthclients/oauthclients.go
@@ -6,9 +6,6 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
-	apiexensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	apiexensionsv1informers "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/apiextensions/v1"
-	apiexensionsv1listers "k8s.io/apiextensions-apiserver/pkg/client/listers/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -34,17 +31,13 @@ import (
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
-	appsv1informers "k8s.io/client-go/informers/apps/v1"
-	appsv1listers "k8s.io/client-go/listers/apps/v1"
 
 	"github.com/openshift/console-operator/pkg/api"
 	"github.com/openshift/console-operator/pkg/console/controllers/util"
 	"github.com/openshift/console-operator/pkg/console/status"
-	deploymentsub "github.com/openshift/console-operator/pkg/console/subresource/deployment"
 	oauthsub "github.com/openshift/console-operator/pkg/console/subresource/oauthclient"
 	routesub "github.com/openshift/console-operator/pkg/console/subresource/route"
 	secretsub "github.com/openshift/console-operator/pkg/console/subresource/secret"
-	utilsub "github.com/openshift/console-operator/pkg/console/subresource/util"
 	"github.com/openshift/console-operator/pkg/crypto"
 )
 
@@ -58,32 +51,23 @@ type oauthClientsController struct {
 	authentication              configv1client.AuthenticationInterface
 	authnLister                 configv1lister.AuthenticationLister
 	consoleOperatorLister       operatorv1listers.ConsoleLister
-	crdLister                   apiexensionsv1listers.CustomResourceDefinitionLister
 	routesLister                routev1listers.RouteLister
 	ingressConfigLister         configv1lister.IngressLister
 	targetNSSecretsLister       corev1listers.SecretLister
-	configNSSecretsLister       corev1listers.SecretLister
-	targetNSDeploymentsLister   appsv1listers.DeploymentLister
-	targetNSConfigLister        corev1listers.ConfigMapLister
 
-	authStatusHandler status.AuthStatusHandler
+	authStatusHandler *status.AuthStatusHandler
 }
 
 func NewOAuthClientsController(
-	ctx context.Context,
 	operatorClient v1helpers.OperatorClient,
 	oauthClient oauthclient.Interface,
 	secretsClient corev1client.SecretsGetter,
-	crdInformer apiexensionsv1informers.CustomResourceDefinitionInformer,
 	authentication configv1client.AuthenticationInterface,
 	authnInformer configv1informers.AuthenticationInformer,
 	consoleOperatorInformer operatorv1informers.ConsoleInformer,
 	routeInformer routev1informers.RouteInformer,
 	ingressConfigInformer configv1informers.IngressInformer,
 	targetNSsecretsInformer corev1informers.SecretInformer,
-	configNSSecretsInformer corev1informers.SecretInformer,
-	targetNSConfigInformer corev1informers.ConfigMapInformer,
-	targetNSDeploymentsInformer appsv1informers.DeploymentInformer,
 	oauthClientSwitchedInformer *util.InformerWithSwitch,
 	recorder events.Recorder,
 ) factory.Controller {
@@ -100,10 +84,6 @@ func NewOAuthClientsController(
 		routesLister:                routeInformer.Lister(),
 		ingressConfigLister:         ingressConfigInformer.Lister(),
 		targetNSSecretsLister:       targetNSsecretsInformer.Lister(),
-		configNSSecretsLister:       configNSSecretsInformer.Lister(),
-		targetNSConfigLister:        targetNSConfigInformer.Lister(),
-		targetNSDeploymentsLister:   targetNSDeploymentsInformer.Lister(),
-		crdLister:                   crdInformer.Lister(),
 
 		authStatusHandler: status.NewAuthStatusHandler(authentication, api.OpenShiftConsoleName, api.TargetNamespace, api.OpenShiftConsoleOperator),
 	}
@@ -116,16 +96,10 @@ func NewOAuthClientsController(
 			routeInformer.Informer(),
 			ingressConfigInformer.Informer(),
 			targetNSsecretsInformer.Informer(),
-			configNSSecretsInformer.Informer(),
-			targetNSDeploymentsInformer.Informer(),
 		).
 		WithFilteredEventsInformers(
 			factory.NamesFilter(api.OAuthClientName),
 			oauthClientSwitchedInformer.Informer(),
-		).
-		WithFilteredEventsInformers(
-			factory.NamesFilter("authentications.config.openshift.io"),
-			crdInformer.Informer(),
 		).
 		WithSyncDegradedOnError(operatorClient).
 		ResyncEvery(wait.Jitter(time.Minute, 1.0)).
@@ -133,12 +107,26 @@ func NewOAuthClientsController(
 }
 
 func (c *oauthClientsController) sync(ctx context.Context, controllerContext factory.SyncContext) error {
-	statusHandler := status.NewStatusHandler(c.operatorClient)
-
 	if shouldSync, err := c.handleManaged(ctx); err != nil {
 		return err
 	} else if !shouldSync {
 		return nil
+	}
+
+	statusHandler := status.NewStatusHandler(c.operatorClient)
+
+	authnConfig, err := c.authnLister.Get(api.ConfigResourceName)
+	if err != nil {
+		return err
+	}
+
+	switch authnConfig.Spec.Type {
+	case "", configv1.AuthenticationTypeIntegratedOAuth:
+	default:
+		// if we're not using integrated oauth, reset all degraded conditions
+		statusHandler.AddConditions(status.HandleProgressingOrDegraded("OAuthClientSecretSync", "", nil))
+		statusHandler.AddConditions(status.HandleProgressingOrDegraded("OAuthClientSync", "", nil))
+		return statusHandler.FlushAndReturn(nil)
 	}
 
 	operatorConfig, err := c.consoleOperatorLister.Get(api.ConfigResourceName)
@@ -147,11 +135,6 @@ func (c *oauthClientsController) sync(ctx context.Context, controllerContext fac
 	}
 
 	ingressConfig, err := c.ingressConfigLister.Get(api.ConfigResourceName)
-	if err != nil {
-		return err
-	}
-
-	authnConfig, err := c.authnLister.Get(api.ConfigResourceName)
 	if err != nil {
 		return err
 	}
@@ -167,141 +150,25 @@ func (c *oauthClientsController) sync(ctx context.Context, controllerContext fac
 		return routeErr
 	}
 
-	var syncErr error
-	switch authnConfig.Spec.Type {
-	case "", configv1.AuthenticationTypeIntegratedOAuth:
-		waitCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
-		defer cancel()
-		if !cache.WaitForCacheSync(waitCtx.Done(), c.oauthClientSwitchedInformer.Informer().HasSynced) {
-			return statusHandler.FlushAndReturn(fmt.Errorf("timed out waiting for OAuthClients cache sync"))
-		}
-
-		clientSecret, secErr := c.syncSecret(ctx, operatorConfig, controllerContext.Recorder())
-		statusHandler.AddConditions(status.HandleProgressingOrDegraded("OAuthClientSecretSync", "FailedApply", secErr))
-		if secErr != nil {
-			return statusHandler.FlushAndReturn(secErr)
-		}
-
-		oauthErrReason, oauthErr := c.syncOAuthClient(ctx, clientSecret, consoleURL.String())
-		statusHandler.AddConditions(status.HandleProgressingOrDegraded("OAuthClientSync", oauthErrReason, oauthErr))
-		if oauthErr != nil {
-			return statusHandler.FlushAndReturn(oauthErr)
-		}
-
-	case configv1.AuthenticationTypeOIDC:
-		syncErr = c.syncAuthTypeOIDC(ctx, controllerContext, statusHandler, operatorConfig, authnConfig)
-		if syncErr != nil {
-			return statusHandler.FlushAndReturn(syncErr)
-		}
+	waitCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	if !cache.WaitForCacheSync(waitCtx.Done(), c.oauthClientSwitchedInformer.Informer().HasSynced) {
+		return statusHandler.FlushAndReturn(fmt.Errorf("timed out waiting for OAuthClients cache sync"))
 	}
 
-	oidcClientsSchema, err := authnConfigHasOIDCFields(c.crdLister)
+	clientSecret, err := c.syncSecret(ctx, operatorConfig, controllerContext.Recorder())
+	statusHandler.AddConditions(status.HandleProgressingOrDegraded("OAuthClientSecretSync", "FailedApply", err))
 	if err != nil {
 		return statusHandler.FlushAndReturn(err)
 	}
 
-	if oidcClientsSchema {
-		applyErr := c.authStatusHandler.Apply(ctx, authnConfig)
-		statusHandler.AddConditions(status.HandleProgressingOrDegraded("AuthStatusHandler", "FailedApply", applyErr))
-		if applyErr != nil {
-			return statusHandler.FlushAndReturn(applyErr)
-		}
+	oauthErrReason, err := c.syncOAuthClient(ctx, clientSecret, consoleURL.String())
+	statusHandler.AddConditions(status.HandleProgressingOrDegraded("OAuthClientSync", oauthErrReason, err))
+	if err != nil {
+		return statusHandler.FlushAndReturn(err)
 	}
 
 	return statusHandler.FlushAndReturn(nil)
-}
-
-func (c *oauthClientsController) syncAuthTypeOIDC(
-	ctx context.Context,
-	controllerContext factory.SyncContext,
-	statusHandler status.StatusHandler,
-	operatorConfig *operatorv1.Console,
-	authnConfig *configv1.Authentication,
-) error {
-	clientConfig := utilsub.GetOIDCClientConfig(authnConfig)
-	if clientConfig == nil {
-		c.authStatusHandler.WithCurrentOIDCClient("")
-		c.authStatusHandler.Unavailable("OIDCClientConfig", "no OIDC client found")
-		return nil
-	}
-
-	if len(clientConfig.ClientID) == 0 {
-		err := fmt.Errorf("no ID set on OIDC client")
-		statusHandler.AddConditions(status.HandleProgressingOrDegraded("OIDCClientConfig", "MissingID", err))
-		return statusHandler.FlushAndReturn(err)
-	}
-	c.authStatusHandler.WithCurrentOIDCClient(clientConfig.ClientID)
-
-	if len(clientConfig.ClientSecret.Name) == 0 {
-		c.authStatusHandler.Degraded("OIDCClientMissingSecret", "no client secret in the OIDC client config")
-		return nil
-	}
-
-	clientSecret, err := c.configNSSecretsLister.Secrets(api.OpenShiftConfigNamespace).Get(clientConfig.ClientSecret.Name)
-	if err != nil {
-		c.authStatusHandler.Degraded("OIDCClientSecretGet", err.Error())
-		return err
-	}
-
-	secret, err := c.targetNSSecretsLister.Secrets(api.TargetNamespace).Get(secretsub.Stub().Name)
-	expectedClientSecret := secretsub.GetSecretString(clientSecret)
-	if apierrors.IsNotFound(err) || secretsub.GetSecretString(secret) != expectedClientSecret {
-		secret, _, err = resourceapply.ApplySecret(ctx, c.secretsClient, controllerContext.Recorder(), secretsub.DefaultSecret(operatorConfig, expectedClientSecret))
-		if err != nil {
-			statusHandler.AddConditions(status.HandleProgressingOrDegraded("OIDCClientSecretSync", "FailedApply", err))
-			return err
-		}
-	}
-
-	if valid, msg, err := c.checkClientConfigStatus(authnConfig, secret); err != nil {
-		c.authStatusHandler.Degraded("DeploymentOIDCConfig", err.Error())
-		return err
-
-	} else if !valid {
-		c.authStatusHandler.Progressing("DeploymentOIDCConfig", msg)
-		return nil
-	}
-
-	c.authStatusHandler.Available("OIDCConfigAvailable", "")
-	return nil
-}
-
-// checkClientConfigStatus checks whether the current client configuration is being currently in use,
-// by looking at the deployment status. It checks whether the deployment is available and updated,
-// and also whether the resource versions for the oauth secret and server CA trust configmap match
-// the deployment.
-func (c *oauthClientsController) checkClientConfigStatus(authnConfig *configv1.Authentication, clientSecret *corev1.Secret) (bool, string, error) {
-	depl, err := c.targetNSDeploymentsLister.Deployments(api.OpenShiftConsoleNamespace).Get(api.OpenShiftConsoleDeploymentName)
-	if err != nil {
-		return false, "", err
-	}
-
-	deplAvailableUpdated := deploymentsub.IsAvailableAndUpdated(depl)
-	if !deplAvailableUpdated {
-		return false, "deployment unavailable or outdated", nil
-	}
-
-	if clientSecret.GetResourceVersion() != depl.ObjectMeta.Annotations["console.openshift.io/oauth-secret-version"] {
-		return false, "client secret version not up to date in current deployment", nil
-	}
-
-	if len(authnConfig.Spec.OIDCProviders) > 0 {
-		serverCAConfigName := authnConfig.Spec.OIDCProviders[0].Issuer.CertificateAuthority.Name
-		if len(serverCAConfigName) == 0 {
-			return deplAvailableUpdated, "", nil
-		}
-
-		serverCAConfig, err := c.targetNSConfigLister.ConfigMaps(api.OpenShiftConsoleNamespace).Get(serverCAConfigName)
-		if err != nil {
-			return false, "", err
-		}
-
-		if serverCAConfig.GetResourceVersion() != depl.ObjectMeta.Annotations["console.openshift.io/authn-ca-trust-config-version"] {
-			return false, "OIDC provider CA version not up to date in current deployment", nil
-		}
-	}
-
-	return deplAvailableUpdated, "", nil
 }
 
 // handleStatus returns whether sync should happen and any error encountering
@@ -372,30 +239,5 @@ func (c *oauthClientsController) deregisterClient(ctx context.Context) error {
 	updated := oauthsub.DeRegisterConsoleFromOAuthClient(existingOAuthClient.DeepCopy())
 	_, err = c.oauthClient.OAuthClients().Update(ctx, updated, metav1.UpdateOptions{})
 	return err
-
-}
-
-func authnConfigHasOIDCFields(crdLister apiexensionsv1listers.CustomResourceDefinitionLister) (bool, error) {
-	authnCRD, err := crdLister.Get("authentications.config.openshift.io")
-	if err != nil {
-		return false, err
-	}
-
-	var authnV1Config *apiexensionsv1.CustomResourceDefinitionVersion
-	for _, version := range authnCRD.Spec.Versions {
-		if version.Name == "v1" && version.Served && version.Storage {
-			authnV1Config = &version
-			break
-		}
-	}
-
-	if authnV1Config == nil {
-		return false, fmt.Errorf("authentications.config.openshift.io is not served or stored as v1")
-	}
-
-	schema := authnV1Config.Schema.OpenAPIV3Schema
-	_, clientsExist := schema.Properties["status"].Properties["oidcClients"]
-
-	return clientsExist, nil
 
 }

--- a/pkg/console/controllers/oauthclients/oauthclients.go
+++ b/pkg/console/controllers/oauthclients/oauthclients.go
@@ -36,6 +36,14 @@ import (
 	secretsub "github.com/openshift/console-operator/pkg/console/subresource/secret"
 )
 
+// oauthClientsController:
+//
+//	updates:
+//	- oauthclient.oauth.openshift.io/console (created by CVO)
+//	writes:
+//	- consoles.operator.openshift.io/cluster .status.conditions:
+//		- type=OAuthClientSyncProgressing
+//		- type=OAuthClientSyncDegraded
 type oauthClientsController struct {
 	oauthClient    oauthv1client.OAuthClientsGetter
 	operatorClient v1helpers.OperatorClient
@@ -47,8 +55,6 @@ type oauthClientsController struct {
 	routesLister                routev1listers.RouteLister
 	ingressConfigLister         configv1lister.IngressLister
 	targetNSSecretsLister       corev1listers.SecretLister
-
-	authStatusHandler *status.AuthStatusHandler
 }
 
 func NewOAuthClientsController(

--- a/pkg/console/controllers/oauthclients/oauthclients.go
+++ b/pkg/console/controllers/oauthclients/oauthclients.go
@@ -111,7 +111,6 @@ func (c *oauthClientsController) sync(ctx context.Context, controllerContext fac
 	case "", configv1.AuthenticationTypeIntegratedOAuth:
 	default:
 		// if we're not using integrated oauth, reset all degraded conditions
-		statusHandler.AddConditions(status.HandleProgressingOrDegraded("OAuthClientSecretSync", "", nil))
 		statusHandler.AddConditions(status.HandleProgressingOrDegraded("OAuthClientSync", "", nil))
 		return statusHandler.FlushAndReturn(nil)
 	}

--- a/pkg/console/controllers/oauthclientsecret/oauthclientsecret.go
+++ b/pkg/console/controllers/oauthclientsecret/oauthclientsecret.go
@@ -1,0 +1,179 @@
+package oauthclientsecret
+
+import (
+	"context"
+	"fmt"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	corev1informers "k8s.io/client-go/informers/core/v1"
+	corev1clients "k8s.io/client-go/kubernetes/typed/core/v1"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+	"k8s.io/klog/v2"
+
+	configv1 "github.com/openshift/api/config/v1"
+	operatorv1 "github.com/openshift/api/operator/v1"
+	configv1informers "github.com/openshift/client-go/config/informers/externalversions/config/v1"
+	configv1listers "github.com/openshift/client-go/config/listers/config/v1"
+	operatorv1informers "github.com/openshift/client-go/operator/informers/externalversions/operator/v1"
+	operatorv1listers "github.com/openshift/client-go/operator/listers/operator/v1"
+	"github.com/openshift/console-operator/pkg/api"
+	"github.com/openshift/console-operator/pkg/console/status"
+	"github.com/openshift/console-operator/pkg/crypto"
+	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
+	v1helpers "github.com/openshift/library-go/pkg/operator/v1helpers"
+
+	secretsub "github.com/openshift/console-operator/pkg/console/subresource/secret"
+	utilsub "github.com/openshift/console-operator/pkg/console/subresource/util"
+)
+
+// oauthClientSecretController behaves differently based on authentication/cluster .spec.type:
+//
+//   - IntegratedOAuth - self-manage the client secret string
+//   - OIDC - lookup our client in the authentication/cluster .spec.oidcProviders[x].oidcClients
+//     slice and use the 'clientSecret' from the secret referred to by .clientSecret.name
+//   - None - do nothing
+//
+// The secret written is 'openshift-console/console-oauth-config' in .Data['clientSecret']
+type oauthClientSecretController struct {
+	operatorClient v1helpers.OperatorClient
+	secretsClient  corev1clients.SecretsGetter
+
+	authConfigLister      configv1listers.AuthenticationLister
+	consoleOperatorLister operatorv1listers.ConsoleLister
+	configSecretsLister   corev1listers.SecretLister
+	targetNSSecretsLister corev1listers.SecretLister
+}
+
+func NewOAuthClientSecretController(
+	operatorClient v1helpers.OperatorClient,
+	secretsClient corev1clients.SecretsGetter,
+	authnInformer configv1informers.AuthenticationInformer,
+	consoleOperatorInformer operatorv1informers.ConsoleInformer,
+	configSecretsInformer corev1informers.SecretInformer,
+	targetNSsecretsInformer corev1informers.SecretInformer,
+	recorder events.Recorder,
+) factory.Controller {
+	c := &oauthClientSecretController{
+		operatorClient: operatorClient,
+		secretsClient:  secretsClient,
+
+		authConfigLister:      authnInformer.Lister(),
+		consoleOperatorLister: consoleOperatorInformer.Lister(),
+		configSecretsLister:   configSecretsInformer.Lister(),
+		targetNSSecretsLister: targetNSsecretsInformer.Lister(),
+	}
+
+	return factory.New().
+		WithSync(c.sync).
+		WithInformers(
+			authnInformer.Informer(),
+			consoleOperatorInformer.Informer(),
+			configSecretsInformer.Informer(),
+		).
+		WithFilteredEventsInformers(
+			factory.NamesFilter("console-oauth-config"), targetNSsecretsInformer.Informer(),
+		).
+		ToController("OAuthClientSecretController", recorder.WithComponentSuffix("oauthclient-secret-controller"))
+}
+
+func (c *oauthClientSecretController) sync(ctx context.Context, syncCtx factory.SyncContext) error {
+	if shouldSync, err := c.handleManaged(ctx); err != nil {
+		return err
+	} else if !shouldSync {
+		return nil
+	}
+
+	statusHandler := status.NewStatusHandler(c.operatorClient)
+
+	clientSecret, err := c.targetNSSecretsLister.Secrets(api.TargetNamespace).Get("console-oauth-config")
+	if err != nil && !apierrors.IsNotFound(err) {
+		return err
+	}
+
+	authConfig, err := c.authConfigLister.Get("cluster")
+	if err != nil {
+		return fmt.Errorf("failed to retrieve authentication config: %w", err)
+	}
+
+	var secretString string
+	switch authConfig.Spec.Type {
+	case "", configv1.AuthenticationTypeIntegratedOAuth:
+		// in OpenShift controlled world, we generate the client secret ourselves
+		if clientSecret != nil {
+			secretString = secretsub.GetSecretString(clientSecret)
+		}
+		if len(secretString) == 0 {
+			secretString = crypto.Random256BitsString()
+		}
+	case configv1.AuthenticationTypeOIDC:
+		clientConfig := utilsub.GetOIDCClientConfig(authConfig)
+		if clientConfig == nil {
+			// no config, flush the condition and return
+			statusHandler.AddConditions(status.HandleProgressingOrDegraded("OAuthClientSecretSync", "", nil))
+			return statusHandler.FlushAndReturn(nil)
+		}
+
+		if len(clientConfig.ClientSecret.Name) == 0 {
+			statusHandler.AddConditions(status.HandleProgressingOrDegraded("OAuthClientSecretSync", "MissingClientSecretConfig", fmt.Errorf("missing client secret name reference in config")))
+			return statusHandler.FlushAndReturn(nil)
+		}
+
+		conficClientSecret, err := c.configSecretsLister.Secrets(api.OpenShiftConfigNamespace).Get(clientConfig.ClientSecret.Name)
+		if err != nil {
+			statusHandler.AddConditions(status.HandleProgressingOrDegraded("OAuthClientSecretSync", "FailedClientSecretGet", err))
+			return statusHandler.FlushAndReturn(err)
+		}
+
+		secretString = secretsub.GetSecretString(conficClientSecret)
+		if len(secretString) == 0 {
+			statusHandler.AddConditions(status.HandleProgressingOrDegraded("OAuthClientSecretSync", "ClientSecretKeyMissing", fmt.Errorf("missing the 'clientSecret' key in the client secret secret %q", clientConfig.ClientSecret.Name)))
+			return statusHandler.FlushAndReturn(nil)
+		}
+	default:
+		klog.V(2).Infof("unknown authentication type: %s", authConfig.Spec.Type)
+		return nil
+	}
+
+	err = c.syncSecret(ctx, secretString, syncCtx.Recorder())
+	statusHandler.AddConditions(status.HandleProgressingOrDegraded("OAuthClientSecretSync", "FailedApply", err))
+	return statusHandler.FlushAndReturn(err)
+}
+
+func (c *oauthClientSecretController) syncSecret(ctx context.Context, clientSecret string, recorder events.Recorder) error {
+	operatorConfig, err := c.consoleOperatorLister.Get(api.ConfigResourceName)
+	if err != nil {
+		return err
+	}
+
+	secret, err := c.targetNSSecretsLister.Secrets(api.TargetNamespace).Get("console-oauth-config")
+	if apierrors.IsNotFound(err) || secretsub.GetSecretString(secret) == clientSecret {
+		_, _, err = resourceapply.ApplySecret(ctx, c.secretsClient, recorder, secretsub.DefaultSecret(operatorConfig, clientSecret))
+	}
+	return err
+}
+
+// handleStatus returns whether sync should happen and any error encountering
+// determining the operator's management state
+// TODO: extract this logic to where it can be used for all controllers
+func (c *oauthClientSecretController) handleManaged(ctx context.Context) (bool, error) {
+	operatorSpec, _, _, err := c.operatorClient.GetOperatorState()
+	if err != nil {
+		return false, fmt.Errorf("failed to retrieve operator config: %w", err)
+	}
+
+	switch managementState := operatorSpec.ManagementState; managementState {
+	case operatorv1.Managed:
+		klog.V(4).Infoln("console is in a managed state.")
+		return true, nil
+	case operatorv1.Unmanaged:
+		klog.V(4).Infoln("console is in an unmanaged state.")
+		return false, nil
+	case operatorv1.Removed:
+		klog.V(4).Infoln("console has been removed.")
+		return false, nil
+	default:
+		return false, fmt.Errorf("console is in an unknown state: %v", managementState)
+	}
+}

--- a/pkg/console/controllers/oauthclientsecret/oauthclientsecret.go
+++ b/pkg/console/controllers/oauthclientsecret/oauthclientsecret.go
@@ -36,6 +36,14 @@ import (
 //   - None - do nothing
 //
 // The secret written is 'openshift-console/console-oauth-config' in .Data['clientSecret']
+//
+// ==========
+//
+//	writes:
+//	- secrets.console-oauth-config -n openshift-console .Data['clientSecret']
+//	- consoles.operator.openshift.io/cluster .status.conditions:
+//		- type=OAuthClientSecretSyncProgressing
+//		- type=OAuthClientSecretSyncDegraded
 type oauthClientSecretController struct {
 	operatorClient v1helpers.OperatorClient
 	secretsClient  corev1clients.SecretsGetter

--- a/pkg/console/controllers/oidcsetup/oidcsetup.go
+++ b/pkg/console/controllers/oidcsetup/oidcsetup.go
@@ -1,0 +1,283 @@
+package oidcsetup
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
+	corev1 "k8s.io/api/core/v1"
+	apiexensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiexensionsv1informers "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/apiextensions/v1"
+	apiexensionsv1listers "k8s.io/apiextensions-apiserver/pkg/client/listers/apiextensions/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/wait"
+	appsv1informers "k8s.io/client-go/informers/apps/v1"
+	corev1informers "k8s.io/client-go/informers/core/v1"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	appsv1listers "k8s.io/client-go/listers/apps/v1"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+	"k8s.io/klog/v2"
+
+	configv1 "github.com/openshift/api/config/v1"
+	operatorv1 "github.com/openshift/api/operator/v1"
+	configv1informers "github.com/openshift/client-go/config/informers/externalversions/config/v1"
+	configv1listers "github.com/openshift/client-go/config/listers/config/v1"
+	operatorv1informers "github.com/openshift/client-go/operator/informers/externalversions/operator/v1"
+	operatorv1listers "github.com/openshift/client-go/operator/listers/operator/v1"
+	"github.com/openshift/console-operator/pkg/api"
+	"github.com/openshift/console-operator/pkg/console/status"
+	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+
+	deploymentsub "github.com/openshift/console-operator/pkg/console/subresource/deployment"
+	secretsub "github.com/openshift/console-operator/pkg/console/subresource/secret"
+	utilsub "github.com/openshift/console-operator/pkg/console/subresource/util"
+)
+
+type oidcSetupController struct {
+	operatorClient v1helpers.OperatorClient
+	secretsClient  corev1client.SecretsGetter
+
+	authnLister               configv1listers.AuthenticationLister
+	configNSSecretsLister     corev1listers.SecretLister
+	crdLister                 apiexensionsv1listers.CustomResourceDefinitionLister
+	consoleOperatorLister     operatorv1listers.ConsoleLister
+	targetNSSecretsLister     corev1listers.SecretLister
+	targetNSConfigMapLister   corev1listers.ConfigMapLister
+	targetNSDeploymentsLister appsv1listers.DeploymentLister
+
+	authStatusHandler *status.AuthStatusHandler
+}
+
+func NewOIDCSetupController(
+	operatorClient v1helpers.OperatorClient,
+	secretsClient corev1client.SecretsGetter,
+	authnInformer configv1informers.AuthenticationInformer,
+	authenticationClient configv1client.AuthenticationInterface,
+	consoleOperatorInformer operatorv1informers.ConsoleInformer,
+	crdInformer apiexensionsv1informers.CustomResourceDefinitionInformer,
+	configNSSecretsInformer corev1informers.SecretInformer,
+	targetNSsecretsInformer corev1informers.SecretInformer,
+	targetNSConfigMapInformer corev1informers.ConfigMapInformer,
+	targetNSDeploymentsInformer appsv1informers.DeploymentInformer,
+	recorder events.Recorder,
+) factory.Controller {
+	c := &oidcSetupController{
+		operatorClient: operatorClient,
+		secretsClient:  secretsClient,
+
+		authnLister:               authnInformer.Lister(),
+		consoleOperatorLister:     consoleOperatorInformer.Lister(),
+		configNSSecretsLister:     configNSSecretsInformer.Lister(),
+		crdLister:                 crdInformer.Lister(),
+		targetNSSecretsLister:     targetNSsecretsInformer.Lister(),
+		targetNSDeploymentsLister: targetNSDeploymentsInformer.Lister(),
+		targetNSConfigMapLister:   targetNSConfigMapInformer.Lister(),
+
+		authStatusHandler: status.NewAuthStatusHandler(authenticationClient, api.OpenShiftConsoleName, api.TargetNamespace, api.OpenShiftConsoleOperator),
+	}
+	return factory.New().
+		WithSync(c.sync).
+		ResyncEvery(wait.Jitter(time.Minute, 1.0)).
+		WithFilteredEventsInformers(
+			factory.NamesFilter("authentications.config.openshift.io"),
+			crdInformer.Informer(),
+		).
+		WithInformers(
+			authnInformer.Informer(),
+			consoleOperatorInformer.Informer(),
+			targetNSsecretsInformer.Informer(),
+			configNSSecretsInformer.Informer(),
+			targetNSDeploymentsInformer.Informer(),
+			targetNSConfigMapInformer.Informer(),
+		).
+		ToController("OIDCSetupController", recorder.WithComponentSuffix("oidc-setup-controller"))
+}
+
+func (c *oidcSetupController) sync(ctx context.Context, syncCtx factory.SyncContext) error {
+	statusHandler := status.NewStatusHandler(c.operatorClient)
+
+	if shouldSync, err := c.handleManaged(ctx); err != nil {
+		return err
+	} else if !shouldSync {
+		return nil
+	}
+
+	operatorConfig, err := c.consoleOperatorLister.Get(api.ConfigResourceName)
+	if err != nil {
+		return err
+	}
+
+	authnConfig, err := c.authnLister.Get(api.ConfigResourceName)
+	if err != nil {
+		return err
+	}
+
+	if authnConfig.Spec.Type == configv1.AuthenticationTypeOIDC {
+		err = c.syncAuthTypeOIDC(ctx, syncCtx, statusHandler, operatorConfig, authnConfig)
+		if err != nil {
+			return statusHandler.FlushAndReturn(err)
+		}
+	}
+
+	oidcClientsSchema, err := authnConfigHasOIDCFields(c.crdLister)
+	if err != nil {
+		return statusHandler.FlushAndReturn(err)
+	}
+
+	if oidcClientsSchema {
+		applyErr := c.authStatusHandler.Apply(ctx, authnConfig)
+		statusHandler.AddConditions(status.HandleProgressingOrDegraded("AuthStatusHandler", "FailedApply", applyErr))
+		if applyErr != nil {
+			return statusHandler.FlushAndReturn(applyErr)
+		}
+	}
+
+	return statusHandler.FlushAndReturn(nil)
+}
+
+func (c *oidcSetupController) syncAuthTypeOIDC(
+	ctx context.Context,
+	controllerContext factory.SyncContext,
+	statusHandler status.StatusHandler,
+	operatorConfig *operatorv1.Console,
+	authnConfig *configv1.Authentication,
+) error {
+
+	clientConfig := utilsub.GetOIDCClientConfig(authnConfig)
+	if clientConfig == nil {
+		c.authStatusHandler.WithCurrentOIDCClient("")
+		c.authStatusHandler.Unavailable("OIDCClientConfig", "no OIDC client found")
+		return nil
+	}
+
+	if len(clientConfig.ClientID) == 0 {
+		err := fmt.Errorf("no ID set on OIDC client")
+		statusHandler.AddConditions(status.HandleProgressingOrDegraded("OIDCClientConfig", "MissingID", err))
+		return statusHandler.FlushAndReturn(err)
+	}
+	c.authStatusHandler.WithCurrentOIDCClient(clientConfig.ClientID)
+
+	if len(clientConfig.ClientSecret.Name) == 0 {
+		c.authStatusHandler.Degraded("OIDCClientMissingSecret", "no client secret in the OIDC client config")
+		return nil
+	}
+
+	clientSecret, err := c.configNSSecretsLister.Secrets(api.OpenShiftConfigNamespace).Get(clientConfig.ClientSecret.Name)
+	if err != nil {
+		c.authStatusHandler.Degraded("OIDCClientSecretGet", err.Error())
+		return err
+	}
+
+	secret, err := c.targetNSSecretsLister.Secrets(api.TargetNamespace).Get(secretsub.Stub().Name)
+	expectedClientSecret := secretsub.GetSecretString(clientSecret)
+	if apierrors.IsNotFound(err) || secretsub.GetSecretString(secret) != expectedClientSecret {
+		secret, _, err = resourceapply.ApplySecret(ctx, c.secretsClient, controllerContext.Recorder(), secretsub.DefaultSecret(operatorConfig, expectedClientSecret))
+		if err != nil {
+			statusHandler.AddConditions(status.HandleProgressingOrDegraded("OIDCClientSecretSync", "FailedApply", err))
+			return err
+		}
+	}
+
+	if valid, msg, err := c.checkClientConfigStatus(authnConfig, secret); err != nil {
+		c.authStatusHandler.Degraded("DeploymentOIDCConfig", err.Error())
+		return err
+
+	} else if !valid {
+		c.authStatusHandler.Progressing("DeploymentOIDCConfig", msg)
+		return nil
+	}
+
+	c.authStatusHandler.Available("OIDCConfigAvailable", "")
+	return nil
+}
+
+// checkClientConfigStatus checks whether the current client configuration is being currently in use,
+// by looking at the deployment status. It checks whether the deployment is available and updated,
+// and also whether the resource versions for the oauth secret and server CA trust configmap match
+// the deployment.
+func (c *oidcSetupController) checkClientConfigStatus(authnConfig *configv1.Authentication, clientSecret *corev1.Secret) (bool, string, error) {
+	depl, err := c.targetNSDeploymentsLister.Deployments(api.OpenShiftConsoleNamespace).Get(api.OpenShiftConsoleDeploymentName)
+	if err != nil {
+		return false, "", err
+	}
+
+	deplAvailableUpdated := deploymentsub.IsAvailableAndUpdated(depl)
+	if !deplAvailableUpdated {
+		return false, "deployment unavailable or outdated", nil
+	}
+
+	if clientSecret.GetResourceVersion() != depl.ObjectMeta.Annotations["console.openshift.io/oauth-secret-version"] {
+		return false, "client secret version not up to date in current deployment", nil
+	}
+
+	if len(authnConfig.Spec.OIDCProviders) > 0 {
+		serverCAConfigName := authnConfig.Spec.OIDCProviders[0].Issuer.CertificateAuthority.Name
+		if len(serverCAConfigName) == 0 {
+			return deplAvailableUpdated, "", nil
+		}
+
+		serverCAConfig, err := c.targetNSConfigMapLister.ConfigMaps(api.OpenShiftConsoleNamespace).Get(serverCAConfigName)
+		if err != nil {
+			return false, "", err
+		}
+
+		if serverCAConfig.GetResourceVersion() != depl.ObjectMeta.Annotations["console.openshift.io/authn-ca-trust-config-version"] {
+			return false, "OIDC provider CA version not up to date in current deployment", nil
+		}
+	}
+
+	return deplAvailableUpdated, "", nil
+}
+
+// handleStatus returns whether sync should happen and any error encountering
+// determining the operator's management state
+// TODO: extract this logic to where it can be used for all controllers
+func (c *oidcSetupController) handleManaged(ctx context.Context) (bool, error) {
+	operatorSpec, _, _, err := c.operatorClient.GetOperatorState()
+	if err != nil {
+		return false, fmt.Errorf("failed to retrieve operator config: %w", err)
+	}
+
+	switch managementState := operatorSpec.ManagementState; managementState {
+	case operatorv1.Managed:
+		klog.V(4).Infoln("console is in a managed state.")
+		return true, nil
+	case operatorv1.Unmanaged:
+		klog.V(4).Infoln("console is in an unmanaged state.")
+		return false, nil
+	case operatorv1.Removed:
+		klog.V(4).Infoln("console has been removed.")
+		return false, nil
+	default:
+		return false, fmt.Errorf("console is in an unknown state: %v", managementState)
+	}
+}
+
+func authnConfigHasOIDCFields(crdLister apiexensionsv1listers.CustomResourceDefinitionLister) (bool, error) {
+	authnCRD, err := crdLister.Get("authentications.config.openshift.io")
+	if err != nil {
+		return false, err
+	}
+
+	var authnV1Config *apiexensionsv1.CustomResourceDefinitionVersion
+	for _, version := range authnCRD.Spec.Versions {
+		if version.Name == "v1" && version.Served && version.Storage {
+			authnV1Config = &version
+			break
+		}
+	}
+
+	if authnV1Config == nil {
+		return false, fmt.Errorf("authentications.config.openshift.io is not served or stored as v1")
+	}
+
+	schema := authnV1Config.Schema.OpenAPIV3Schema
+	_, clientsExist := schema.Properties["status"].Properties["oidcClients"]
+
+	return clientsExist, nil
+
+}

--- a/pkg/console/controllers/oidcsetup/oidcsetup.go
+++ b/pkg/console/controllers/oidcsetup/oidcsetup.go
@@ -107,9 +107,12 @@ func (c *oidcSetupController) sync(ctx context.Context, syncCtx factory.SyncCont
 
 	if authnConfig.Spec.Type == configv1.AuthenticationTypeOIDC {
 		err = c.syncAuthTypeOIDC(ctx, syncCtx, statusHandler, operatorConfig, authnConfig)
+		statusHandler.AddConditions(status.HandleProgressingOrDegraded("OIDCClientConfig", "MissingID", err))
 		if err != nil {
 			return statusHandler.FlushAndReturn(err)
 		}
+	} else {
+		statusHandler.AddConditions(status.HandleProgressingOrDegraded("OIDCClientConfig", "", nil))
 	}
 
 	oidcClientsSchema, err := authnConfigHasOIDCFields(c.crdLister)
@@ -144,9 +147,7 @@ func (c *oidcSetupController) syncAuthTypeOIDC(
 	}
 
 	if len(clientConfig.ClientID) == 0 {
-		err := fmt.Errorf("no ID set on OIDC client")
-		statusHandler.AddConditions(status.HandleProgressingOrDegraded("OIDCClientConfig", "MissingID", err))
-		return statusHandler.FlushAndReturn(err)
+		return fmt.Errorf("no ID set on console's OIDC client")
 	}
 	c.authStatusHandler.WithCurrentOIDCClient(clientConfig.ClientID)
 

--- a/pkg/console/controllers/oidcsetup/oidcsetup.go
+++ b/pkg/console/controllers/oidcsetup/oidcsetup.go
@@ -33,6 +33,22 @@ import (
 	utilsub "github.com/openshift/console-operator/pkg/console/subresource/util"
 )
 
+// oidcSetupController:
+//
+//	writes:
+//	- authentication.config.openshift.io/cluster .status.oidcClients:
+//		- componentName=console
+//		- componentNamespace=openshift-console
+//		- currentOIDCClients
+//		- conditions:
+//			- Available
+//			- Progressing
+//			- Degraded
+//	- consoles.operator.openshift.io/cluster .status.conditions:
+//		- type=OIDCClientConfigProgressing
+//		- type=OIDCClientConfigDegraded
+//		- type=AuthStatusHandlerProgressing
+//		- type=AuthStatusHandlerDegraded
 type oidcSetupController struct {
 	operatorClient v1helpers.OperatorClient
 

--- a/pkg/console/operator/sync_v400.go
+++ b/pkg/console/operator/sync_v400.go
@@ -150,7 +150,7 @@ func (co *consoleOperator) sync_v400(ctx context.Context, controllerContext fact
 	}
 
 	clientSecret, secErr := co.secretsLister.Secrets(api.TargetNamespace).Get(secretsub.Stub().Name)
-	statusHandler.AddConditions(status.HandleProgressingOrDegraded("OAuthClientSecretSync", "FailedGet", secErr))
+	statusHandler.AddConditions(status.HandleProgressingOrDegraded("OAuthClientSecretGet", "FailedGet", secErr))
 	if secErr != nil {
 		return statusHandler.FlushAndReturn(secErr)
 	}

--- a/pkg/console/starter/starter.go
+++ b/pkg/console/starter/starter.go
@@ -27,6 +27,7 @@ import (
 	"github.com/openshift/console-operator/pkg/console/controllers/downloadsdeployment"
 	"github.com/openshift/console-operator/pkg/console/controllers/healthcheck"
 	"github.com/openshift/console-operator/pkg/console/controllers/oauthclients"
+	"github.com/openshift/console-operator/pkg/console/controllers/oauthclientsecret"
 	"github.com/openshift/console-operator/pkg/console/controllers/oidcsetup"
 	pdb "github.com/openshift/console-operator/pkg/console/controllers/poddisruptionbudget"
 	"github.com/openshift/console-operator/pkg/console/controllers/route"
@@ -214,8 +215,6 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 	oauthClientController := oauthclients.NewOAuthClientsController(
 		operatorClient,
 		oauthClient,
-		kubeClient.CoreV1(),
-		configClient.ConfigV1().Authentications(),
 		configInformers.Config().V1().Authentications(),
 		operatorConfigInformers.Operator().V1().Consoles(),
 		routesInformersNamespaced.Route().V1().Routes(),
@@ -225,14 +224,22 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 		recorder,
 	)
 
-	oidcSetupController := oidcsetup.NewOIDCSetupController(
+	oauthClientSecretController := oauthclientsecret.NewOAuthClientSecretController(
 		operatorClient,
 		kubeClient.CoreV1(),
+		configInformers.Config().V1().Authentications(),
+		operatorConfigInformers.Operator().V1().Consoles(),
+		kubeInformersConfigNamespaced.Core().V1().Secrets(),
+		kubeInformersNamespaced.Core().V1().Secrets(),
+		recorder,
+	)
+
+	oidcSetupController := oidcsetup.NewOIDCSetupController(
+		operatorClient,
 		configInformers.Config().V1().Authentications(),
 		configClient.ConfigV1().Authentications(),
 		operatorConfigInformers.Operator().V1().Consoles(),
 		apiextensionsInformers.Apiextensions().V1().CustomResourceDefinitions(),
-		kubeInformersConfigNamespaced.Core().V1().Secrets(),
 		kubeInformersNamespaced.Core().V1().Secrets(),
 		kubeInformersNamespaced.Core().V1().ConfigMaps(),
 		kubeInformersNamespaced.Apps().V1().Deployments(),
@@ -506,6 +513,7 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 		consolePDBController,
 		downloadsPDBController,
 		oauthClientController,
+		oauthClientSecretController,
 		oidcSetupController,
 		upgradeNotificationController,
 		staleConditionsController,

--- a/pkg/console/status/auth_status.go
+++ b/pkg/console/status/auth_status.go
@@ -30,8 +30,8 @@ type AuthStatusHandler struct {
 // NewAuthStatusHandler creates a handler for updating the Authentication.config.openshift.io
 // status with information about the expected and currently used OIDC client.
 // Not thread safe, only use in controllers with a single worker!
-func NewAuthStatusHandler(authnClient configv1client.AuthenticationInterface, componentName, componentNamespace, fieldManager string) AuthStatusHandler {
-	return AuthStatusHandler{
+func NewAuthStatusHandler(authnClient configv1client.AuthenticationInterface, componentName, componentNamespace, fieldManager string) *AuthStatusHandler {
+	return &AuthStatusHandler{
 		client:             authnClient,
 		componentName:      componentName,
 		componentNamespace: componentNamespace,


### PR DESCRIPTION
backport of https://github.com/openshift/console-operator/pull/861 + it adds a commit `authn status handling: flush conditions on Apply()` from https://github.com/openshift/console-operator/pull/848 that got lost somehow in https://github.com/openshift/console-operator/pull/851

/cc @deads2k 
/assign @jhadvig 