### PR TITLE
[WIP]CONSOLE-3340: Rewriting the downloads server into golang

### DIFF
--- a/bindata/assets/deployments/console-deployment.yaml
+++ b/bindata/assets/deployments/console-deployment.yaml
@@ -22,6 +22,9 @@ spec:
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
         openshift.io/required-scc: restricted-v2
+    volumes:
+      - name: shared-data
+        emptyDir: {}
     spec:
       nodeSelector:
         node-role.kubernetes.io/master: ""
@@ -111,6 +114,9 @@ spec:
             - name: http
               containerPort: 8080
               protocol: TCP
+          volumeMounts:
+            - name: shared-data
+              mountPath: /tmp
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
           image: ${IMAGE}

--- a/bindata/assets/deployments/console-deployment.yaml
+++ b/bindata/assets/deployments/console-deployment.yaml
@@ -34,6 +34,22 @@ spec:
           type: RuntimeDefault
       terminationGracePeriodSeconds: 40
       priorityClassName: system-cluster-critical
+      initContainers:
+        - name: downloadsImageSidecar
+          securityContext:
+            readOnlyRootFilesystem: false
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+          image: ${DOWNLOADS_IMAGE}
+          ports:
+            - containerPort: 8081
+              protocol: TCP
+          command: ['sh', '-c', 'echo The sidecar is running! && touch "/tmp/file.txt" && echo "Hello from the shared Sidecar Content" > /tmp/file.txt ']
+          volumeMounts:
+            - name: shared-data
+              mountPath: /tmp
       containers:
         - resources:
             requests:
@@ -57,6 +73,7 @@ spec:
             - "--public-dir=/opt/bridge/static"
             - "--config=/var/console-config/console-config.yaml"
             - "--service-ca-file=/var/service-ca/service-ca.crt"
+            - "--downloads-server"
           startupProbe:
             httpGet:
               path: /health
@@ -90,6 +107,9 @@ spec:
           ports:
             - name: https
               containerPort: 8443
+              protocol: TCP
+            - name: http
+              containerPort: 8080
               protocol: TCP
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError

--- a/bindata/assets/services/downloads-service.yaml
+++ b/bindata/assets/services/downloads-service.yaml
@@ -13,6 +13,6 @@ spec:
     targetPort: 8080
   selector:
     app: console
-    component: downloads
+    component: ui
   type: ClusterIP
   sessionAffinity: None


### PR DESCRIPTION
Adding the sidecar container to the console pod, that shares oc executables from cli-artifacts image to console container. The console will serve this executables in a goroutine on port 8080 instead of the standalone Downloads server. Rerouting the downloads service to point itself to console container.