### PR TITLE
ODC-7721: Disable developer perspective by default

### DIFF
--- a/manifests/01-operator-config.yaml
+++ b/manifests/01-operator-config.yaml
@@ -13,13 +13,15 @@ spec:
   managementState: Managed
   customization:
     capabilities:
-    - name: LightspeedButton
-      visibility:
-        state: Enabled
-    - name: GettingStartedBanner
-      visibility:
-        state: Enabled
+      - name: LightspeedButton
+        visibility:
+          state: Enabled
+      - name: GettingStartedBanner
+        visibility:
+          state: Enabled
+    # The admin and the dev perspectives are merged into a single perspective and the dev perspective is disabled.
+    # Jira Epic: https://issues.redhat.com/browse/ODC-7716
     perspectives:
-    - id: dev
-      visibility:
-        state: Disabled
+      - id: dev
+        visibility:
+          state: Disabled

--- a/manifests/01-operator-config.yaml
+++ b/manifests/01-operator-config.yaml
@@ -19,3 +19,7 @@ spec:
     - name: GettingStartedBanner
       visibility:
         state: Enabled
+    perspectives:
+    - id: dev
+      visibility:
+        state: Disabled

--- a/pkg/console/subresource/configmap/configmap_test.go
+++ b/pkg/console/subresource/configmap/configmap_test.go
@@ -127,6 +127,10 @@ session: {}
 customization:
   branding: ` + DEFAULT_BRAND + `
   documentationBaseURL: ` + DEFAULT_DOC_URL + `
+  perspectives:
+    - id: dev
+      visibility:
+        state: Disabled
 servingInfo:
   bindAddress: https://[::]:8443
   certFile: /var/serving-cert/tls.crt
@@ -189,6 +193,10 @@ session: {}
 customization:
   branding: ` + DEFAULT_BRAND + `
   documentationBaseURL: ` + DEFAULT_DOC_URL + `
+  perspectives:
+    - id: dev
+      visibility:
+        state: Disabled
 servingInfo:
   bindAddress: https://[::]:8443
   certFile: /var/serving-cert/tls.crt
@@ -267,6 +275,10 @@ session: {}
 customization:
   branding: online
   documentationBaseURL: https://docs.okd.io/4.4/
+  perspectives:
+    - id: dev
+      visibility:
+        state: Disabled
 servingInfo:
   bindAddress: https://[::]:8443
   certFile: /var/serving-cert/tls.crt
@@ -344,6 +356,10 @@ session: {}
 customization:
   branding: online
   documentationBaseURL: https://docs.okd.io/4.4/
+  perspectives:
+    - id: dev
+      visibility:
+        state: Disabled
 servingInfo:
   bindAddress: https://[::]:8443
   certFile: /var/serving-cert/tls.crt
@@ -424,6 +440,10 @@ session: {}
 customization:
   branding: ` + string(operatorv1.BrandDedicatedLegacy) + `
   documentationBaseURL: ` + mockOperatorDocURL + `
+  perspectives:
+    - id: dev
+      visibility:
+        state: Disabled
 servingInfo:
   bindAddress: https://[::]:8443
   certFile: /var/serving-cert/tls.crt
@@ -511,6 +531,10 @@ customization:
   documentationBaseURL: ` + mockOperatorDocURL + `
   customLogoFile: /var/logo/logo.svg
   customProductName: custom-product-name
+  perspectives:
+    - id: dev
+      visibility:
+        state: Disabled
 servingInfo:
   bindAddress: https://[::]:8443
   certFile: /var/serving-cert/tls.crt
@@ -596,6 +620,10 @@ session: {}
 customization:
   branding: ` + string(operatorv1.BrandDedicatedLegacy) + `
   documentationBaseURL: ` + mockOperatorDocURL + `
+  perspectives:
+    - id: dev
+      visibility:
+        state: Disabled
 servingInfo:
   bindAddress: https://[::]:8443
   certFile: /var/serving-cert/tls.crt
@@ -665,6 +693,10 @@ session: {}
 customization:
   branding: ` + DEFAULT_BRAND + `
   documentationBaseURL: ` + DEFAULT_DOC_URL + `
+  perspectives:
+    - id: dev
+      visibility:
+        state: Disabled
 servingInfo:
   bindAddress: https://[::]:8443
   certFile: /var/serving-cert/tls.crt
@@ -729,6 +761,10 @@ session: {}
 customization:
   branding: ` + DEFAULT_BRAND + `
   documentationBaseURL: ` + DEFAULT_DOC_URL + `
