### PR TITLE
OCPBUGS-51156: Revert #950 "OCPBUGS-45514: Report email_domain to telemetry"

### DIFF
--- a/pkg/console/operator/operator.go
+++ b/pkg/console/operator/operator.go
@@ -101,9 +101,8 @@ type consoleOperator struct {
 type trackables struct {
 	// used to keep track of OLM capability
 	isOLMDisabled bool
-	// track organization ID and mail
+	// track organization ID
 	organizationID string
-	accountMail    string
 }
 
 func NewConsoleOperator(

--- a/pkg/console/operator/sync_v400.go
+++ b/pkg/console/operator/sync_v400.go
@@ -480,14 +480,12 @@ func (co *consoleOperator) GetTelemetryConfiguration(ctx context.Context, operat
 	if err != nil {
 		return nil, err
 	}
-	organizationID, accountMail, refreshCache := telemetry.GetOrganizationMeta(telemetryConfig, co.trackables.organizationID, co.trackables.accountMail, clusterID, accessToken)
+	organizationID, refreshCache := telemetry.GetOrganizationID(telemetryConfig, co.trackables.organizationID, clusterID, accessToken)
 	// cache fetched ORGANIZATION_ID
 	if refreshCache {
 		co.trackables.organizationID = organizationID
-		co.trackables.accountMail = accountMail
 	}
 	telemetryConfig["ORGANIZATION_ID"] = organizationID
-	telemetryConfig["ACCOUNT_MAIL"] = accountMail
 
 	return telemetryConfig, nil
 }

--- a/pkg/console/telemetry/telemetry.go
+++ b/pkg/console/telemetry/telemetry.go
@@ -84,23 +84,23 @@ func GetAccessToken(secretsLister v1.SecretLister) (string, error) {
 // 1. custom ORGANIZATION_ID is awailable as telemetry annotation on console-operator config or in telemetry-config configmap
 // 2. cached ORGANIZATION_ID is available on the operator controller instance
 // else fetch the ORGANIZATION_ID from OCM
-func GetOrganizationMeta(telemetryConfig map[string]string, cachedOrganizationID, cachedAccountEmail, clusterID, accessToken string) (string, string, bool) {
+func GetOrganizationID(telemetryConfig map[string]string, cachedOrganizationID, clusterID, accessToken string) (string, bool) {
 	customOrganizationID, isCustomOrgIDSet := telemetryConfig["ORGANIZATION_ID"]
 	if isCustomOrgIDSet {
 		klog.V(4).Infoln("telemetry config: using custom organization ID")
-		return customOrganizationID, "", false
+		return customOrganizationID, false
 	}
 
-	if cachedOrganizationID != "" && cachedAccountEmail != "" {
-		klog.V(4).Infoln("telemetry config: using cached organization metadata")
-		return cachedOrganizationID, cachedAccountEmail, false
+	if cachedOrganizationID != "" {
+		klog.V(4).Infoln("telemetry config: using cached organization ID")
+		return cachedOrganizationID, false
 	}
 
-	fetchedOCMRespose, err := FetchSubscription(clusterID, accessToken)
+	fetchedOrganizationID, err := FetchOrganizationID(clusterID, accessToken)
 	if err != nil {
 		klog.Errorf("telemetry config error: %s", err)
 	}
-	return fetchedOCMRespose.Organization.ExternalId, fetchedOCMRespose.Creator.Email, true
+	return fetchedOrganizationID, true
 }
 
 // Needed to create our own types for OCM Subscriptions since their types and client are useless
@@ -111,28 +111,23 @@ type OCMAPIResponse struct {
 }
 type Subscription struct {
 	Organization Organization `json:"organization,omitempty"`
-	Creator      Creator      `json:"creator,omitempty"`
-}
-
-type Creator struct {
-	Email string `json:"email,omitempty"`
 }
 
 type Organization struct {
 	ExternalId string `json:"external_id,omitempty"`
 }
 
-// FetchOrganizationMeta fetches the organization ID and Accout email using the cluster ID and access token
-func FetchSubscription(clusterID, accessToken string) (*Subscription, error) {
+// FetchOrganizationID fetches the organization ID using the cluster ID and access token
+func FetchOrganizationID(clusterID, accessToken string) (string, error) {
 	klog.V(4).Infoln("telemetry config: fetching organization ID")
 	u, err := buildURL(clusterID)
 	if err != nil {
-		return nil, err // more contextual error handling can be added here if needed
+		return "", err // more contextual error handling can be added here if needed
 	}
 
 	req, err := createRequest(u, clusterID, accessToken)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 
 	client := &http.Client{
@@ -143,31 +138,29 @@ func FetchSubscription(clusterID, accessToken string) (*Subscription, error) {
 	}
 	resp, err := client.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("failed to GET (%s): %v", u.String(), err)
+		return "", fmt.Errorf("failed to GET (%s): %v", u.String(), err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("HTTP request failed with status '%s'", resp.Status)
+		return "", fmt.Errorf("HTTP request failed with status '%s'", resp.Status)
 	}
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read response body: %v", err)
+		return "", fmt.Errorf("failed to read response body: %v", err)
 	}
 
 	var ocmResponse OCMAPIResponse
 	if err = json.Unmarshal(body, &ocmResponse); err != nil {
-		return nil, fmt.Errorf("error decoding JSON: %v", err)
+		return "", fmt.Errorf("error decoding JSON: %v", err)
 	}
-	klog.Infof("---> data: %#v\n", string(body))
-	klog.Infof("---> ocmResponse: %#v\n", ocmResponse)
 
 	if len(ocmResponse.Items) == 0 {
-		return nil, fmt.Errorf("empty OCM response")
+		return "", fmt.Errorf("empty OCM response")
 	}
 
-	return &ocmResponse.Items[0], nil
+	return ocmResponse.Items[0].Organization.ExternalId, nil
 }
 
 // buildURL constructs the URL for the API request
@@ -179,7 +172,6 @@ func buildURL(clusterID string) (*url.URL, error) {
 	}
 	q := u.Query()
 	q.Add("fetchOrganization", "true")
-	q.Add("fetchAccounts", "true")
 	q.Add("search", fmt.Sprintf("external_cluster_id='%s'", clusterID))
 	u.RawQuery = q.Encode()
 	return u, nil


### PR DESCRIPTION

Reverts #950 ; tracked by OCPBUGS-51156

Per [OpenShift policy](https://github.com/openshift/enhancements/blob/master/enhancements/release/improving-ci-signal.md#quick-revert), we are reverting this breaking change to get CI and/or nightly payloads flowing again.

Multiple payload failures due to console-operator panic

To unrevert this, revert this PR, and layer an additional separate commit on top that addresses the problem. Before merging the unrevert, please run these jobs on the PR and check the result of these jobs to confirm the fix has corrected the problem:

```
/payload-aggregate periodic-ci-openshift-hypershift-release-4.19-periodics-e2e-aws-ovn-conformance 10
```

CC: @jhadvig

<div align="right">
PR created by <a href="https://github.com/stbenjam/revertomatic">Revertomatic<sup>:tm:</sup></a>
</div>
