### PR TITLE
[WIP] CONSOLE-4277: Console-operator should make use of the new downloads server

### DIFF
--- a/bindata/assets/configmaps/artifacts-configmap.yaml
+++ b/bindata/assets/configmaps/artifacts-configmap.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: artifacts-config
+  namespace: openshift-console
+  labels:
+    app: "console"
+  annotations: {}
+data:
+  artifacts-config.yaml: |
+    defaultArtifactsConfig:
+      - arch: amd64
+        operatingSystem: linux
+        path: /usr/share/openshift/linux_amd64/oc
+      - arch: amd64
+        operatingSystem: mac
+        path: /usr/share/openshift/mac/oc
+      - arch: amd64
+        operatingSystem: windows
+        path: /usr/share/openshift/windows/oc.exe
+      - arch: arm64
+        operatingSystem: linux
+        path: /usr/share/openshift/linux_arm64/oc
+      - arch: arm64
+        operatingSystem: mac
+        path: /usr/share/openshift/mac_arm64/oc
+      - arch: ppc64le
+        operatingSystem: linux
+        path: /usr/share/openshift/linux_ppc64le/oc
+      - arch: s390x
+        operatingSystem: linux
+        path: /usr/share/openshift/linux_s390x/oc

--- a/bindata/assets/deployments/downloads-deployment.yaml
+++ b/bindata/assets/deployments/downloads-deployment.yaml
@@ -31,6 +31,10 @@ spec:
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
+      volumes:
+        - name: downloads-config-volume
+          configMap:
+            name: artifacts-config
       containers:
         - resources:
             requests:
@@ -39,7 +43,7 @@ spec:
           readinessProbe:
             httpGet:
               path: /
-              port: 8080
+              port: 8081
               scheme: HTTP
             timeoutSeconds: 1
             periodSeconds: 10
@@ -52,12 +56,10 @@ spec:
             capabilities:
               drop:
               - ALL
-          command:
-            - /bin/sh
           livenessProbe:
             httpGet:
               path: /
-              port: 8080
+              port: 8081
               scheme: HTTP
             timeoutSeconds: 1
             periodSeconds: 10
@@ -65,129 +67,16 @@ spec:
             failureThreshold: 3
           ports:
             - name: http
-              containerPort: 8080
+              containerPort: 8081
               protocol: TCP
           imagePullPolicy: IfNotPresent
           terminationMessagePolicy: FallbackToLogsOnError
-          image: ${IMAGE}
-          args:
-            - '-c'
-            - |
-              cat <<EOF >>/tmp/serve.py
-              import errno, http.server, os, re, signal, socket, sys, tarfile, tempfile, threading, time, zipfile
-
-              signal.signal(signal.SIGTERM, lambda signum, frame: sys.exit(0))
-
-              def write_index(path, message):
-                with open(path, 'wb') as f:
-                  f.write('\n'.join([
-                    '<!doctype html>',
-                    '<html lang="en">',
-                    '<head>',
-                    '  <meta charset="utf-8">',
-                    '</head>',
-                    '<body>',
-                    '  {}'.format(message),
-                    '</body>',
-                    '</html>',
-                    '',
-                  ]).encode('utf-8'))
-
-              # Launch multiple listeners as threads
-              class Thread(threading.Thread):
-                def __init__(self, i, socket):
-                  threading.Thread.__init__(self)
-                  self.i = i
-                  self.socket = socket
-                  self.daemon = True
-                  self.start()
-
-                def run(self):
-                  server = http.server.SimpleHTTPRequestHandler
-                  server.server_version = "OpenShift Downloads Server"
-                  server.sys_version = ""
-                  httpd = http.server.HTTPServer(addr, server, False)
-
-                  # Prevent the HTTP server from re-binding every handler.
-                  # https://stackoverflow.com/questions/46210672/
-                  httpd.socket = self.socket
-                  httpd.server_bind = self.server_close = lambda self: None
-
-                  httpd.serve_forever()
-
-              temp_dir = tempfile.mkdtemp()
-              print('serving from {}'.format(temp_dir))
-              os.chdir(temp_dir)
-              for arch in ['amd64', 'arm64', 'ppc64le', 's390x']:
-                os.mkdir(arch)
-              content = ['<a href="oc-license">license</a>']
-              os.symlink('/usr/share/openshift/LICENSE', 'oc-license')
-
-              for arch, operating_system, path in [
-                  ('amd64', 'linux', '/usr/share/openshift/linux_amd64/oc'),
-                  ('amd64', 'mac', '/usr/share/openshift/mac/oc'),
-                  ('amd64', 'windows', '/usr/share/openshift/windows/oc.exe'),
-                  ('arm64', 'linux', '/usr/share/openshift/linux_arm64/oc'),
-                  ('arm64', 'mac', '/usr/share/openshift/mac_arm64/oc'),
-                  ('ppc64le', 'linux', '/usr/share/openshift/linux_ppc64le/oc'),
-                  ('s390x', 'linux', '/usr/share/openshift/linux_s390x/oc'),
-                  ]:
-                basename = os.path.basename(path)
-                target_path = os.path.join(arch, operating_system, basename)
-                os.mkdir(os.path.join(arch, operating_system))
-                os.symlink(path, target_path)
-                base_root, _ = os.path.splitext(basename)
-                archive_path_root = os.path.join(arch, operating_system, base_root)
-                with tarfile.open('{}.tar'.format(archive_path_root), 'w') as tar:
-                  tar.add(path, basename)
-                with zipfile.ZipFile('{}.zip'.format(archive_path_root), 'w') as zip:
-                  zip.write(path, basename)
-                content.append(
-                  '<a href="{0}">oc ({1} {2})</a> (<a href="{3}.tar">tar</a> <a href="{3}.zip">zip</a>)'.format(
-                    target_path, arch, operating_system, archive_path_root
-                  )
-                )
-
-              for root, directories, filenames in os.walk(temp_dir):
-                root_link = os.path.relpath(temp_dir, os.path.join(root, 'child')).replace(os.path.sep, '/')
-                for directory in directories:
-                  write_index(
-                    path=os.path.join(root, directory, 'index.html'),
-                    message='<p>Directory listings are disabled.  See <a href="{}">here</a> for available content.</p>'.format(root_link),
-                  )
-
-              write_index(
-                path=os.path.join(temp_dir, 'index.html'),
-                message='\n'.join(
-                  ['<ul>'] +
-                  ['  <li>{}</li>'.format(entry) for entry in content] +
-                  ['</ul>']
-                ),
-              )
-
-              # Create socket
-              # IPv6 should handle IPv4 passively so long as it is not bound to a
-              # specific address or set to IPv6_ONLY
-              # https://stackoverflow.com/questions/25817848/python-3-does-http-server-support-ipv6
-              try:
-                addr = ('::', 8080)
-                sock = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
-              except socket.error as err:
-                # errno.EAFNOSUPPORT is "socket.error: [Errno 97] Address family not supported by protocol"
-                # When IPv6 is disabled, socket will bind using IPv4.
-                if err.errno == errno.EAFNOSUPPORT:
-                  addr = ('', 8080)
-                  sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-                else:
-                  raise    
-              sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-              sock.bind(addr)
-              sock.listen(5)
-
-              [Thread(i, socket=sock) for i in range(100)]
-              time.sleep(9e9)
-              EOF
-              exec python3 /tmp/serve.py
+          image: ${DOWNLOADS_IMAGE}
+          command: ["/opt/downloads/downloads"]
+          args: ["--config-path=/etc/artifacts-config/artifacts-config.yaml"]
+          volumeMounts:
+            - name: downloads-config-volume
+              mountPath: /etc/artifacts-config
       tolerations:
         - key: node-role.kubernetes.io/master
           operator: Exists