+  perspectives:
+    - id: dev
+      visibility:
+        state: Disabled
 servingInfo:
   bindAddress: https://[::]:8443
   certFile: /var/serving-cert/tls.crt
@@ -796,6 +832,10 @@ session: {}
 customization:
   branding: ` + DEFAULT_BRAND + `
   documentationBaseURL: ` + DEFAULT_DOC_URL + `
+  perspectives:
+    - id: dev
+      visibility:
+        state: Disabled
 i18nNamespaces:
 - plugin__plugin3
 servingInfo:
@@ -904,6 +944,10 @@ session: {}
 customization:
   branding: ` + DEFAULT_BRAND + `
   documentationBaseURL: ` + DEFAULT_DOC_URL + `
+  perspectives:
+    - id: dev
+      visibility:
+        state: Disabled
 servingInfo:
   bindAddress: https://[::]:8443
   certFile: /var/serving-cert/tls.crt
@@ -970,6 +1014,10 @@ session: {}
 customization:
   branding: ` + DEFAULT_BRAND + `
   documentationBaseURL: ` + DEFAULT_DOC_URL + `
+  perspectives:
+    - id: dev
+      visibility:
+        state: Disabled
 servingInfo:
   bindAddress: https://[::]:8443
   certFile: /var/serving-cert/tls.crt
@@ -1040,6 +1088,10 @@ session: {}
 customization:
   branding: ` + DEFAULT_BRAND + `
   documentationBaseURL: ` + DEFAULT_DOC_URL + `
+  perspectives:
+    - id: dev
+      visibility:
+        state: Disabled
 monitoringInfo:
   alertmanagerTenancyHost: alertmanager-user-workload.openshift-user-workload-monitoring.svc:9092
   alertmanagerUserWorkloadHost: alertmanager-user-workload.openshift-user-workload-monitoring.svc:9094

--- a/pkg/console/subresource/consoleserver/config_builder.go
+++ b/pkg/console/subresource/consoleserver/config_builder.go
@@ -501,6 +501,16 @@ func (b *ConsoleServerCLIConfigBuilder) customization() Customization {
 		}
 
 		conf.Perspectives = perspectives
+	} else {
+		// Disable the developer perspective by default
+		perspectives := make([]Perspective, 1)
+		perspectives[0] = Perspective{
+			ID: string(PerspectiveIDDev),
+			Visibility: PerspectiveVisibility{
+				State: PerspectiveDisabled,
+			},
+		}
+		conf.Perspectives = perspectives
 	}
 
 	conf.Capabilities = b.capabilities

--- a/pkg/console/subresource/consoleserver/config_builder_test.go
+++ b/pkg/console/subresource/consoleserver/config_builder_test.go
@@ -42,8 +42,15 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 					ClientID:         api.OpenShiftConsoleName,
 					ClientSecretFile: clientSecretFilePath,
 				},
-				Customization: Customization{},
-				Providers:     Providers{},
+				Customization: Customization{
+					Perspectives: []Perspective{
+						{
+							ID:         "dev",
+							Visibility: PerspectiveVisibility{State: PerspectiveDisabled},
+						},
+					},
+				},
+				Providers: Providers{},
 			},
 		}, {
 			name: "Config builder should handle customization with LightspeedButton capability",
@@ -84,6 +91,12 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 							},
 						},
 					},
+					Perspectives: []Perspective{
+						{
+							ID:         "dev",
+							Visibility: PerspectiveVisibility{State: PerspectiveDisabled},
+						},
+					},
 				},
 				Providers: Providers{},
 			},
@@ -118,8 +131,15 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 					OAuthEndpointCAFile: "/var/oauth-serving-cert/ca-bundle.crt",
 					LogoutRedirect:      "https://foobar.com/logout",
 				},
-				Customization: Customization{},
-				Providers:     Providers{},
+				Customization: Customization{
+					Perspectives: []Perspective{
+						{
+							ID:         "dev",
+							Visibility: PerspectiveVisibility{State: PerspectiveDisabled},
+						},
+					},
+				},
+				Providers: Providers{},
 			},
 		}, {
 			name: "Config builder should handle cluster info with external OIDC",
@@ -173,8 +193,15 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 					CookieEncryptionKeyFile:     "/var/session-secret/sessionEncryptionKey",
 					CookieAuthenticationKeyFile: "/var/session-secret/sessionAuthenticationKey",
 				},
-				Customization: Customization{},
-				Providers:     Providers{},
+				Customization: Customization{
+					Perspectives: []Perspective{
+						{
+							ID:         "dev",
+							Visibility: PerspectiveVisibility{State: PerspectiveDisabled},
+						},
+					},
+				},
+				Providers: Providers{},
 			},
 		}, {
 			name: "Config builder should handle monitoring and info",
@@ -219,8 +246,15 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 					ClientSecretFile: clientSecretFilePath,
 					LogoutRedirect:   "https://foobar.com/logout",
 				},
