### PR TITLE
OCPBUGS-33787: Tolerate the absence of ingress capability on HyperShift clusters

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ docker build -t <registry>/<your-username>/console-operator:<version> .
 # following: docker.io/openshift/origin-console-operator:latest
 # for development, you are going to push to an alternate registry.
 # specifically it can look something like this:
-docker build -t quay.io/benjaminapetersen/console-operator:latest .
+docker build -f Dockerfile.rhel7 -t quay.io/benjaminapetersen/console-operator:latest .
 ```
 You can optionally build a specific version.
 

--- a/bindata/assets/services/console-nodeport-service.yaml
+++ b/bindata/assets/services/console-nodeport-service.yaml
@@ -1,0 +1,20 @@
+# This 'console' service manifest is used when the ingress cluster capability is disabled.
+# Service will be exposed using a NodePort to enable the alternative ingress.
+apiVersion: v1
+kind: Service
+metadata:
+  name: console
+  namespace: openshift-console
+  labels:
+    app: console
+spec:
+  ports:
+    - name: https
+      protocol: TCP
+      port: 443
+      targetPort: 8443
+  selector:
+    app: console
+    component: ui
+  type: NodePort
+  sessionAffinity: None

--- a/bindata/assets/services/downloads-nodeport-service.yaml
+++ b/bindata/assets/services/downloads-nodeport-service.yaml
@@ -1,0 +1,18 @@
+# This 'downloads' service manifest is used when the ingress cluster capability is disabled.
+# Service will be exposed using a NodePort to enable the alternative ingress.
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: openshift-console
+  name: downloads
+spec:
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: console
+    component: downloads
+  type: NodePort
+  sessionAffinity: None

--- a/docs/alb-ingress-rosa-hcp.md
+++ b/docs/alb-ingress-rosa-hcp.md
@@ -1,0 +1,115 @@
+# Use AWS ALB as alternative ingress on ROSA HCP
+
+This doc aims at showing the effort needed to expose the OpenShift console via AWS ALB on a ROSA HCP cluster.
+The use case in mind is [HyperShift hosted clusters where the Ingress capability is disabled](https://github.com/openshift/enhancements/pull/1415).
+
+## Requirements
+
+- ROSA HCP OpenShift cluster.
+- [AWS Load Balancer Operator installed and its controller created](https://docs.openshift.com/rosa/networking/aws-load-balancer-operator.html).
+- User logged as a cluster admin.
+
+## Procedure
+
+### Create certificate in AWS Certificate Manager
+
+In order to configure an HTTPS listener on AWS ALB you need to have a certificate created in AWS Certificate Manager.
+You can import an existing certificate or request a new one. Make sure the certificate is created in the same region as your cluster.
+Note the certificate ARN, you will need it later.
+
+### Create Ingress resources for the NodePort services
+
+To provision ALBs create the following resources:
+```bash
+cat <<EOF | oc apply -f -
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/target-type: instance
+    alb.ingress.kubernetes.io/backend-protocol: HTTPS
+    alb.ingress.kubernetes.io/certificate-arn: ${CERTIFICATE_ARN}
+  name: console
+  namespace: openshift-console
+spec:
+  ingressClassName: alb
+  rules:
+    - http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: console
+                port:
+                  number: 443
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/target-type: instance
+    alb.ingress.kubernetes.io/backend-protocol: HTTP
+    alb.ingress.kubernetes.io/certificate-arn: ${CERTIFICATE_ARN}
+  name: downloads
+  namespace: openshift-console
+spec:
+  ingressClassName: alb
+  rules:
+    - http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: downloads
+                port:
+                  number: 80
+EOF
+```
+
+### Update console config
+
+Once the console ALBs are ready you need to let the console operator know which urls to use.
+Update the console operator config providing the custom urls:
+```bash
+$ CONSOLE_ALB_HOST=$(oc -n openshift-console get ing console -o yaml | yq .status.loadBalancer.ingress[0].hostname)
+$ DOWNLOADS_ALB_HOST=$(oc -n openshift-console get ing downloads -o yaml | yq .status.loadBalancer.ingress[0].hostname)
+$ oc patch console.operator.openshift.io cluster --type=merge -p "{\"spec\":{\"ingress\":{\"consoleURL\":\"https://${CONSOLE_ALB_HOST}\",\"clientDownloadsURL\":\"https://${DOWNLOADS_ALB_HOST}\"}}}"
+```
+
+## Notes
+
+1. ROSA HCP does not have the authentication operator, the authentication server is managed centrally by the HyperShift layer:
+```bash
+$ oc -n openshift-authentication-operator get deploy,route
+No resources found
+
+$ oc -n openshift-authentication get pods,routes
+No resources found
+
+$ oc get oauthclient | grep -v console
+NAME                           SECRET                                        WWW-CHALLENGE   TOKEN-MAX-AGE   REDIRECT URIS
+openshift-browser-client                                                     false           default         https://oauth.mytestcluster.5199.s3.devshift.org:443/oauth/token/display
+openshift-challenging-client                                                 true            default         https://oauth.mytestcluster.5199.s3.devshift.org:443/oauth/token/implicit
+
+$ oc -n openshift-console rsh deploy/console curl -k https://openshift.default.svc/.well-known/oauth-authorization-server
+{
+"issuer": "https://oauth.mytestcluster.5199.s3.devshift.org:443",
+"authorization_endpoint": "https://oauth.mytestcluster.5199.s3.devshift.org:443/oauth/authorize",
+"token_endpoint": "https://oauth.mytestcluster.5199.s3.devshift.org:443/oauth/token",
+```
+
+2. When the ingress capability is disabled, the console operator relies on the end user to provide the console and download URLs (using the operator API) for health checks and oauthclient.
+
+3. When the ingress capability is disabled, the console operator skips the implementation of the component route customization.
+
+4. To simulate the absence of ingress connectivity when the ingress capability is disabled, set the desired replicas to zero in the default ingress controller:
+```bash
+$ oc -n openshift-ingress-operator patch ingresscontroller default --type='json' -p='[{"op": "replace", "path": "/spec/replicas", "value":0}]'
+```
+
+## Links
+- [Demo of ALB ingress for the console on ROSA HCP](https://drive.google.com/file/d/1uWZgFbSeZTlDzlFyPW7QcH-625JsbSbw/view)

--- a/pkg/console/controllers/util/util.go
+++ b/pkg/console/controllers/util/util.go
@@ -1,8 +1,6 @@
 package util
 
 import (
-	//k8s
-
 	"context"
 	"fmt"
 
@@ -11,7 +9,9 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 
+	configv1 "github.com/openshift/api/config/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
+
 	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 )
@@ -83,4 +83,18 @@ func HandleManagementState(ctx context.Context, c consoleOperatorController, ope
 	default:
 		return fmt.Errorf("console is in an unknown state: %v", managementState)
 	}
+}
+
+// IsExternalControlPlaneWithIngressDisabled returns true if the cluster is in external control plane topology (hypershift)
+// and the ingress cluster capability is disabled.
+func IsExternalControlPlaneWithIngressDisabled(infrastructureConfig *configv1.Infrastructure, clusterVersionConfig *configv1.ClusterVersion) bool {
+	isIngressCapabilityEnabled := false
+	for _, capability := range clusterVersionConfig.Status.Capabilities.EnabledCapabilities {
+		if capability == configv1.ClusterVersionCapabilityIngress {
+			isIngressCapabilityEnabled = true
+			break
+		}
+	}
+
+	return infrastructureConfig.Status.ControlPlaneTopology == configv1.ExternalTopologyMode && !isIngressCapabilityEnabled
 }

--- a/pkg/console/subresource/configmap/configmap_test.go
+++ b/pkg/console/subresource/configmap/configmap_test.go
@@ -1069,6 +1069,7 @@ providers: {}
 				tt.args.nodeOperatingSystems,
 				tt.args.copiedCSVsDisabled,
 				tt.args.telemetryConfig,
+				tt.args.rt.Spec.Host,
 			)
 
 			// marshall the exampleYaml to map[string]interface{} so we can use it in diff below


### PR DESCRIPTION
Part of the implementation of [Make Ingress optional for HyperShift EP](https://github.com/openshift/enhancements/pull/1415). Note that this change targets only HyperShift managed deployments and should not impact standalone OpenShift installations.

This PR:
- Implements [alternative ingress fields](https://github.com/openshift/api/pull/1887) from the console operator config API
- Skips component route customizations if ingress capability is disabled
- Uses NodePort type for console and downloads services if ingress capability is disabled
- Adds document to describe how to implement alternative ingress on ROSA