### PR TITLE
OCPBUGS-31619: use InfrastructureTopology for clusters using external CP as the console deploys on the worker nodes

### DIFF
--- a/pkg/console/subresource/deployment/deployment.go
+++ b/pkg/console/subresource/deployment/deployment.go
@@ -122,9 +122,18 @@ func DefaultDownloadsDeployment(
 	return downloadsDeployment
 }
 
+// ShouldDeployHA returns true if the console should be deployed in HA mode.
+// If the control plane is externalized, the console should be deployed in HA mode based on the InfrastructureTopology,
+// otherwise it should be deployed in HA mode based on the ControlPlaneTopology.
+func ShouldDeployHA(infrastructureConfig *configv1.Infrastructure) bool {
+	return infrastructureConfig.Status.ControlPlaneTopology == configv1.HighlyAvailableTopologyMode ||
+		(infrastructureConfig.Status.ControlPlaneTopology == configv1.ExternalTopologyMode &&
+			infrastructureConfig.Status.InfrastructureTopology == configv1.HighlyAvailableTopologyMode)
+}
+
 func withReplicas(deployment *appsv1.Deployment, infrastructureConfig *configv1.Infrastructure) {
 	replicas := int32(SingleNodeConsoleReplicas)
-	if infrastructureConfig.Status.ControlPlaneTopology != configv1.SingleReplicaTopologyMode {
+	if ShouldDeployHA(infrastructureConfig) {
 		replicas = int32(DefaultConsoleReplicas)
 	}
 	deployment.Spec.Replicas = &replicas
@@ -136,7 +145,7 @@ func withAffinity(
 	component string,
 ) {
 	affinity := &corev1.Affinity{}
-	if infrastructureConfig.Status.ControlPlaneTopology != configv1.SingleReplicaTopologyMode {
+	if ShouldDeployHA(infrastructureConfig) {
 		affinity = &corev1.Affinity{
 			PodAntiAffinity: &corev1.PodAntiAffinity{
 				RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{{
@@ -159,7 +168,7 @@ func withAffinity(
 
 func withStrategy(deployment *appsv1.Deployment, infrastructureConfig *configv1.Infrastructure) {
 	rollingUpdateParams := &appsv1.RollingUpdateDeployment{}
-	if infrastructureConfig.Status.InfrastructureTopology != configv1.SingleReplicaTopologyMode {
+	if ShouldDeployHA(infrastructureConfig) {
 		rollingUpdateParams = &appsv1.RollingUpdateDeployment{
 			MaxSurge: &intstr.IntOrString{
 				IntVal: int32(3),

--- a/pkg/console/subresource/deployment/deployment.go
+++ b/pkg/console/subresource/deployment/deployment.go
@@ -124,7 +124,7 @@ func DefaultDownloadsDeployment(
 
 func withReplicas(deployment *appsv1.Deployment, infrastructureConfig *configv1.Infrastructure) {
 	replicas := int32(SingleNodeConsoleReplicas)
-	if infrastructureConfig.Status.InfrastructureTopology != configv1.SingleReplicaTopologyMode {
+	if infrastructureConfig.Status.ControlPlaneTopology != configv1.SingleReplicaTopologyMode {
 		replicas = int32(DefaultConsoleReplicas)
 	}
 	deployment.Spec.Replicas = &replicas
@@ -136,7 +136,7 @@ func withAffinity(
 	component string,
 ) {
 	affinity := &corev1.Affinity{}
-	if infrastructureConfig.Status.InfrastructureTopology != configv1.SingleReplicaTopologyMode {
+	if infrastructureConfig.Status.ControlPlaneTopology != configv1.SingleReplicaTopologyMode {
 		affinity = &corev1.Affinity{
 			PodAntiAffinity: &corev1.PodAntiAffinity{
 				RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{{

--- a/pkg/console/subresource/deployment/deployment_test.go
+++ b/pkg/console/subresource/deployment/deployment_test.go
@@ -554,7 +554,7 @@ func TestWithConsoleAnnotations(t *testing.T) {
 			ResourceVersion: "12345",
 		},
 		Status: configv1.InfrastructureStatus{
-			InfrastructureTopology: configv1.SingleReplicaTopologyMode,
+			ControlPlaneTopology: configv1.SingleReplicaTopologyMode,
 		},
 	}
 

--- a/pkg/console/subresource/deployment/deployment_test.go
+++ b/pkg/console/subresource/deployment/deployment_test.go
@@ -166,9 +166,12 @@ func TestDefaultDeployment(t *testing.T) {
 		},
 	}
 
-	infrastructureConfigHighlyAvailable := infrastructureConfigWithTopology(configv1.HighlyAvailableTopologyMode)
-	infrastructureConfigSingleReplica := infrastructureConfigWithTopology(configv1.SingleReplicaTopologyMode)
-	infrastructureConfigExternalTopologyMode := infrastructureConfigWithTopology(configv1.ExternalTopologyMode)
+	infrastructureConfigHighlyAvailable := infrastructureConfigWithTopology(configv1.HighlyAvailableTopologyMode,
+		configv1.HighlyAvailableTopologyMode)
+	infrastructureConfigSingleReplica := infrastructureConfigWithTopology(configv1.SingleReplicaTopologyMode,
+		configv1.SingleReplicaTopologyMode)
+	infrastructureConfigExternalTopologyMode := infrastructureConfigWithTopology(configv1.ExternalTopologyMode,
+		configv1.HighlyAvailableTopologyMode)
 	consoleDeploymentTemplate := resourceread.ReadDeploymentV1OrDie(bindata.MustAsset("assets/deployments/console-deployment.yaml"))
 	withConsoleContainerImage(consoleDeploymentTemplate, consoleOperatorConfig, proxyConfig)
 	withConsoleVolumes(consoleDeploymentTemplate, &corev1.ConfigMap{
@@ -670,8 +673,14 @@ func TestWithReplicas(t *testing.T) {
 		infrastructureConfig *configv1.Infrastructure
 	}
 
-	infrastructureConfigHighlyAvailable := infrastructureConfigWithTopology(configv1.HighlyAvailableTopologyMode)
-	infrastructureConfigSingleReplica := infrastructureConfigWithTopology(configv1.SingleReplicaTopologyMode)
+	infrastructureConfigHighlyAvailable := infrastructureConfigWithTopology(configv1.HighlyAvailableTopologyMode,
+		configv1.HighlyAvailableTopologyMode)
+	infrastructureConfigSingleReplica := infrastructureConfigWithTopology(configv1.SingleReplicaTopologyMode,
+		configv1.SingleReplicaTopologyMode)
+	infrastructureConfigExternalCPSingleReplica := infrastructureConfigWithTopology(configv1.ExternalTopologyMode,
+		configv1.SingleReplicaTopologyMode)
+	infrastructureConfigExternalCPHighlyAvailable := infrastructureConfigWithTopology(configv1.ExternalTopologyMode,
+		configv1.HighlyAvailableTopologyMode)
 
 	tests := []struct {
 		name string
@@ -706,6 +715,34 @@ func TestWithReplicas(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "Test External CP with Single Replica workers",
+			args: args{
+				deployment: &appsv1.Deployment{
+					Spec: appsv1.DeploymentSpec{},
+				},
+				infrastructureConfig: infrastructureConfigExternalCPSingleReplica,
+			},
+			want: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Replicas: &singleNodeReplicaCount,
+				},
+			},
+		},
+		{
+			name: "Test External CP with Highly Available workers",
+			args: args{
+				deployment: &appsv1.Deployment{
+					Spec: appsv1.DeploymentSpec{},
+				},
+				infrastructureConfig: infrastructureConfigExternalCPHighlyAvailable,
+			},
+			want: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Replicas: &defaultReplicaCount,
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -724,8 +761,12 @@ func TestWithAffinity(t *testing.T) {
 		component            string
 	}
 
-	infrastructureConfigHighlyAvailable := infrastructureConfigWithTopology(configv1.HighlyAvailableTopologyMode)
-	infrastructureConfigSingleReplica := infrastructureConfigWithTopology(configv1.SingleReplicaTopologyMode)
+	infrastructureConfigHighlyAvailable := infrastructureConfigWithTopology(configv1.HighlyAvailableTopologyMode, configv1.HighlyAvailableTopologyMode)
+	infrastructureConfigSingleReplica := infrastructureConfigWithTopology(configv1.SingleReplicaTopologyMode, configv1.SingleReplicaTopologyMode)
+	infrastructureConfigExternalCPSingleReplica := infrastructureConfigWithTopology(configv1.ExternalTopologyMode,
+		configv1.SingleReplicaTopologyMode)
+	infrastructureConfigExternalCPHighlyAvailable := infrastructureConfigWithTopology(configv1.ExternalTopologyMode,
+		configv1.HighlyAvailableTopologyMode)
 
 	tests := []struct {
 		name string
@@ -758,6 +799,59 @@ func TestWithAffinity(t *testing.T) {
 					Spec: appsv1.DeploymentSpec{},
 				},
 				infrastructureConfig: infrastructureConfigHighlyAvailable,
+				component:            "foobar",
+			},
+			want: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Affinity: &corev1.Affinity{
+								PodAntiAffinity: &corev1.PodAntiAffinity{
+									RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{{
+										LabelSelector: &metav1.LabelSelector{
+											MatchExpressions: []metav1.LabelSelectorRequirement{
+												{
+													Key:      "component",
+													Operator: metav1.LabelSelectorOpIn,
+													Values:   []string{"foobar"},
+												},
+											},
+										},
+										TopologyKey: "kubernetes.io/hostname",
+									}},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Test Single Replica Affinity in externalized control plane with Single Replica workers",
+			args: args{
+				deployment: &appsv1.Deployment{
+					Spec: appsv1.DeploymentSpec{},
+				},
+				infrastructureConfig: infrastructureConfigExternalCPSingleReplica,
+				component:            "ui",
+			},
+			want: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Affinity: &corev1.Affinity{},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Test Highly Available Affinity in externalized control plane with Highly Available workers",
+			args: args{
+				deployment: &appsv1.Deployment{
+					Spec: appsv1.DeploymentSpec{},
+				},
+				infrastructureConfig: infrastructureConfigExternalCPHighlyAvailable,
 				component:            "foobar",
 			},
 			want: &appsv1.Deployment{
@@ -1182,8 +1276,10 @@ func TestWithStrategy(t *testing.T) {
 		infrastructureConfig *configv1.Infrastructure
 	}
 
-	infrastructureConfigHighlyAvailable := infrastructureConfigWithTopology(configv1.HighlyAvailableTopologyMode)
-	infrastructureConfigSingleReplica := infrastructureConfigWithTopology(configv1.SingleReplicaTopologyMode)
+	infrastructureConfigHighlyAvailable := infrastructureConfigWithTopology(configv1.HighlyAvailableTopologyMode, configv1.HighlyAvailableTopologyMode)
+	infrastructureConfigSingleReplica := infrastructureConfigWithTopology(configv1.SingleReplicaTopologyMode, configv1.SingleReplicaTopologyMode)
+	infrastructureConfigExternalTopologyHighlyAvailable := infrastructureConfigWithTopology(configv1.ExternalTopologyMode, configv1.HighlyAvailableTopologyMode)
+	infrastructureConfigExternalTopologySingleReplica := infrastructureConfigWithTopology(configv1.ExternalTopologyMode, configv1.SingleReplicaTopologyMode)
 
 	singleReplicaStrategy := appsv1.RollingUpdateDeployment{}
 	highAvailStrategy := appsv1.RollingUpdateDeployment{
@@ -1228,6 +1324,34 @@ func TestWithStrategy(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "Test Single Replica Strategy in externalized control plane with Single Replica workers",
+			args: args{
+				deployment:           &appsv1.Deployment{},
+				infrastructureConfig: infrastructureConfigExternalTopologySingleReplica,
+			},
+			want: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Strategy: appsv1.DeploymentStrategy{
+						RollingUpdate: &singleReplicaStrategy,
+					},
+				},
+			},
+		},
+		{
+			name: "Test Highly Available Strategy in externalized control plane with Highly Available workers",
+			args: args{
+				deployment:           &appsv1.Deployment{},
+				infrastructureConfig: infrastructureConfigExternalTopologyHighlyAvailable,
+			},
+			want: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Strategy: appsv1.DeploymentStrategy{
+						RollingUpdate: &highAvailStrategy,
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -1245,9 +1369,10 @@ func TestWithConsoleNodeSelector(t *testing.T) {
 		infrastructureConfig *configv1.Infrastructure
 	}
 
-	infrastructureConfigSingleReplica := infrastructureConfigWithTopology(configv1.SingleReplicaTopologyMode)
-	infrastructureConfigExternalTopology := infrastructureConfigSingleReplica
-	infrastructureConfigExternalTopology.Status.ControlPlaneTopology = configv1.ExternalTopologyMode
+	infrastructureConfigSingleReplica := infrastructureConfigWithTopology(configv1.SingleReplicaTopologyMode,
+		configv1.SingleReplicaTopologyMode)
+	infrastructureConfigExternalTopology := infrastructureConfigWithTopology(configv1.ExternalTopologyMode,
+		configv1.SingleReplicaTopologyMode)
 	defaultDeployment := appsv1.Deployment{
 		Spec: appsv1.DeploymentSpec{
 			Template: corev1.PodTemplateSpec{
@@ -1344,8 +1469,10 @@ func TestDefaultDownloadsDeployment(t *testing.T) {
 		Finalizers:                 nil,
 	}
 
-	infrastructureConfigHighlyAvailable := infrastructureConfigWithTopology(configv1.HighlyAvailableTopologyMode)
-	infrastructureConfigSingleReplica := infrastructureConfigWithTopology(configv1.SingleReplicaTopologyMode)
+	infrastructureConfigHighlyAvailable := infrastructureConfigWithTopology(configv1.HighlyAvailableTopologyMode,
+		configv1.HighlyAvailableTopologyMode)
+	infrastructureConfigSingleReplica := infrastructureConfigWithTopology(configv1.SingleReplicaTopologyMode,
+		configv1.SingleReplicaTopologyMode)
 
 	downloadsDeploymentPodSpecSingleReplica := corev1.PodSpec{
 		NodeSelector: map[string]string{
@@ -1791,13 +1918,13 @@ func TestIsAvailableAndUpdated(t *testing.T) {
 
 }
 
-func infrastructureConfigWithTopology(topologyMode configv1.TopologyMode) *configv1.Infrastructure {
+func infrastructureConfigWithTopology(controlPlaneTopologyMode, infrastructureTopologyMode configv1.TopologyMode) *configv1.Infrastructure {
 	return &configv1.Infrastructure{
 		TypeMeta:   metav1.TypeMeta{},
 		ObjectMeta: metav1.ObjectMeta{},
 		Status: configv1.InfrastructureStatus{
-			InfrastructureTopology: topologyMode,
-			ControlPlaneTopology:   topologyMode,
+			InfrastructureTopology: infrastructureTopologyMode,
+			ControlPlaneTopology:   controlPlaneTopologyMode,
 		},
 	}
 }

--- a/test/e2e/deployment_replicas_test.go
+++ b/test/e2e/deployment_replicas_test.go
@@ -7,7 +7,6 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 
-	configv1 "github.com/openshift/api/config/v1"
 	operatorsv1 "github.com/openshift/api/operator/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -34,10 +33,10 @@ func TestDeploymentsReplicas(t *testing.T) {
 	}
 
 	var expectedReplicas int32
-	if infrastructureConfig.Status.ControlPlaneTopology == configv1.SingleReplicaTopologyMode {
-		expectedReplicas = int32(deploymentsub.SingleNodeConsoleReplicas)
-	} else {
+	if deploymentsub.ShouldDeployHA(infrastructureConfig) {
 		expectedReplicas = int32(deploymentsub.DefaultConsoleReplicas)
+	} else {
+		expectedReplicas = int32(deploymentsub.SingleNodeConsoleReplicas)
 	}
 
 	consoleDeployment, err := framework.GetConsoleDeployment(client)

--- a/test/e2e/deployment_replicas_test.go
+++ b/test/e2e/deployment_replicas_test.go
@@ -34,7 +34,7 @@ func TestDeploymentsReplicas(t *testing.T) {
 	}
 
 	var expectedReplicas int32
-	if infrastructureConfig.Status.InfrastructureTopology == configv1.SingleReplicaTopologyMode {
+	if infrastructureConfig.Status.ControlPlaneTopology == configv1.SingleReplicaTopologyMode {
 		expectedReplicas = int32(deploymentsub.SingleNodeConsoleReplicas)
 	} else {
 		expectedReplicas = int32(deploymentsub.DefaultConsoleReplicas)


### PR DESCRIPTION
Manual backport of https://github.com/openshift/console-operator/pull/841