### PR TITLE
CONSOLE-4481: Add junit generation for unit and e2e testing

### DIFF
--- a/test-e2e.sh
+++ b/test-e2e.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -e
+
+ARTIFACT_DIR=${ARTIFACT_DIR:=/tmp/artifacts}
+
+# https://ci-operator-configresolver-ui-ci.apps.ci.l2s4.p1.openshiftapps.com/help#env
+OPENSHIFT_CI=${OPENSHIFT_CI:=false}
+
+echo "Running tests..."
+if [ "$OPENSHIFT_CI" = true ]; then
+    KUBERNETES_CONFIG=${KUBECONFIG} go test -timeout 30m -v ./test/e2e/ 2>&1 | tee "$ARTIFACT_DIR/test.out"
+    RESULT="${PIPESTATUS[0]}"
+    go-junit-report < "$ARTIFACT_DIR/test.out" > "$ARTIFACT_DIR/junit.xml"
+    if [ "$RESULT" -ne 0 ]; then
+        exit 255
+    fi
+else
+	echo 'KUBERNETES_CONFIG=${KUBECONFIG} go test -timeout 30m -v ./test/e2e/'
+    KUBERNETES_CONFIG=${KUBECONFIG} go test -timeout 30m -v ./test/e2e/
+fi
+
+echo "Success"

--- a/test-unit.sh
+++ b/test-unit.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+
+set -e
+
+#
+# Run all tests (not including functional)
+#   ./test-.sh
+#   ./test-unit.sh -v
+#
+# Run tests for one package
+#   PKG=./unit ./test-unit.sh
+#   PKG=ssh ./test-unit.sh
+#
+
+ARTIFACT_DIR=${ARTIFACT_DIR:=/tmp/artifacts}
+
+export GOBIN=${PWD}/bin:${GOBIN}
+
+# Use deps from vendor dir.
+export GOFLAGS="-mod=vendor"
+
+# Invoke ./cover for HTML output
+COVER=${COVER:-"-cover"}
+
+# https://ci-operator-configresolver-ui-ci.apps.ci.l2s4.p1.openshiftapps.com/help#env
+OPENSHIFT_CI=${OPENSHIFT_CI:=false}
+
+TESTABLE="./pkg/... ./cmd/..."
+FORMATTABLE=(cmd pkg)
+
+# user has not provided PKG override
+if [ -z "${PKG}" ]; then
+	TEST=${TESTABLE}
+	FMT=("${FORMATTABLE[@]}")
+
+# user has provided PKG override
+else
+	# strip out slashes and dots from PKG=./foo/
+	TEST=${PKG//\//}
+	TEST=${TEST//./}
+
+	# only run gofmt on packages provided by user
+	FMT=("${TEST[@]}")
+fi
+
+# split TEST into an array and prepend repo path to each local package
+read -ra split <<<"$TEST"
+TEST=("${split[@]/#/github.com/openshift/console-operator/}")
+
+echo "Running tests..."
+if [ "$OPENSHIFT_CI" = true ]; then
+    go test -v "${COVER}" "$@" "${TEST[@]}" 2>&1 | tee "$ARTIFACT_DIR/test.out"
+    RESULT="${PIPESTATUS[0]}"
+    go-junit-report < "$ARTIFACT_DIR/test.out" > "$ARTIFACT_DIR/junit.xml"
+    if [ "$RESULT" -ne 0 ]; then
+        exit 255
+    fi
+else
+	echo "go test "${COVER}" "$@" "${TEST[@]}""
+    go test "${COVER}" "${TEST[@]}"
+fi
+
+echo "Checking gofmt..."
+fmtRes=$(gofmt -l "${FMT[@]}")
+if [ -n "${fmtRes}" ]; then
+	echo -e "gofmt checking failed:\n${fmtRes}"
+	exit 255
+fi
+
+echo "Checking govet..."
+vetRes=$(go vet "${TEST[@]}")
+if [ -n "${vetRes}" ]; then
+	echo -e "govet checking failed:\n${vetRes}"
+	exit 255
+fi
+
+echo "Success"


### PR DESCRIPTION
In order for prow to contribute tests output to sippy our unit and e2e tests need to generate junit files.

For that reason I've rewrote how the unit tests and e2e tests are being executed. 
<img width="1913" alt="Screenshot 2025-04-07 at 14 45 51" src="https://github.com/user-attachments/assets/c099f0b3-d2ea-4acb-9736-f682d32c510b" />


/assign @TheRealJon @yapei 