### PR TITLE
CONSOLE-4523: Add rhel8 and rhel9 oc binaries for Linux OS in CLI downloads

### DIFF
--- a/bindata/assets/deployments/downloads-deployment.yaml
+++ b/bindata/assets/deployments/downloads-deployment.yaml
@@ -125,19 +125,26 @@ spec:
 
               for arch, operating_system, path in [
                   ('amd64', 'linux', '/usr/share/openshift/linux_amd64/oc'),
+                  ('amd64', 'linux', '/usr/share/openshift/linux_amd64/oc.rhel8'),
+                  ('amd64', 'linux', '/usr/share/openshift/linux_amd64/oc.rhel9'),
                   ('amd64', 'mac', '/usr/share/openshift/mac/oc'),
                   ('amd64', 'windows', '/usr/share/openshift/windows/oc.exe'),
                   ('arm64', 'linux', '/usr/share/openshift/linux_arm64/oc'),
+                  ('arm64', 'linux', '/usr/share/openshift/linux_arm64/oc.rhel8'),
+                  ('arm64', 'linux', '/usr/share/openshift/linux_arm64/oc.rhel9'),
                   ('arm64', 'mac', '/usr/share/openshift/mac_arm64/oc'),
                   ('ppc64le', 'linux', '/usr/share/openshift/linux_ppc64le/oc'),
+                  ('ppc64le', 'linux', '/usr/share/openshift/linux_ppc64le/oc.rhel8'),
+                  ('ppc64le', 'linux', '/usr/share/openshift/linux_ppc64le/oc.rhel9'),
                   ('s390x', 'linux', '/usr/share/openshift/linux_s390x/oc'),
+                  ('s390x', 'linux', '/usr/share/openshift/linux_s390x/oc.rhel8'),
+                  ('s390x', 'linux', '/usr/share/openshift/linux_s390x/oc.rhel9'),
                   ]:
                 basename = os.path.basename(path)
                 target_path = os.path.join(arch, operating_system, basename)
-                os.mkdir(os.path.join(arch, operating_system))
+                os.makedirs(os.path.join(arch, operating_system), exist_ok=True)
                 os.symlink(path, target_path)
-                base_root, _ = os.path.splitext(basename)
-                archive_path_root = os.path.join(arch, operating_system, base_root)
+                archive_path_root = os.path.join(arch, operating_system, basename)
                 with tarfile.open('{}.tar'.format(archive_path_root), 'w') as tar:
                   tar.add(path, basename)
                 with zipfile.ZipFile('{}.zip'.format(archive_path_root), 'w') as zip:

--- a/pkg/console/controllers/clidownloads/controller.go
+++ b/pkg/console/controllers/clidownloads/controller.go
@@ -184,12 +184,20 @@ func PlatformBasedOCConsoleCLIDownloads(host, cliDownloadsName string) *v1.Conso
 		archType string
 	}{
 		{"Linux for x86_64", "amd64/linux", "oc.tar"},
+		{"Linux for x86_64 - RHEL 8", "amd64/linux", "oc.rhel8.tar"},
+		{"Linux for x86_64 - RHEL 9", "amd64/linux", "oc.rhel9.tar"},
 		{"Mac for x86_64", "amd64/mac", "oc.zip"},
-		{"Windows for x86_64", "amd64/windows", "oc.zip"},
+		{"Windows for x86_64", "amd64/windows", "oc.exe.zip"},
 		{"Linux for ARM 64", "arm64/linux", "oc.tar"},
+		{"Linux for ARM 64 - RHEL 8", "arm64/linux", "oc.rhel8.tar"},
+		{"Linux for ARM 64 - RHEL 9", "arm64/linux", "oc.rhel9.tar"},
 		{"Mac for ARM 64", "arm64/mac", "oc.zip"},
 		{"Linux for IBM Power, little endian", "ppc64le/linux", "oc.tar"},
+		{"Linux for IBM Power, little endian - RHEL 8", "ppc64le/linux", "oc.rhel8.tar"},
+		{"Linux for IBM Power, little endian - RHEL 9", "ppc64le/linux", "oc.rhel9.tar"},
 		{"Linux for IBM Z", "s390x/linux", "oc.tar"},
+		{"Linux for IBM Z - RHEL 8", "s390x/linux", "oc.rhel8.tar"},
+		{"Linux for IBM Z - RHEL 9", "s390x/linux", "oc.rhel9.tar"},
 	}
 
 	links := []v1.CLIDownloadLink{}