-				Customization: Customization{},
-				Providers:     Providers{},
+				Customization: Customization{
+					Perspectives: []Perspective{
+						{
+							ID:         "dev",
+							Visibility: PerspectiveVisibility{State: PerspectiveDisabled},
+						},
+					},
+				},
+				Providers: Providers{},
 			},
 		}, {
 			name: "Config builder should handle StatuspageID",
@@ -243,7 +277,14 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 					ClientID:         api.OpenShiftConsoleName,
 					ClientSecretFile: clientSecretFilePath,
 				},
-				Customization: Customization{},
+				Customization: Customization{
+					Perspectives: []Perspective{
+						{
+							ID:         "dev",
+							Visibility: PerspectiveVisibility{State: PerspectiveDisabled},
+						},
+					},
+				},
 				Providers: Providers{
 					StatuspageID: "status-12345",
 				},
@@ -271,8 +312,15 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 					ClientID:         api.OpenShiftConsoleName,
 					ClientSecretFile: clientSecretFilePath,
 				},
-				Customization: Customization{},
-				Providers:     Providers{},
+				Customization: Customization{
+					Perspectives: []Perspective{
+						{
+							ID:         "dev",
+							Visibility: PerspectiveVisibility{State: PerspectiveDisabled},
+						},
+					},
+				},
+				Providers: Providers{},
 			},
 		},
 		{
@@ -303,6 +351,12 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 				Customization: Customization{
 					DeveloperCatalog: &DeveloperConsoleCatalogCustomization{
 						Categories: &[]DeveloperConsoleCatalogCategory{},
+					},
+					Perspectives: []Perspective{
+						{
+							ID:         "dev",
+							Visibility: PerspectiveVisibility{State: PerspectiveDisabled},
+						},
 					},
 				},
 				Providers: Providers{},
@@ -355,6 +409,12 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 				},
 				Session: Session{},
 				Customization: Customization{
+					Perspectives: []Perspective{
+						{
+							ID:         "dev",
+							Visibility: PerspectiveVisibility{State: PerspectiveDisabled},
+						},
+					},
 					DeveloperCatalog: &DeveloperConsoleCatalogCustomization{
 						Categories: &[]DeveloperConsoleCatalogCategory{
 							{
@@ -413,6 +473,12 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 						Categories: nil,
 						Types:      DeveloperConsoleCatalogTypes{State: CatalogTypeDisabled, Disabled: &[]string{"type1", "type2"}},
 					},
+					Perspectives: []Perspective{
+						{
+							ID:         "dev",
+							Visibility: PerspectiveVisibility{State: PerspectiveDisabled},
+						},
+					},
 				},
 				Providers: Providers{},
 			},
@@ -447,6 +513,12 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 						Categories: nil,
 						Types:      DeveloperConsoleCatalogTypes{State: CatalogTypeEnabled, Enabled: &[]string{}},
 					},
+					Perspectives: []Perspective{
+						{
+							ID:         "dev",
+							Visibility: PerspectiveVisibility{State: PerspectiveDisabled},
+						},
+					},
 				},
 				Providers: Providers{},
 			},
@@ -480,6 +552,12 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 					ProjectAccess: ProjectAccess{
 						AvailableClusterRoles: []string{"View", "Edit", "Admin"},
 					},
+					Perspectives: []Perspective{
+						{
+							ID:         "dev",
+							Visibility: PerspectiveVisibility{State: PerspectiveDisabled},
+						},
+					},
 				},
 				Providers: Providers{},
 			},
@@ -512,6 +590,12 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 				Customization: Customization{
 					QuickStarts: QuickStarts{
 						Disabled: []string{"quick-start0", "quick-start1", "quick-start2"},
+					},
+					Perspectives: []Perspective{
+						{
+							ID:         "dev",
+							Visibility: PerspectiveVisibility{State: PerspectiveDisabled},
+						},
 					},
 				},
 				Providers: Providers{},
@@ -745,6 +829,12 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 				Customization: Customization{
 					Branding:             "okd",
 					DocumentationBaseURL: "https://foobar.com/docs",
+					Perspectives: []Perspective{
+						{
+							ID:         "dev",
+							Visibility: PerspectiveVisibility{State: PerspectiveDisabled},
+						},
+					},
 				},
 				Providers: Providers{
 					StatuspageID: "status-12345",
@@ -780,8 +870,15 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 					ClientID:         api.OpenShiftConsoleName,
 					ClientSecretFile: clientSecretFilePath,
 				},
