### PR TITLE
OCPBUGS-51256: Custom route TLS should be optional when IngressController's DefaultCertificate is set 

### DIFF
--- a/manifests/03-rbac-role-cluster.yaml
+++ b/manifests/03-rbac-role-cluster.yaml
@@ -99,6 +99,14 @@ rules:
       - delete
       - patch
   - apiGroups:
+      - operator.openshift.io
+    resources:
+      - ingresscontrollers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - console.openshift.io
     resources:
       - consoleclidownloads

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -48,6 +48,11 @@ const (
 	V1Alpha1PluginI18nAnnotation        = "console.openshift.io/use-i18n"
 	VersionResourceName                 = "version"
 
+	// ingress instance named "default" is the OOTB ingresscontroller
+	// this is an implicit stable API
+	DefaultIngressController   = "default"
+	IngressControllerNamespace = "openshift-ingress-operator"
+
 	OAuthClientName                         = OpenShiftConsoleName
 	OpenShiftConsoleDeploymentName          = OpenShiftConsoleName
 	OpenShiftConsoleDownloadsDeploymentName = DownloadsResourceName

--- a/pkg/console/starter/starter.go
+++ b/pkg/console/starter/starter.go
@@ -23,7 +23,6 @@ import (
 	// openshift
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/api/oauth"
-	operator "github.com/openshift/api/operator"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	"github.com/openshift/console-operator/pkg/api"
 	"github.com/openshift/console-operator/pkg/console/clientwrapper"
@@ -379,6 +378,7 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 		routesClient.RouteV1(),
 		// route
 		operatorConfigInformers.Operator().V1().Consoles(),
+		operatorConfigInformers.Operator().V1().IngressControllers(),
 		kubeInformersConfigNamespaced.Core().V1().Secrets(), // `openshift-config` namespace informers
 		routesInformersNamespaced.Route().V1().Routes(),
 		// events
@@ -396,6 +396,7 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 		routesClient.RouteV1(),
 		// route
 		operatorConfigInformers.Operator().V1().Consoles(),
+		operatorConfigInformers.Operator().V1().IngressControllers(),
 		kubeInformersConfigNamespaced.Core().V1().Secrets(), // `openshift-config` namespace informers
 		routesInformersNamespaced.Route().V1().Routes(),
 		// events
@@ -433,7 +434,7 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 	clusterOperatorStatus := status.NewClusterOperatorStatusController(
 		api.ClusterOperatorName,
 		[]configv1.ObjectReference{
-			{Group: operator.GroupName, Resource: "consoles", Name: api.ConfigResourceName},
+			{Group: operatorv1.GroupName, Resource: "consoles", Name: api.ConfigResourceName},
 			{Group: configv1.GroupName, Resource: "consoles", Name: api.ConfigResourceName},
 			{Group: configv1.GroupName, Resource: "infrastructures", Name: api.ConfigResourceName},
 			{Group: configv1.GroupName, Resource: "proxies", Name: api.ConfigResourceName},

--- a/pkg/console/subresource/route/route_test.go
+++ b/pkg/console/subresource/route/route_test.go
@@ -1,11 +1,15 @@
 package route
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/go-test/deep"
 
 	configv1 "github.com/openshift/api/config/v1"
+	operatorv1 "github.com/openshift/api/operator/v1"
+	"github.com/openshift/console-operator/pkg/api"
 )
 
 func TestGetDefaultRouteHost(t *testing.T) {
@@ -35,6 +39,124 @@ func TestGetDefaultRouteHost(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if diff := deep.Equal(GetDefaultRouteHost(tt.args.routeName, tt.args.ingressConfig), tt.want); diff != nil {
 				t.Error(diff)
+			}
+		})
+	}
+}
+
+func TestNewRouteConfig(t *testing.T) {
+	tests := []struct {
+		name           string
+		operatorConfig *operatorv1.Console
+		ingressConfig  *configv1.Ingress
+		routeName      string
+		expectedConfig *RouteConfig
+	}{
+		{
+			name: "Custom hostname and TLS secret set",
+			operatorConfig: &operatorv1.Console{
+				Spec: operatorv1.ConsoleSpec{
+					Route: operatorv1.ConsoleConfigRoute{
+						Hostname: "custom.example.com",
+						Secret:   configv1.SecretNameReference{Name: "custom-tls-secret"},
+					},
+				},
+			},
+			ingressConfig: &configv1.Ingress{Spec: configv1.IngressSpec{Domain: "example.com"}},
+			routeName:     api.OpenShiftConsoleRouteName,
+			expectedConfig: &RouteConfig{
+				customRoute: RouteControllerSpec{
+					Hostname:   "custom.example.com",
+					SecretName: "custom-tls-secret",
+				},
+				defaultRoute: RouteControllerSpec{
+					Hostname: "console-openshift-console.example.com",
+				},
+				domain:    "example.com",
+				routeName: api.OpenShiftConsoleRouteName,
+			},
+		},
+		{
+			name:           "No custom hostname or TLS secret",
+			operatorConfig: &operatorv1.Console{},
+			ingressConfig:  &configv1.Ingress{Spec: configv1.IngressSpec{Domain: "example.com"}},
+			routeName:      api.OpenShiftConsoleRouteName,
+			expectedConfig: &RouteConfig{
+				customRoute:  RouteControllerSpec{},
+				defaultRoute: RouteControllerSpec{Hostname: "console-openshift-console.example.com"},
+				domain:       "example.com",
+				routeName:    api.OpenShiftConsoleRouteName,
+			},
+		},
+		{
+			name: "Custom route matches default route",
+			operatorConfig: &operatorv1.Console{
+				Spec: operatorv1.ConsoleSpec{
+					Route: operatorv1.ConsoleConfigRoute{Hostname: "console-openshift-console.example.com"},
+				},
+			},
+			ingressConfig: &configv1.Ingress{Spec: configv1.IngressSpec{Domain: "example.com"}},
+			routeName:     api.OpenShiftConsoleRouteName,
+			expectedConfig: &RouteConfig{
+				customRoute:  RouteControllerSpec{},
+				defaultRoute: RouteControllerSpec{Hostname: "console-openshift-console.example.com"},
+				domain:       "example.com",
+				routeName:    api.OpenShiftConsoleRouteName,
+			},
+		},
+		{
+			name:           "Empty Ingress Domain",
+			operatorConfig: &operatorv1.Console{},
+			ingressConfig:  &configv1.Ingress{Spec: configv1.IngressSpec{Domain: "example.com"}},
+			routeName:      api.OpenShiftConsoleRouteName,
+			expectedConfig: &RouteConfig{
+				domain:       "example.com",
+				routeName:    api.OpenShiftConsoleRouteName,
+				defaultRoute: RouteControllerSpec{Hostname: "console-openshift-console.example.com"},
+			},
+		},
+		{
+			name:           "Operator Config Without Hostname But Ingress Config Provides a Custom Route",
+			operatorConfig: &operatorv1.Console{},
+			ingressConfig: &configv1.Ingress{
+				Spec: configv1.IngressSpec{
+					Domain: "example.com",
+					ComponentRoutes: []configv1.ComponentRouteSpec{
+						{Name: api.OpenShiftConsoleRouteName, Hostname: "ingress-provided.example.com"},
+					},
+				},
+			},
+			routeName: api.OpenShiftConsoleRouteName,
+			expectedConfig: &RouteConfig{
+				domain:       "example.com",
+				routeName:    api.OpenShiftConsoleRouteName,
+				defaultRoute: RouteControllerSpec{Hostname: "console-openshift-console.example.com"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		var errors []string
+		t.Run(tt.name, func(t *testing.T) {
+			config := NewRouteConfig(tt.operatorConfig, tt.ingressConfig, tt.routeName)
+
+			if diff := deep.Equal(tt.expectedConfig.domain, config.GetDomain()); diff != nil {
+				errors = append(errors, fmt.Sprintf("Domain mismatch: %v\n", diff))
+			}
+			if diff := deep.Equal(tt.expectedConfig.routeName, config.GetRouteName()); diff != nil {
+				errors = append(errors, fmt.Sprintf("Route domain mismatch: %v\n", diff))
+			}
+
+			if diff := deep.Equal(tt.expectedConfig.defaultRoute, config.GetDefaultRoute()); diff != nil {
+				errors = append(errors, fmt.Sprintf("Default route mismatch: %v\n", diff))
+			}
+
+			if diff := deep.Equal(tt.expectedConfig.customRoute, config.GetCustomRoute()); diff != nil {
+				errors = append(errors, fmt.Sprintf("Custom route mismatch: %v\n", diff))
+			}
+
+			if len(errors) > 0 {
+				t.Errorf("RouteConfig mismatch in %s test case: %v", tt.name, strings.Join(errors, ", "))
 			}
 		})
 	}


### PR DESCRIPTION
Due to this change Routes controller needs to start fetching IngressController `default` instance form the `openshift-ingress-operator` namespace and check if the `Sepc.DefaultCertificate` is set. If so, console-operator does not need to enforce setting the custom TLS secret for custom route, in the `ValidateCustomRouteConfig` method.

+ Add unit tests for the NewRouteConfig function, for which I needed to make the `RouteControllerSpec` fields public.

/assign @TheRealJon 