### PR TITLE
TRT-1733: Revert #914 "OCPBUGS-29547: Apply hypershift cluster-profile for ibm-cloud-managed"

### DIFF
--- a/manifests/07-operator.yaml
+++ b/manifests/07-operator.yaml
@@ -7,8 +7,6 @@ metadata:
     config.openshift.io/inject-proxy: console-operator
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
-    include.release.openshift.io/hypershift: "true"
-    include.release.openshift.io/ibm-cloud-managed: "true"
     capability.openshift.io/name: Console
 spec:
   replicas: 1

--- a/quickstarts/consolequickstart-install-cryostat.yaml
+++ b/quickstarts/consolequickstart-install-cryostat.yaml
@@ -3,7 +3,6 @@ kind: ConsoleQuickStart
 metadata:
   annotations:
     capability.openshift.io/name: Console
-    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: 'true'
     include.release.openshift.io/self-managed-high-availability: 'true'
     include.release.openshift.io/single-node-developer: 'true'

--- a/quickstarts/impersonate-user.yaml
+++ b/quickstarts/impersonate-user.yaml
@@ -3,7 +3,6 @@ kind: ConsoleQuickStart
 metadata:
   annotations:
     capability.openshift.io/name: Console
-    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: 'true'
     include.release.openshift.io/self-managed-high-availability: 'true'
     include.release.openshift.io/single-node-developer: 'true'

--- a/quickstarts/install-helmchartrepo-ns.yaml
+++ b/quickstarts/install-helmchartrepo-ns.yaml
@@ -3,7 +3,6 @@ kind: ConsoleQuickStart
 metadata:
   name: install-helmchartrepo-ns
   annotations:
-    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: 'true'
     include.release.openshift.io/self-managed-high-availability: 'true'
     include.release.openshift.io/single-node-developer: 'true'

--- a/quickstarts/install-serverless.yaml
+++ b/quickstarts/install-serverless.yaml
@@ -3,7 +3,6 @@ kind: ConsoleQuickStart
 metadata:
   name: install-serverless
   annotations:
-    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: 'true'
     include.release.openshift.io/self-managed-high-availability: 'true'
     include.release.openshift.io/single-node-developer: 'true'

--- a/quickstarts/jboss-eap7-with-helm.yaml
+++ b/quickstarts/jboss-eap7-with-helm.yaml
@@ -3,7 +3,6 @@ kind: ConsoleQuickStart
 metadata:
   name: jboss-eap7-with-helm
   annotations:
-    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: 'true'
     include.release.openshift.io/self-managed-high-availability: 'true'
     include.release.openshift.io/single-node-developer: 'true'

--- a/quickstarts/manage-helm-repos.yaml
+++ b/quickstarts/manage-helm-repos.yaml
@@ -3,7 +3,6 @@ kind: ConsoleQuickStart
 metadata:
   name: manage-helm-repos
   annotations:
-    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: 'true'
     include.release.openshift.io/self-managed-high-availability: 'true'
     include.release.openshift.io/single-node-developer: 'true'

--- a/quickstarts/node-with-s2i.yaml
+++ b/quickstarts/node-with-s2i.yaml
@@ -3,7 +3,6 @@ kind: ConsoleQuickStart
 metadata:
   name: node-with-s2i
   annotations:
-    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: 'true'
     include.release.openshift.io/self-managed-high-availability: 'true'
     include.release.openshift.io/single-node-developer: 'true'

--- a/quickstarts/quarkus-with-helm.yaml
+++ b/quickstarts/quarkus-with-helm.yaml
@@ -3,7 +3,6 @@ kind: ConsoleQuickStart
 metadata:
   name: quarkus-with-helm
   annotations:
-    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: 'true'
     include.release.openshift.io/self-managed-high-availability: 'true'
     include.release.openshift.io/single-node-developer: 'true'

--- a/quickstarts/quarkus-with-s2i.yaml
+++ b/quickstarts/quarkus-with-s2i.yaml
@@ -3,7 +3,6 @@ kind: ConsoleQuickStart
 metadata:
   name: quarkus-with-s2i
   annotations:
-    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: 'true'
     include.release.openshift.io/self-managed-high-availability: 'true'
     include.release.openshift.io/single-node-developer: 'true'

--- a/quickstarts/spring-with-s2i.yaml
+++ b/quickstarts/spring-with-s2i.yaml
@@ -3,7 +3,6 @@ kind: ConsoleQuickStart
 metadata:
   name: spring-with-s2i
   annotations:
-    include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: 'true'
     include.release.openshift.io/self-managed-high-availability: 'true'
     include.release.openshift.io/single-node-developer: 'true'


### PR DESCRIPTION
Reverts #914 ; tracked by [TRT-1733](https://issues.redhat.com//browse/TRT-1733)

Per [OpenShift policy](https://github.com/openshift/enhancements/blob/master/enhancements/release/improving-ci-signal.md#quick-revert), we are reverting this breaking change to get CI and/or nightly payloads flowing again.

Hypershift is permafailing on 4.17, the manifests have a master node selector which will never schedule on a hosted hypershift cluster

To unrevert this, revert this PR, and layer an additional separate commit on top that addresses the problem. Before merging the unrevert, please run these jobs on the PR and check the result of these jobs to confirm the fix has corrected the problem:

```
/payload-job 
periodic-ci-openshift-hypershift-release-4.17-periodics-e2e-aws-ovn-conformance should pass
```

CC: @jhadvig

<div align="right">
PR created by <a href="https://github.com/stbenjam/revertomatic">Revertomatic<sup>:tm:</sup></a>
</div>
