### PR TITLE
OCPBUGS-33715: Cache organization ID

### DIFF
--- a/pkg/console/operator/operator.go
+++ b/pkg/console/operator/operator.go
@@ -91,10 +91,16 @@ type consoleOperator struct {
 
 	resourceSyncer resourcesynccontroller.ResourceSyncer
 
-	// used to keep track of OLM capability
-	isOLMDisabled bool
+	trackables trackables
 
 	monitoringDeploymentLister appsv1listers.DeploymentLister
+}
+
+type trackables struct {
+	// used to keep track of OLM capability
+	isOLMDisabled bool
+	// track organization ID
+	organizationID string
 }
 
 func NewConsoleOperator(
@@ -207,7 +213,7 @@ func NewConsoleOperator(
 		informers = append(informers, olmConfigInformer.Informer())
 	} else {
 		klog.Info("olmconfigs resource does not exist in cluster, launching poll and disabling olmconfigs informer")
-		c.isOLMDisabled = true
+		c.trackables.isOLMDisabled = true
 		c.startPollAndRestartIfResourceEnabled(olmGroupVersionResource)
 	}
 

--- a/pkg/console/operator/sync_v400.go
+++ b/pkg/console/operator/sync_v400.go
@@ -376,7 +376,7 @@ func (co *consoleOperator) SyncConfigMap(
 		copiedCSVsDisabled bool
 		ccdErr             error
 	)
-	if !co.isOLMDisabled {
+	if !co.trackables.isOLMDisabled {
 		copiedCSVsDisabled, ccdErr = co.isCopiedCSVsDisabled(ctx)
 		if ccdErr != nil {
 			return nil, false, "FailedGetOLMConfig", ccdErr
@@ -461,12 +461,9 @@ func (co *consoleOperator) GetTelemetryConfiguration(ctx context.Context, operat
 		return nil, err
 	}
 
-	// If for any reason the getting the ORGANIZATION_ID fails,
-	// log the error and set ORGANIZATION_ID to empty string.
-	organizationID, err := telemetry.GetOrganizationID(clusterID, accessToken)
-	if err != nil {
-		klog.Errorf("telemetry config error: %s", err)
-	}
+	organizationID := telemetry.GetOrganizationID(telemetryConfig, co.trackables.organizationID, clusterID, accessToken)
+	// cache ORGANIZATION_ID
+	co.trackables.organizationID = organizationID
 	telemetryConfig["ORGANIZATION_ID"] = organizationID
 
 	return telemetryConfig, nil


### PR DESCRIPTION
Fetching ORGANIZATION_ID is too noisy on the OCM side. Lets rather cache it on main operator controller instance and use when building the console-config CM. 
The correct order for setting the ID should be:
1. custom ORGANIZATION_ID is awailable as telemetry annotation on console-operator config or in telemetry-config configmap
2. cached ORGANIZATION_ID is available on the operator controller instance

**else** fetch the ORGANIZATION_ID from OCM

/assign @TheRealJon 