### PR TITLE
OCPBUGS-51379: Re-revert Report email_domain to telemetry + fix panic for uninitialized mail value.

### DIFF
--- a/pkg/console/operator/operator.go
+++ b/pkg/console/operator/operator.go
@@ -101,9 +101,8 @@ type consoleOperator struct {
 type trackables struct {
 	// used to keep track of OLM capability
 	isOLMDisabled bool
-	// track organization ID and mail
+	// track organization ID
 	organizationID string
-	accountMail    string
 }
 
 func NewConsoleOperator(
@@ -207,13 +206,6 @@ func NewConsoleOperator(
 		Group:    api.OLMConfigGroup,
 		Version:  api.OLMConfigVersion,
 		Resource: api.OLMConfigResource,
-	}
-
-	// set default values for trackables
-	c.trackables = trackables{
-		isOLMDisabled:  false,
-		organizationID: "",
-		accountMail:    "",
 	}
 
 	if found, _ := isResourceEnabled(dynamicClient, olmGroupVersionResource); found {

--- a/pkg/console/operator/sync_v400.go
+++ b/pkg/console/operator/sync_v400.go
@@ -438,7 +438,7 @@ func (co *consoleOperator) SyncConfigMap(
 //  2. get telemetry annotation from console-operator config
 //  3. get default telemetry value from telemetry-config configmap
 //  4. get CLUSTER_ID from the cluster-version config
-//  5. get ORGANIZATION_ID and ACCOUNT_MAIL from OCM, if they are not already set
+//  5. get ORGANIZATION_ID from OCM, if ORGANIZATION_ID is not already set
 func (co *consoleOperator) GetTelemetryConfiguration(ctx context.Context, operatorConfig *operatorv1.Console) (map[string]string, error) {
 	telemetryConfig := make(map[string]string)
 
@@ -480,14 +480,12 @@ func (co *consoleOperator) GetTelemetryConfiguration(ctx context.Context, operat
 	if err != nil {
 		return nil, err
 	}
-	organizationID, accountMail, refreshCache := telemetry.GetOrganizationMeta(telemetryConfig, co.trackables.organizationID, co.trackables.accountMail, clusterID, accessToken)
-	// cache fetched ORGANIZATION_ID and ACCOUNT_MAIL
+	organizationID, refreshCache := telemetry.GetOrganizationID(telemetryConfig, co.trackables.organizationID, clusterID, accessToken)
+	// cache fetched ORGANIZATION_ID
 	if refreshCache {
 		co.trackables.organizationID = organizationID
-		co.trackables.accountMail = accountMail
 	}
 	telemetryConfig["ORGANIZATION_ID"] = organizationID
-	telemetryConfig["ACCOUNT_MAIL"] = accountMail
 
 	return telemetryConfig, nil
 }

--- a/pkg/console/telemetry/telemetry.go
+++ b/pkg/console/telemetry/telemetry.go
@@ -81,28 +81,26 @@ func GetAccessToken(secretsLister v1.SecretLister) (string, error) {
 }
 
 // check if:
-// 1. custom ORGANIZATION_ID and ACCOUNT_MAIL is awailable as telemetry annotation on console-operator config or in telemetry-config configmap
-// 2. cached ORGANIZATION_ID and ACCOUNT_MAIL is available on the operator controller instance
-// else fetch the ORGANIZATION_ID and ACCOUNT_MAIL from OCM
-func GetOrganizationMeta(telemetryConfig map[string]string, cachedOrganizationID, cachedAccountEmail, clusterID, accessToken string) (string, string, bool) {
+// 1. custom ORGANIZATION_ID is awailable as telemetry annotation on console-operator config or in telemetry-config configmap
+// 2. cached ORGANIZATION_ID is available on the operator controller instance
+// else fetch the ORGANIZATION_ID from OCM
+func GetOrganizationID(telemetryConfig map[string]string, cachedOrganizationID, clusterID, accessToken string) (string, bool) {
 	customOrganizationID, isCustomOrgIDSet := telemetryConfig["ORGANIZATION_ID"]
-	customAccountMail, isCustomAccountMailSet := telemetryConfig["ACCOUNT_MAIL"]
-
-	if isCustomOrgIDSet && isCustomAccountMailSet {
-		klog.V(4).Infoln("telemetry config: using custom data")
-		return customOrganizationID, customAccountMail, false
+	if isCustomOrgIDSet {
+		klog.V(4).Infoln("telemetry config: using custom organization ID")
+		return customOrganizationID, false
 	}
 
-	if cachedOrganizationID != "" && cachedAccountEmail != "" {
-		klog.V(4).Infoln("telemetry config: using cached organization metadata")
-		return cachedOrganizationID, cachedAccountEmail, false
+	if cachedOrganizationID != "" {
+		klog.V(4).Infoln("telemetry config: using cached organization ID")
+		return cachedOrganizationID, false
 	}
 
-	fetchedOCMRespose, err := FetchSubscription(clusterID, accessToken)
+	fetchedOrganizationID, err := FetchOrganizationID(clusterID, accessToken)
 	if err != nil {
 		klog.Errorf("telemetry config error: %s", err)
 	}
-	return fetchedOCMRespose.Organization.ExternalId, fetchedOCMRespose.Creator.Email, true
+	return fetchedOrganizationID, true
 }
 
 // Needed to create our own types for OCM Subscriptions since their types and client are useless
@@ -113,28 +111,23 @@ type OCMAPIResponse struct {
 }
 type Subscription struct {
 	Organization Organization `json:"organization,omitempty"`
-	Creator      Creator      `json:"creator,omitempty"`
-}
-
-type Creator struct {
-	Email string `json:"email,omitempty"`
 }
 
 type Organization struct {
 	ExternalId string `json:"external_id,omitempty"`
 }
 
-// FetchOrganizationMeta fetches the organization ID and Accout email using the cluster ID and access token
-func FetchSubscription(clusterID, accessToken string) (*Subscription, error) {
+// FetchOrganizationID fetches the organization ID using the cluster ID and access token
+func FetchOrganizationID(clusterID, accessToken string) (string, error) {
 	klog.V(4).Infoln("telemetry config: fetching organization ID")
 	u, err := buildURL(clusterID)
 	if err != nil {
-		return nil, err // more contextual error handling can be added here if needed
+		return "", err // more contextual error handling can be added here if needed
 	}
 
 	req, err := createRequest(u, clusterID, accessToken)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 
 	client := &http.Client{
@@ -145,29 +138,29 @@ func FetchSubscription(clusterID, accessToken string) (*Subscription, error) {
 	}
 	resp, err := client.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("failed to GET (%s): %v", u.String(), err)
+		return "", fmt.Errorf("failed to GET (%s): %v", u.String(), err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("HTTP request failed with status '%s'", resp.Status)
+		return "", fmt.Errorf("HTTP request failed with status '%s'", resp.Status)
 	}
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read response body: %v", err)
+		return "", fmt.Errorf("failed to read response body: %v", err)
 	}
 
 	var ocmResponse OCMAPIResponse
 	if err = json.Unmarshal(body, &ocmResponse); err != nil {
-		return nil, fmt.Errorf("error decoding JSON: %v", err)
+		return "", fmt.Errorf("error decoding JSON: %v", err)
 	}
 
 	if len(ocmResponse.Items) == 0 {
-		return nil, fmt.Errorf("empty OCM response")
+		return "", fmt.Errorf("empty OCM response")
 	}
 
-	return &ocmResponse.Items[0], nil
+	return ocmResponse.Items[0].Organization.ExternalId, nil
 }
 
 // buildURL constructs the URL for the API request
@@ -179,7 +172,6 @@ func buildURL(clusterID string) (*url.URL, error) {
 	}
 	q := u.Query()
 	q.Add("fetchOrganization", "true")
-	q.Add("fetchAccounts", "true")
 	q.Add("search", fmt.Sprintf("external_cluster_id='%s'", clusterID))
 	u.RawQuery = q.Encode()
 	return u, nil


### PR DESCRIPTION
Reverts openshift/console-operator#962 


Per [OpenShift policy](https://github.com/openshift/enhancements/blob/master/enhancements/release/improving-ci-signal.md#quick-revert), we are reverting this breaking change to get CI and/or nightly payloads flowing again.

Multiple payload failures due to console-operator panic

To unrevert this, revert this PR, and layer an additional separate commit on top that addresses the problem. Before merging the unrevert, please run these jobs on the PR and check the result of these jobs to confirm the fix has corrected the problem:

```
/payload-aggregate periodic-ci-openshift-hypershift-release-4.19-periodics-e2e-aws-ovn-conformance 10
```

CC: @jhadvig