### PR TITLE
OCPBUGS-44556: console/status: set initial value of Message field

### DIFF
--- a/pkg/console/status/auth_status.go
+++ b/pkg/console/status/auth_status.go
@@ -155,12 +155,14 @@ func existingOrNewCondition(applyConfig *configv1ac.AuthenticationApplyConfigura
 			tt     = metav1.Now()
 			reason = "Unknown"
 			status = metav1.ConditionUnknown
+			msg    = ""
 		)
 		condition = &applymetav1.ConditionApplyConfiguration{
 			Type:               &conditionType,
 			Status:             &status,
 			LastTransitionTime: &tt,
 			Reason:             &reason,
+			Message:            &msg,
 		}
 	}
 


### PR DESCRIPTION
Due to [this change](https://github.com/openshift/console-operator/pull/907/files#diff-8c5a69d560f0051604d71443b7331e22477075face20b6ea723b0fc71e1437b0L153-R163), the condition's `Message` field has now a zero value of `nil` (due to using the `ConditionApplyConfiguration`), while before it was simply `""`, which is a valid value for `Message`.

This PR simply initializes the `Message` field to an empty string.