-				Customization: Customization{},
-				Providers:     Providers{},
+				Customization: Customization{
+					Perspectives: []Perspective{
+						{
+							ID:         "dev",
+							Visibility: PerspectiveVisibility{State: PerspectiveDisabled},
+						},
+					},
+				},
+				Providers: Providers{},
 				Telemetry: map[string]string{
 					"a-key": "a-value",
 				},
@@ -814,8 +911,15 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 					ClientID:         api.OpenShiftConsoleName,
 					ClientSecretFile: clientSecretFilePath,
 				},
-				Customization: Customization{},
-				Providers:     Providers{},
+				Customization: Customization{
+					Perspectives: []Perspective{
+						{
+							ID:         "dev",
+							Visibility: PerspectiveVisibility{State: PerspectiveDisabled},
+						},
+					},
+				},
+				Providers: Providers{},
 				MonitoringInfo: MonitoringInfo{
 					AlertmanagerUserWorkloadHost: "alertmanager-user-workload.openshift-user-workload-monitoring.svc:9094",
 					AlertmanagerTenancyHost:      "alertmanager-user-workload.openshift-user-workload-monitoring.svc:9092",
@@ -861,7 +965,11 @@ auth:
   clientID: console
   clientSecretFile: /var/oauth-config/clientSecret
 session: {}
-customization: {}
+customization:
+  perspectives:
+  - id: dev
+    visibility:
+      state: Disabled
 providers: {}
 `,
 		},
@@ -905,7 +1013,11 @@ auth:
 session:
   cookieEncryptionKeyFile: /var/session-secret/sessionEncryptionKey
   cookieAuthenticationKeyFile: /var/session-secret/sessionAuthenticationKey
-customization: {}
+customization:
+  perspectives:
+  - id: dev
+    visibility:
+      state: Disabled
 providers: {}
 `,
 		},
@@ -936,7 +1048,11 @@ auth:
   oauthEndpointCAFile: /var/oauth-serving-cert/ca-bundle.crt
   logoutRedirect: https://foobar.com/logout
 session: {}
-customization: {}
+customization:
+  perspectives:
+  - id: dev
+    visibility:
+      state: Disabled
 providers: {}
 `,
 		},
@@ -957,7 +1073,11 @@ auth:
   clientID: console
   clientSecretFile: /var/oauth-config/clientSecret
 session: {}
-customization: {}
+customization:
+  perspectives:
+  - id: dev
+    visibility:
+      state: Disabled
 providers:
   statuspageID: status-12345
 `,
@@ -980,7 +1100,11 @@ auth:
   clientID: console
   clientSecretFile: /var/oauth-config/clientSecret
 session: {}
-customization: {}
+customization:
+  perspectives:
+  - id: dev
+    visibility:
+      state: Disabled
 providers: {}
 `,
 		},
@@ -1008,6 +1132,10 @@ customization:
   developerCatalog:
     categories: []
     types: {}
+  perspectives:
+  - id: dev
+    visibility:
+      state: Disabled
 providers: {}
 `,
 		},
@@ -1069,6 +1197,10 @@ customization:
     - id: notagsorsubcategory
       label: No tags or subcategory
     types: {}
+  perspectives:
+  - id: dev
+    visibility:
+      state: Disabled
 providers: {}
 `,
 		},
@@ -1100,6 +1232,10 @@ customization:
       disabled:
       - type1
       - type2
+  perspectives:
+  - id: dev
+    visibility:
+      state: Disabled
 providers: {}
 `,
 		},
@@ -1129,6 +1265,10 @@ customization:
     types:
       state: Enabled
       enabled: []
+  perspectives:
+  - id: dev
+    visibility:
+      state: Disabled
 providers: {}
 `,
 		},
@@ -1160,6 +1300,10 @@ customization:
     disabledActions:
     - git
     - tekton.dev/pipelines
+  perspectives:
+  - id: dev
+    visibility:
+      state: Disabled
 providers: {}
 `,
 		},
@@ -1200,6 +1344,10 @@ session: {}
 customization:
   branding: okd
   documentationBaseURL: https://foobar.com/docs
+  perspectives:
+  - id: dev
+    visibility:
+      state: Disabled
 providers:
   statuspageID: status-12345
 plugins:
@@ -1237,6 +1385,10 @@ customization:
     disabled:
     - quickStarts0
     - quickStarts1