--- a/bindata/assets/services/downloads-service.yaml
+++ b/bindata/assets/services/downloads-service.yaml
@@ -10,7 +10,7 @@ spec:
   - name: http
     port: 80
     protocol: TCP
-    targetPort: 8080
+    targetPort: 8081
   selector:
     app: console
     component: downloads

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -11,7 +11,7 @@ const (
 	ConsoleContainerTargetPort          = 8443
 	ConsoleServingCertName              = "console-serving-cert"
 	DefaultIngressCertConfigMapName     = "default-ingress-cert"
-	DownloadsPort                       = 8080
+	DownloadsPort                       = 8081
 	DownloadsPortName                   = "http"
 	DownloadsResourceName               = "downloads"
 	NodeArchitectureLabel               = "kubernetes.io/arch"

--- a/pkg/console/subresource/deployment/deployment_test.go
+++ b/pkg/console/subresource/deployment/deployment_test.go
@@ -1488,6 +1488,7 @@ func TestDefaultDownloadsDeployment(t *testing.T) {
 		NodeSelector: map[string]string{
 			"kubernetes.io/os": "linux",
 		},
+		Volumes:  downloadsDeploymentTemplate.Spec.Template.Spec.Volumes,
 		Affinity: &corev1.Affinity{},
 		Tolerations: []corev1.Toleration{
 			{
@@ -1521,6 +1522,7 @@ func TestDefaultDownloadsDeployment(t *testing.T) {
 					Protocol:      corev1.ProtocolTCP,
 					ContainerPort: api.DownloadsPort,
 				}},
+				VolumeMounts: downloadsDeploymentTemplate.Spec.Template.Spec.Containers[0].VolumeMounts,
 				ReadinessProbe: &corev1.Probe{
 					ProbeHandler: corev1.ProbeHandler{
 						HTTPGet: &corev1.HTTPGetAction{
@@ -1547,7 +1549,7 @@ func TestDefaultDownloadsDeployment(t *testing.T) {
 					SuccessThreshold: 1,
 					FailureThreshold: 3,
 				},
-				Command: []string{"/bin/sh"},
+				Command: []string{"/opt/downloads/downloads"},
 				Resources: corev1.ResourceRequirements{
 					Requests: map[corev1.ResourceName]resource.Quantity{
 						corev1.ResourceCPU:    resource.MustParse("10m"),


### PR DESCRIPTION
Prepare the console-operator for new downloads server image, to be built from the `openshift/console` codebase ([link](https://github.com/openshift/console/tree/master/cmd/downloads)) as part of release repository as soon the [CONSOLE-4276](https://issues.redhat.com/browse/CONSOLE-4276) merges. 

Setup the configuration of the artifacts to be stored in the `ConfigMap` as part of the CO repo and use it instead of the default `artifactsConfiguration` provided in [console](https://github.com/openshift/console/tree/master/cmd/downloads/config/downloads_config.go).

Tested it on my own image of the downloads-server instead of the image *TO BE* published in the release repo. At the moment I left the original image in place - Needs to be updated when [CONSOLE-4276](https://issues.redhat.com/browse/CONSOLE-4276) merges.

On the following screenshot we can see the downloads-server pod running.
![Screenshot 2024-10-09 at 16 46 21](https://github.com/user-attachments/assets/f3603cd6-5d6c-4b3a-88ad-2355ba13bdd5)

Showcase of the pod being deployed with updated downloads-deployment, and artifacts download links.

https://github.com/user-attachments/assets/3b40fc6c-903b-467b-9d6b-76bc3071da79