@@ -212,7 +220,7 @@ func PlatformBasedOCConsoleCLIDownloads(host, cliDownloadsName string) *v1.Conso
 		Spec: v1.ConsoleCLIDownloadSpec{
 			Description: `With the OpenShift command line interface, you can create applications and manage OpenShift projects from a terminal.
 
-The oc binary offers the same capabilities as the kubectl binary, but it is further extended to natively support OpenShift Container Platform features.
+The oc binary offers the same capabilities as the kubectl binary, but it is further extended to natively support OpenShift Container Platform features. You can download oc using the following links.
 `,
 			DisplayName: "oc - OpenShift Command Line Interface (CLI)",
 			Links:       links,

--- a/pkg/console/controllers/clidownloads/controller_test.go
+++ b/pkg/console/controllers/clidownloads/controller_test.go
@@ -116,7 +116,7 @@ func TestPlatformBasedOCConsoleCLIDownloads(t *testing.T) {
 				Spec: v1.ConsoleCLIDownloadSpec{
 					Description: `With the OpenShift command line interface, you can create applications and manage OpenShift projects from a terminal.
 
-The oc binary offers the same capabilities as the kubectl binary, but it is further extended to natively support OpenShift Container Platform features.
+The oc binary offers the same capabilities as the kubectl binary, but it is further extended to natively support OpenShift Container Platform features. You can download oc using the following links.
 `,
 					DisplayName: "oc - OpenShift Command Line Interface (CLI)",
 					Links: []v1.CLIDownloadLink{
@@ -125,16 +125,32 @@ The oc binary offers the same capabilities as the kubectl binary, but it is furt
 							Text: "Download oc for Linux for x86_64",
 						},
 						{
+							Href: "https://www.example.com/amd64/linux/oc.rhel8.tar",
+							Text: "Download oc for Linux for x86_64 - RHEL 8",
+						},
+						{
+							Href: "https://www.example.com/amd64/linux/oc.rhel9.tar",
+							Text: "Download oc for Linux for x86_64 - RHEL 9",
+						},
+						{
 							Href: "https://www.example.com/amd64/mac/oc.zip",
 							Text: "Download oc for Mac for x86_64",
 						},
 						{
-							Href: "https://www.example.com/amd64/windows/oc.zip",
+							Href: "https://www.example.com/amd64/windows/oc.exe.zip",
 							Text: "Download oc for Windows for x86_64",
 						},
 						{
 							Href: "https://www.example.com/arm64/linux/oc.tar",
 							Text: "Download oc for Linux for ARM 64",
+						},
+						{
+							Href: "https://www.example.com/arm64/linux/oc.rhel8.tar",
+							Text: "Download oc for Linux for ARM 64 - RHEL 8",
+						},
+						{
+							Href: "https://www.example.com/arm64/linux/oc.rhel9.tar",
+							Text: "Download oc for Linux for ARM 64 - RHEL 9",
 						},
 						{
 							Href: "https://www.example.com/arm64/mac/oc.zip",
@@ -145,8 +161,24 @@ The oc binary offers the same capabilities as the kubectl binary, but it is furt
 							Text: "Download oc for Linux for IBM Power, little endian",
 						},
 						{
+							Href: "https://www.example.com/ppc64le/linux/oc.rhel8.tar",
+							Text: "Download oc for Linux for IBM Power, little endian - RHEL 8",
+						},
+						{
+							Href: "https://www.example.com/ppc64le/linux/oc.rhel9.tar",
+							Text: "Download oc for Linux for IBM Power, little endian - RHEL 9",
+						},
+						{
 							Href: "https://www.example.com/s390x/linux/oc.tar",
 							Text: "Download oc for Linux for IBM Z",
+						},
+						{
+							Href: "https://www.example.com/s390x/linux/oc.rhel8.tar",
+							Text: "Download oc for Linux for IBM Z - RHEL 8",
+						},
+						{
+							Href: "https://www.example.com/s390x/linux/oc.rhel9.tar",
+							Text: "Download oc for Linux for IBM Z - RHEL 9",
 						},
 						{
 							Href: "https://www.example.com/oc-license",

--- a/test/e2e/downloads_test.go
+++ b/test/e2e/downloads_test.go
@@ -42,6 +42,7 @@ func TestDownloadsEndpoint(t *testing.T) {
 		req := getRequest(t, link.Href)
 		client := getInsecureClient()
 		resp, err := client.Do(req)
+		t.Logf("Requesting %s at %s\n", link.Text, link.Href)
 
 		if err != nil {
 			t.Fatalf("http error getting %s at %s: %s", link.Text, link.Href, err)


### PR DESCRIPTION
Updating the downloads server in order for it to serve the rhel8 and rhel9 binaries for the Linux OS.
Also needed to update `CLIDownloadsSyncController` controller that is responsible for creating the ConsoleCLIDownloads CR of `oc` binaries.
Screen:
<img width="1386" alt="Screenshot 2025-04-09 at 13 20 54" src="https://github.com/user-attachments/assets/2fcae738-682f-4121-9b09-ade2c456b111" />

Originally I wanted to put all the oc + oc.rhel8 + oc.rhel9 into a single archive, but that would be a huge one, more then 500MB 🤯  so I rather added an archive for each binary type.

/assign @Mylanos 

@opayne1 Im open for discussion about the name for the link, cause basically what I did is I've only appended ` - RHEL 8` or ` - RHEL 9` for RHEL binaries (`oc.rhel8` and `oc.rhel9`)