+  perspectives:
+  - id: dev
+    visibility:
+      state: Disabled
 providers: {}
 `,
 		},
@@ -1472,7 +1624,11 @@ auth:
   clientID: console
   clientSecretFile: /var/oauth-config/clientSecret
 session: {}
-customization: {}
+customization:
+  perspectives:
+  - id: dev
+    visibility:
+      state: Disabled
 providers: {}
 telemetry:
   a-boolean-as-string: "false"
@@ -1505,6 +1661,10 @@ auth:
   clientSecretFile: /var/oauth-config/clientSecret
 session: {}
 customization:
+  perspectives:
+  - id: dev
+    visibility:
+      state: Disabled
   capabilities:
   - name: LightspeedButton
     visibility:

--- a/pkg/console/subresource/consoleserver/config_builder_test.go
+++ b/pkg/console/subresource/consoleserver/config_builder_test.go
@@ -22,6 +22,42 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 		output Config
 	}{
 		{
+			name: "Config builder should not disable dev perspective if perspective config exists",
+			input: func() Config {
+				b := &ConsoleServerCLIConfigBuilder{}
+
+				return b.Perspectives([]v1.Perspective{
+					{
+						ID:         "some-other-perspective",
+						Visibility: v1.PerspectiveVisibility{State: v1.PerspectiveEnabled},
+					},
+				}).Config()
+			},
+			output: Config{
+				Kind:       "ConsoleConfig",
+				APIVersion: "console.openshift.io/v1",
+				ServingInfo: ServingInfo{
+					BindAddress: "https://[::]:8443",
+					CertFile:    certFilePath,
+					KeyFile:     keyFilePath,
+				},
+				ClusterInfo: ClusterInfo{},
+				Auth: Auth{
+					ClientID:         api.OpenShiftConsoleName,
+					ClientSecretFile: clientSecretFilePath,
+				},
+				Customization: Customization{
+					Perspectives: []Perspective{
+						{
+							ID:         "some-other-perspective",
+							Visibility: PerspectiveVisibility{State: PerspectiveEnabled},
+						},
+					},
+				},
+				Providers: Providers{},
+			},
+		},
+		{
 			name: "Config builder should return default config if given no inputs",
 			input: func() Config {
 				b := &ConsoleServerCLIConfigBuilder{}

--- a/pkg/console/subresource/consoleserver/config_merger_test.go
+++ b/pkg/console/subresource/consoleserver/config_merger_test.go
@@ -50,6 +50,10 @@ clusterInfo:
 customization:
   branding: okd
   documentationBaseURL: https://foobar.com/docs
+  perspectives:
+  - id: dev
+    visibility:
+      state: Disabled
 kind: ConsoleConfig
 providers:
   statuspageID: status-12345

--- a/pkg/console/subresource/consoleserver/types.go
+++ b/pkg/console/subresource/consoleserver/types.go
@@ -202,6 +202,16 @@ const (
 	PerspectiveAccessReview PerspectiveState = "AccessReview"
 )
 
+// PerspectiveID defines the id of the perspective.
+// "admin" is the id of the admin perspective.
+// "dev" is the id of the developer perspective.
+type PerspectiveID string
+
+const (
+	PerspectiveIDAdmin PerspectiveID = "admin"
+	PerspectiveIDDev   PerspectiveID = "dev"
+)
+
 // ResourceAttributesAccessReview defines the visibility of the perspective depending on the access review checks.
 // `required` and  `missing` can work together esp. in the case where the cluster admin
 // wants to show another perspective to users without specific permissions. Out of `required` and `missing` atleast one property should be non-empty.


### PR DESCRIPTION

Jira: https://issues.redhat.com/browse/ODC-7721

This pull request introduces changes to manage the visibility of different perspectives in the console server configuration. The changes include adding a new type for perspective IDs, updating the configuration builder to handle perspective visibility, and modifying the operator configuration manifest.

Changes to perspective management:

* [`pkg/console/subresource/consoleserver/types.go`](diffhunk://#diff-800af91abd4a802bcb0ff987850f14f9c4c8b7dd2ffdbb9ca601080deab21471R205-R214): Added `PerspectiveID` type and constants for admin and developer perspectives.

Configuration updates:

* [`pkg/console/subresource/consoleserver/config_builder.go`](diffhunk://#diff-4c176497477ce0b7c52110bc62b4d7cbe480530f729b644af85f38c053eb753eR503-R512): Modified the `customization` function to include perspective visibility settings and disable the developer perspective by default.
* [`manifests/01-operator-config.yaml`](diffhunk://#diff-2c1e82f8842fcdb54a3ccd5f686154e741b1c146316fb814b449277536c0ca98R22-R25): Added configuration for perspectives, setting the developer perspective to be disabled by default.
