### PR TITLE
OKD-214: Dockerfile: Add ARG TAGS=ocp

### DIFF
--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -1,8 +1,9 @@
 FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.16 AS builder
+ARG TAGS=ocp
 WORKDIR /go/src/github.com/openshift/console-operator
 COPY . .
 ENV GO_PACKAGE github.com/openshift/console-operator
-RUN go build -ldflags "-X $GO_PACKAGE/pkg/version.versionFromGit=$(git describe --long --tags --abbrev=7 --match 'v[0-9]*')" -tags="ocp" -o console ./cmd/console
+RUN go build -ldflags "-X $GO_PACKAGE/pkg/version.versionFromGit=$(git describe --long --tags --abbrev=7 --match 'v[0-9]*')" -tags="${TAGS}" -o console ./cmd/console
 
 FROM registry.ci.openshift.org/ocp/4.16:base-rhel9
 RUN useradd console-operator


### PR DESCRIPTION
Allow this ARG to be overriden by builds so that OKD builds may have the correct branding by default without requiring an additional configmap.

OKD/SCOS builds pass the build-arg `TAGS=scos`, so `pkg/console/subresource/configmap/brand_okd.go` which has `//go:build !ocp` will be built instead of `pkg/console/subresource/configmap/brand_ocp.go` which has `//go:build ocp`.

This change should not affect the OCP build of the console-operator image.

This change will allow OKD to drop the branding image from the payload: https://github.com/openshift/origin-branding/