### PR TITLE
 [release-4.16] OCPBUGS-34012: Cache organization ID

### DIFF
--- a/pkg/console/operator/operator.go
+++ b/pkg/console/operator/operator.go
@@ -90,10 +90,16 @@ type consoleOperator struct {
 
 	resourceSyncer resourcesynccontroller.ResourceSyncer
 
-	// used to keep track of OLM capability
-	isOLMDisabled bool
+	trackables trackables
 
 	monitoringDeploymentLister appsv1listers.DeploymentLister
+}
+
+type trackables struct {
+	// used to keep track of OLM capability
+	isOLMDisabled bool
+	// track organization ID
+	organizationID string
 }
 
 func NewConsoleOperator(
@@ -203,7 +209,7 @@ func NewConsoleOperator(
 		informers = append(informers, olmConfigInformer.Informer())
 	} else {
 		klog.Info("olmconfigs resource does not exist in cluster, launching poll and disabling olmconfigs informer")
-		c.isOLMDisabled = true
+		c.trackables.isOLMDisabled = true
 		c.startPollAndRestartIfResourceEnabled(olmGroupVersionResource)
 	}
 

--- a/pkg/console/operator/sync_v400.go
+++ b/pkg/console/operator/sync_v400.go
@@ -376,7 +376,7 @@ func (co *consoleOperator) SyncConfigMap(
 		copiedCSVsDisabled bool
 		ccdErr             error
 	)
-	if !co.isOLMDisabled {
+	if !co.trackables.isOLMDisabled {
 		copiedCSVsDisabled, ccdErr = co.isCopiedCSVsDisabled(ctx)
 		if ccdErr != nil {
 			return nil, false, "FailedGetOLMConfig", ccdErr
@@ -461,12 +461,9 @@ func (co *consoleOperator) GetTelemetryConfiguration(ctx context.Context, operat
 		return nil, err
 	}
 
-	// If for any reason the getting the ORGANIZATION_ID fails,
-	// log the error and set ORGANIZATION_ID to empty string.
-	organizationID, err := telemetry.GetOrganizationID(clusterID, accessToken)
-	if err != nil {
-		klog.Errorf("telemetry config error: %s", err)
-	}
+	organizationID := telemetry.GetOrganizationID(telemetryConfig, co.trackables.organizationID, clusterID, accessToken)
+	// cache ORGANIZATION_ID
+	co.trackables.organizationID = organizationID
 	telemetryConfig["ORGANIZATION_ID"] = organizationID
 
 	return telemetryConfig, nil

--- a/pkg/console/operator/sync_v400.go
+++ b/pkg/console/operator/sync_v400.go
@@ -460,10 +460,11 @@ func (co *consoleOperator) GetTelemetryConfiguration(ctx context.Context, operat
 	if err != nil {
 		return nil, err
 	}
-
-	organizationID := telemetry.GetOrganizationID(telemetryConfig, co.trackables.organizationID, clusterID, accessToken)
-	// cache ORGANIZATION_ID
-	co.trackables.organizationID = organizationID
+	organizationID, refreshCache := telemetry.GetOrganizationID(telemetryConfig, co.trackables.organizationID, clusterID, accessToken)
+	// cache fetched ORGANIZATION_ID
+	if refreshCache {
+		co.trackables.organizationID = organizationID
+	}
 	telemetryConfig["ORGANIZATION_ID"] = organizationID
 
 	return telemetryConfig, nil

--- a/pkg/console/telemetry/telemetry.go
+++ b/pkg/console/telemetry/telemetry.go
@@ -84,21 +84,21 @@ func GetAccessToken(secretsLister v1.SecretLister) (string, error) {
 // 1. custom ORGANIZATION_ID is awailable as telemetry annotation on console-operator config or in telemetry-config configmap
 // 2. cached ORGANIZATION_ID is available on the operator controller instance
 // else fetch the ORGANIZATION_ID from OCM
-func GetOrganizationID(telemetryConfig map[string]string, cachedOrganizationID, clusterID, accessToken string) string {
-	if customOrganizationID, isCustomOrgIDSet := telemetryConfig["ORGANIZATION_ID"]; isCustomOrgIDSet {
-		return customOrganizationID
+func GetOrganizationID(telemetryConfig map[string]string, cachedOrganizationID, clusterID, accessToken string) (string, bool) {
+	customOrganizationID, isCustomOrgIDSet := telemetryConfig["ORGANIZATION_ID"]
+	if isCustomOrgIDSet {
+		return customOrganizationID, false
 	}
 
 	if cachedOrganizationID != "" {
-		return cachedOrganizationID
+		return cachedOrganizationID, false
 	}
 
 	fetchedOrganizationID, err := FetchOrganizationID(clusterID, accessToken)
-	klog.V(4).Infoln("Fetching ORGANIZATION_ID from OCM")
 	if err != nil {
 		klog.Errorf("telemetry config error: %s", err)
 	}
-	return fetchedOrganizationID
+	return fetchedOrganizationID, true
 }
 
 // Needed to create our own types for OCM Subscriptions since their types and client are useless

--- a/pkg/console/telemetry/telemetry.go
+++ b/pkg/console/telemetry/telemetry.go
@@ -87,10 +87,12 @@ func GetAccessToken(secretsLister v1.SecretLister) (string, error) {
 func GetOrganizationID(telemetryConfig map[string]string, cachedOrganizationID, clusterID, accessToken string) (string, bool) {
 	customOrganizationID, isCustomOrgIDSet := telemetryConfig["ORGANIZATION_ID"]
 	if isCustomOrgIDSet {
+		klog.V(4).Infoln("telemetry config: using custom organization ID")
 		return customOrganizationID, false
 	}
 
 	if cachedOrganizationID != "" {
+		klog.V(4).Infoln("telemetry config: using cached organization ID")
 		return cachedOrganizationID, false
 	}
 
@@ -113,6 +115,7 @@ type Organization struct {
 
 // FetchOrganizationID fetches the organization ID using the cluster ID and access token
 func FetchOrganizationID(clusterID, accessToken string) (string, error) {
+	klog.V(4).Infoln("telemetry config: fetching organization ID")
 	u, err := buildURL(clusterID)
 	if err != nil {
 		return "", err // more contextual error handling can be added here if needed


### PR DESCRIPTION
Manual backport of https://github.com/openshift/console-operator/pull/905 since [additional commit](https://github.com/openshift/console-operator/pull/913) needed to be cherry-picked.

/assign @TheRealJon 