### PR TITLE
OCPBUGS-33787: Add cluster wide trusted CA bundle to operator

### DIFF
--- a/manifests/06-trusted-ca-configmap.yaml
+++ b/manifests/06-trusted-ca-configmap.yaml
@@ -1,0 +1,16 @@
+# The network operator is responsible for injecting
+# the trusted ca bundle into this configmap.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  annotations:
+    capability.openshift.io/name: Console
+    include.release.openshift.io/hypershift: "true"
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/create-only: "true"
+  labels:
+    config.openshift.io/inject-trusted-cabundle: "true"
+  name: trusted-ca
+  namespace: openshift-console-operator

--- a/manifests/07-operator-ibm-cloud-managed.yaml
+++ b/manifests/07-operator-ibm-cloud-managed.yaml
@@ -72,6 +72,8 @@ spec:
           name: config
         - mountPath: /var/run/secrets/serving-cert
           name: serving-cert
+        - mountPath: /etc/pki/ca-trust/extracted/pem
+          name: trusted-ca
       priorityClassName: system-cluster-critical
       securityContext:
         runAsNonRoot: true
@@ -98,3 +100,9 @@ spec:
         secret:
           optional: true
           secretName: serving-cert
+      - configMap:
+          items:
+          - key: ca-bundle.crt
+            path: tls-ca-bundle.pem
+          name: trusted-ca
+        name: trusted-ca

--- a/manifests/07-operator.yaml
+++ b/manifests/07-operator.yaml
@@ -64,6 +64,8 @@ spec:
               name: config
             - mountPath: /var/run/secrets/serving-cert
               name: serving-cert
+            - mountPath: /etc/pki/ca-trust/extracted/pem
+              name: trusted-ca
           env:
             - name: CONSOLE_IMAGE
               value: registry.svc.ci.openshift.org/openshift:console
@@ -99,3 +101,9 @@ spec:
           secret:
             secretName: serving-cert
             optional: true
+        - name: trusted-ca
+          configMap:
+            name: trusted-ca
+            items:
+            - key: ca-bundle.crt
+              path: tls-ca-bundle.pem


### PR DESCRIPTION
The alternative ingress can be provided via the console config API. This PR ensures that health checks to the alternative ingress pass TLS certificate validation even when the TLS certificate has an unknown CA.
Additionally, this PR would help with the proxy support [similar to how it was done in the cluster ingress operator](https://github.com/openshift/cluster-ingress-operator/pull/334).