### PR TITLE
TRT-1664: Revert #895 "CONSOLE-4047: Console-operator should be internally using listers for fetching data"

### DIFF
--- a/pkg/console/controllers/healthcheck/controller.go
+++ b/pkg/console/controllers/healthcheck/controller.go
@@ -10,8 +10,9 @@ import (
 
 	// k8s
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	coreinformersv1 "k8s.io/client-go/informers/core/v1"
-	corev1listers "k8s.io/client-go/listers/core/v1"
+	coreclientv1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
 
@@ -21,11 +22,10 @@ import (
 	routev1 "github.com/openshift/api/route/v1"
 	configclientv1 "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
 	configinformer "github.com/openshift/client-go/config/informers/externalversions"
-	configlistersv1 "github.com/openshift/client-go/config/listers/config/v1"
 	v1 "github.com/openshift/client-go/operator/informers/externalversions/operator/v1"
 	operatorv1listers "github.com/openshift/client-go/operator/listers/operator/v1"
+	routeclientv1 "github.com/openshift/client-go/route/clientset/versioned/typed/route/v1"
 	routesinformersv1 "github.com/openshift/client-go/route/informers/externalversions/route/v1"
-	routev1listers "github.com/openshift/client-go/route/listers/route/v1"
 	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
@@ -40,12 +40,12 @@ import (
 
 type HealthCheckController struct {
 	// clients
-	operatorClient             v1helpers.OperatorClient
-	infrastructureConfigLister configlistersv1.InfrastructureLister
-	configMapLister            corev1listers.ConfigMapLister
-	routeLister                routev1listers.RouteLister
-	ingressConfigLister        configlistersv1.IngressLister
-	operatorConfigLister       operatorv1listers.ConsoleLister
+	operatorClient       v1helpers.OperatorClient
+	operatorConfigLister operatorv1listers.ConsoleLister
+	infrastructureClient configclientv1.InfrastructureInterface
+	ingressClient        configclientv1.IngressInterface
+	routeClient          routeclientv1.RoutesGetter
+	configMapClient      coreclientv1.ConfigMapsGetter
 }
 
 func NewHealthCheckController(
@@ -53,6 +53,8 @@ func NewHealthCheckController(
 	configClient configclientv1.ConfigV1Interface,
 	// clients
 	operatorClient v1helpers.OperatorClient,
+	routev1Client routeclientv1.RoutesGetter,
+	configMapClient coreclientv1.ConfigMapsGetter,
 	// informers
 	operatorConfigInformer v1.ConsoleInformer,
 	configInformer configinformer.SharedInformerFactory,
@@ -62,12 +64,12 @@ func NewHealthCheckController(
 	recorder events.Recorder,
 ) factory.Controller {
 	ctrl := &HealthCheckController{
-		operatorClient:             operatorClient,
-		operatorConfigLister:       operatorConfigInformer.Lister(),
-		infrastructureConfigLister: configInformer.Config().V1().Infrastructures().Lister(),
-		ingressConfigLister:        configInformer.Config().V1().Ingresses().Lister(),
-		routeLister:                routeInformer.Lister(),
-		configMapLister:            coreInformer.ConfigMaps().Lister(),
+		operatorClient:       operatorClient,
+		operatorConfigLister: operatorConfigInformer.Lister(),
+		infrastructureClient: configClient.Infrastructures(),
+		ingressClient:        configClient.Ingresses(),
+		routeClient:          routev1Client,
+		configMapClient:      configMapClient,
 	}
 
 	configMapInformer := coreInformer.ConfigMaps()
@@ -111,12 +113,12 @@ func (c *HealthCheckController) Sync(ctx context.Context, controllerContext fact
 	default:
 		return fmt.Errorf("unknown state: %v", updatedOperatorConfig.Spec.ManagementState)
 	}
-	ingressConfig, err := c.ingressConfigLister.Get(api.ConfigResourceName)
+	ingressConfig, err := c.ingressClient.Get(ctx, api.ConfigResourceName, metav1.GetOptions{})
 	if err != nil {
 		klog.Errorf("ingress config error: %v", err)
 		return statusHandler.FlushAndReturn(err)
 	}
-	infrastructureConfig, err := c.infrastructureConfigLister.Get(api.ConfigResourceName)
+	infrastructureConfig, err := c.infrastructureClient.Get(ctx, api.ConfigResourceName, metav1.GetOptions{})
 	if err != nil {
 		klog.Errorf("infrastructure config error: %v", err)
 		return statusHandler.FlushAndReturn(err)
@@ -134,7 +136,7 @@ func (c *HealthCheckController) Sync(ctx context.Context, controllerContext fact
 		activeRouteName = api.OpenshiftConsoleCustomRouteName
 	}
 
-	activeRoute, activeRouteErr := c.routeLister.Routes(api.OpenShiftConsoleNamespace).Get(activeRouteName)
+	activeRoute, activeRouteErr := c.routeClient.Routes(api.OpenShiftConsoleNamespace).Get(ctx, activeRouteName, metav1.GetOptions{})
 	statusHandler.AddConditions(status.HandleProgressingOrDegraded("RouteHealth", "FailedRouteGet", activeRouteErr))
 	if activeRouteErr != nil {
 		statusHandler.FlushAndReturn(activeRouteErr)
@@ -199,7 +201,7 @@ func (c *HealthCheckController) getCA(ctx context.Context, tls *routev1.TLSConfi
 	}
 
 	for _, cmName := range []string{api.TrustedCAConfigMapName, api.DefaultIngressCertConfigMapName} {
-		cm, err := c.configMapLister.ConfigMaps(api.OpenShiftConsoleNamespace).Get(cmName)
+		cm, err := c.configMapClient.ConfigMaps(api.OpenShiftConsoleNamespace).Get(ctx, cmName, metav1.GetOptions{})
 		if err != nil {
 			klog.V(4).Infof("failed to GET configmap %s / %s ", api.OpenShiftConsoleNamespace, cmName)
 			return nil, err

--- a/pkg/console/controllers/upgradenotification/controller.go
+++ b/pkg/console/controllers/upgradenotification/controller.go
@@ -12,6 +12,7 @@ import (
 	v1 "github.com/openshift/api/config/v1"
 	consolev1 "github.com/openshift/api/console/v1"
 	operatorsv1 "github.com/openshift/api/operator/v1"
+	configclientv1 "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
 	configinformer "github.com/openshift/client-go/config/informers/externalversions"
 	configlistersv1 "github.com/openshift/client-go/config/listers/config/v1"
 	consoleclientv1 "github.com/openshift/client-go/console/clientset/versioned/typed/console/v1"
@@ -42,6 +43,7 @@ type UpgradeNotificationController struct {
 // informers to start them up, clients to pass
 func NewUpgradeNotificationController(
 	// top level config
+	configClient configclientv1.ConfigV1Interface,
 	configInformer configinformer.SharedInformerFactory,
 	// clients
 	operatorClient v1helpers.OperatorClient,

--- a/pkg/console/operator/operator.go
+++ b/pkg/console/operator/operator.go
@@ -75,7 +75,8 @@ type consoleOperator struct {
 	configMapClient          coreclientv1.ConfigMapsGetter
 	targetNSConfigMapLister  corev1listers.ConfigMapLister // for openshift-console namespace
 	managedNSConfigMapLister corev1listers.ConfigMapLister // for openshift-config-managed namespace
-	nodeLister               corev1listers.NodeLister
+	serviceClient            coreclientv1.ServicesGetter
+	nodeClient               coreclientv1.NodesGetter
 	deploymentClient         appsclientv1.DeploymentsGetter
 	// openshift
 	operatorNSConfigMapLister corev1listers.ConfigMapLister //for openshift-console-operator namespace
@@ -117,6 +118,7 @@ func NewConsoleOperator(
 	// oauth API
 	oauthClientSwitchedInformer *util.InformerWithSwitch,
 	// routes
+	routev1Client routeclientv1.RoutesGetter,
 	routeInformer routesinformersv1.RouteInformer,
 	// plugins
 	consolePluginInformer consoleinformersv1.ConsolePluginInformer,
@@ -167,11 +169,13 @@ func NewConsoleOperator(
 		configNSConfigMapLister:   configNSConfigMapInformer.Lister(),
 		managedNSConfigMapLister:  managedNSConfigMapInformer.Lister(),
 
-		nodeLister:       nodeInformer.Lister(),
+		serviceClient:    corev1Client,
+		nodeClient:       corev1Client,
 		deploymentClient: deploymentClient,
 		dynamicClient:    dynamicClient,
 		// openshift
 		oauthClientLister: oauthClientSwitchedInformer.Lister(),
+		routeClient:       routev1Client,
 		routeLister:       routeInformer.Lister(),
 		versionGetter:     versionGetter,
 		// plugins

--- a/pkg/console/operator/sync_v400_test.go
+++ b/pkg/console/operator/sync_v400_test.go
@@ -12,28 +12,30 @@ import (
 func TestGetNodeComputeEnvironments(t *testing.T) {
 	tests := []struct {
 		name                     string
-		nodeList                 []*v1.Node
+		nodeList                 *v1.NodeList
 		expectedArchitectures    []string
 		expectedOperatingSystems []string
 	}{
 		{
 			name: "Test getNodeComputeEnvironments",
-			nodeList: []*v1.Node{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "node-1",
-						Labels: map[string]string{
-							api.NodeArchitectureLabel:    "foo",
-							api.NodeOperatingSystemLabel: "bar",
+			nodeList: &v1.NodeList{
+				Items: []v1.Node{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "node-1",
+							Labels: map[string]string{
+								api.NodeArchitectureLabel:    "foo",
+								api.NodeOperatingSystemLabel: "bar",
+							},
 						},
 					},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "node-1",
-						Labels: map[string]string{
-							api.NodeArchitectureLabel:    "baz",
-							api.NodeOperatingSystemLabel: "bat",
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "node-1",
+							Labels: map[string]string{
+								api.NodeArchitectureLabel:    "baz",
+								api.NodeOperatingSystemLabel: "bat",
+							},
 						},
 					},
 				},
@@ -43,27 +45,29 @@ func TestGetNodeComputeEnvironments(t *testing.T) {
 		},
 		{
 			name:                     "Test getNodeComputeEnvironments empty node list",
-			nodeList:                 []*v1.Node{},
+			nodeList:                 &v1.NodeList{},
 			expectedArchitectures:    []string{},
 			expectedOperatingSystems: []string{},
 		},
 		{
 			name: "Test getNodeComputeEnvironments missing arch label",
-			nodeList: []*v1.Node{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "node-1",
-						Labels: map[string]string{
-							api.NodeOperatingSystemLabel: "bar",
+			nodeList: &v1.NodeList{
+				Items: []v1.Node{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "node-1",
+							Labels: map[string]string{
+								api.NodeOperatingSystemLabel: "bar",
+							},
 						},
 					},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "node-2",
-						Labels: map[string]string{
-							api.NodeArchitectureLabel:    "baz",
-							api.NodeOperatingSystemLabel: "bat",
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "node-2",
+							Labels: map[string]string{
+								api.NodeArchitectureLabel:    "baz",
+								api.NodeOperatingSystemLabel: "bat",
+							},
 						},
 					},
 				},
@@ -73,22 +77,24 @@ func TestGetNodeComputeEnvironments(t *testing.T) {
 		},
 		{
 			name: "Test getNodeComputeEnvironments empty arch label",
-			nodeList: []*v1.Node{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "node-1",
-						Labels: map[string]string{
-							api.NodeArchitectureLabel:    "",
-							api.NodeOperatingSystemLabel: "bar",
+			nodeList: &v1.NodeList{
+				Items: []v1.Node{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "node-1",
+							Labels: map[string]string{
+								api.NodeArchitectureLabel:    "",
+								api.NodeOperatingSystemLabel: "bar",
+							},
 						},
 					},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "node-2",
-						Labels: map[string]string{
-							api.NodeArchitectureLabel:    "baz",
-							api.NodeOperatingSystemLabel: "bat",
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "node-2",
+							Labels: map[string]string{
+								api.NodeArchitectureLabel:    "baz",
+								api.NodeOperatingSystemLabel: "bat",
+							},
 						},
 					},
 				},
@@ -98,22 +104,24 @@ func TestGetNodeComputeEnvironments(t *testing.T) {
 		},
 		{
 			name: "Test getNodeComputeEnvironments duplicate arch label",
-			nodeList: []*v1.Node{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "node-1",
-						Labels: map[string]string{
-							api.NodeArchitectureLabel:    "baz",
-							api.NodeOperatingSystemLabel: "bar",
+			nodeList: &v1.NodeList{
+				Items: []v1.Node{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "node-1",
+							Labels: map[string]string{
+								api.NodeArchitectureLabel:    "baz",
+								api.NodeOperatingSystemLabel: "bar",
+							},
 						},
 					},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "node-2",
-						Labels: map[string]string{
-							api.NodeArchitectureLabel:    "baz",
-							api.NodeOperatingSystemLabel: "bat",
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "node-2",
+							Labels: map[string]string{
+								api.NodeArchitectureLabel:    "baz",
+								api.NodeOperatingSystemLabel: "bat",
+							},
 						},
 					},
 				},
@@ -123,21 +131,23 @@ func TestGetNodeComputeEnvironments(t *testing.T) {
 		},
 		{
 			name: "Test getNodeComputeEnvironments missing OS label",
-			nodeList: []*v1.Node{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "node-1",
-						Labels: map[string]string{
-							api.NodeArchitectureLabel: "foo",
+			nodeList: &v1.NodeList{
+				Items: []v1.Node{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "node-1",
+							Labels: map[string]string{
+								api.NodeArchitectureLabel: "foo",
+							},
 						},
 					},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "node-2",
-						Labels: map[string]string{
-							api.NodeArchitectureLabel:    "baz",
-							api.NodeOperatingSystemLabel: "bat",
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "node-2",
+							Labels: map[string]string{
+								api.NodeArchitectureLabel:    "baz",
+								api.NodeOperatingSystemLabel: "bat",
+							},
 						},
 					},
 				},
@@ -147,22 +157,24 @@ func TestGetNodeComputeEnvironments(t *testing.T) {
 		},
 		{
 			name: "Test getNodeComputeEnvironments empty OS label",
-			nodeList: []*v1.Node{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "node-1",
-						Labels: map[string]string{
-							api.NodeArchitectureLabel:    "foo",
-							api.NodeOperatingSystemLabel: "",
+			nodeList: &v1.NodeList{
+				Items: []v1.Node{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "node-1",
+							Labels: map[string]string{
+								api.NodeArchitectureLabel:    "foo",
+								api.NodeOperatingSystemLabel: "",
+							},
 						},
 					},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "node-2",
-						Labels: map[string]string{
-							api.NodeArchitectureLabel:    "baz",
-							api.NodeOperatingSystemLabel: "bat",
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "node-2",
+							Labels: map[string]string{
+								api.NodeArchitectureLabel:    "baz",
+								api.NodeOperatingSystemLabel: "bat",
+							},
 						},
 					},
 				},
@@ -172,22 +184,24 @@ func TestGetNodeComputeEnvironments(t *testing.T) {
 		},
 		{
 			name: "Test getNodeComputeEnvironments duplicate OS label",
-			nodeList: []*v1.Node{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "node-1",
-						Labels: map[string]string{
-							api.NodeArchitectureLabel:    "foo",
-							api.NodeOperatingSystemLabel: "bat",
+			nodeList: &v1.NodeList{
+				Items: []v1.Node{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "node-1",
+							Labels: map[string]string{
+								api.NodeArchitectureLabel:    "foo",
+								api.NodeOperatingSystemLabel: "bat",
+							},
 						},
 					},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "node-2",
-						Labels: map[string]string{
-							api.NodeArchitectureLabel:    "baz",
-							api.NodeOperatingSystemLabel: "bat",
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "node-2",
+							Labels: map[string]string{
+								api.NodeArchitectureLabel:    "baz",
+								api.NodeOperatingSystemLabel: "bat",
+							},
 						},
 					},
 				},

--- a/pkg/console/starter/starter.go
+++ b/pkg/console/starter/starter.go
@@ -236,6 +236,7 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 		// oauth
 		oauthClientsSwitchedInformer,
 		// routes
+		routesClient.RouteV1(),
 		routesInformersNamespaced.Route().V1().Routes(), // Route
 		// plugins
 		consoleInformers.Console().V1().ConsolePlugins(),
@@ -321,6 +322,7 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 		// clients
 		operatorClient,
 		consoleClient.ConsoleV1().ConsoleCLIDownloads(),
+		routesClient.RouteV1(),
 		// informers
 		operatorConfigInformers.Operator().V1().Consoles(), // OperatorConfig
 		configInformers, // Config
@@ -365,10 +367,12 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 		// enable health check for console route
 		true,
 		// top level config
+		configClient.ConfigV1(),
 		configInformers,
 		// clients
 		operatorClient,
 		routesClient.RouteV1(),
+		kubeClient.CoreV1(),
 		// route
 		operatorConfigInformers.Operator().V1().Consoles(),
 		kubeInformersConfigNamespaced.Core().V1().Secrets(), // `openshift-config` namespace informers
@@ -382,10 +386,12 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 		// disable health check for console route
 		false,
 		// top level config
+		configClient.ConfigV1(),
 		configInformers,
 		// clients
 		operatorClient,
 		routesClient.RouteV1(),
+		kubeClient.CoreV1(),
 		// route
 		operatorConfigInformers.Operator().V1().Consoles(),
 		kubeInformersConfigNamespaced.Core().V1().Secrets(), // `openshift-config` namespace informers
@@ -399,6 +405,8 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 		configClient.ConfigV1(),
 		// clients
 		operatorClient,
+		routesClient.RouteV1(),
+		kubeClient.CoreV1(),
 		// route
 		operatorConfigInformers.Operator().V1().Consoles(),
 		configInformers,                     // Config
@@ -410,6 +418,7 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 
 	upgradeNotificationController := upgradenotification.NewUpgradeNotificationController(
 		// top level config
+		configClient.ConfigV1(),
 		configInformers,
 		// clients
 		operatorClient,


### PR DESCRIPTION

Reverts #895 ; tracked by [TRT-1664](https://issues.redhat.com//browse/TRT-1664)

Per [OpenShift policy](https://github.com/openshift/enhancements/blob/master/enhancements/release/improving-ci-signal.md#quick-revert), we are reverting this breaking change to get CI and/or nightly payloads flowing again.

Suspected of causing console operator pod panics

To unrevert this, revert this PR, and layer an additional separate commit on top that addresses the problem. Before merging the unrevert, please run these jobs on the PR and check the result of these jobs to confirm the fix has corrected the problem:

```
/payload-job periodic-ci-openshift-release-master-ci-4.16-e2e-aws-sdn-serial
```

CC: @jhadvig

<div align="right">
PR created by <a href="https://github.com/stbenjam/revertomatic">Revertomatic<sup>:tm:</sup></a>
</div>
