### PR TITLE
ODC-7780: update quick starts to work in the converged perspective

### DIFF
--- a/quickstarts/add-healthchecks-quickstart.yaml
+++ b/quickstarts/add-healthchecks-quickstart.yaml
@@ -24,8 +24,8 @@ spec:
         
         1. Go to the project your sample application was created in.
 
-        1. If present click on the [perspective switcher]{{highlight
-          qs-perspective-switcher}} at the top of the navigation, and select
+        1. If present, click on the [perspective switcher]{{highlight
+          qs-perspective-switcher}} at the top of the navigation and select
           **Administrator**.
 
         1. In the main navigation menu, select [Workloads]{{highlight qs-nav-workloads}} and select **Topology**.

--- a/quickstarts/add-healthchecks-quickstart.yaml
+++ b/quickstarts/add-healthchecks-quickstart.yaml
@@ -23,10 +23,12 @@ spec:
         To view the details of your sample application:
         
         1. Go to the project your sample application was created in.
-        
-        1. Click on the [perspective switcher]{{highlight qs-perspective-switcher}} at the top of the navigation, and select **Developer**.
-        
-        1. In the navigation menu, click [Topology]{{highlight qs-nav-topology}}.
+
+        1. If present click on the [perspective switcher]{{highlight
+          qs-perspective-switcher}} at the top of the navigation, and select
+          **Administrator**.
+
+        1. In the main navigation menu, select [Workloads]{{highlight qs-nav-workloads}} and select **Topology**.
 
         1. Click on the **nodejs-basic** deployment to view its details.
 

--- a/quickstarts/add-healthchecks-quickstart.yaml
+++ b/quickstarts/add-healthchecks-quickstart.yaml
@@ -24,9 +24,7 @@ spec:
         
         1. Go to the project your sample application was created in.
 
-        1. If present, click on the [perspective switcher]{{highlight
-          qs-perspective-switcher}} at the top of the navigation and select
-          **Administrator**.
+        1. If present, click on the [perspective switcher]{{highlight qs-perspective-switcher}} at the top of the navigation and select **Administrator**.
 
         1. In the main navigation menu, select [Workloads]{{highlight qs-nav-workloads}} and select **Topology**.
 

--- a/quickstarts/install-helmchartrepo-ns.yaml
+++ b/quickstarts/install-helmchartrepo-ns.yaml
@@ -67,8 +67,8 @@ spec:
         instructions: >-
           Verify that the ProjectHelmChartRepository was successfully installed:
 
-          1. If present click on the [perspective switcher]{{highlight
-          qs-perspective-switcher}} at the top of the navigation, and select
+          1. If present, click on the [perspective switcher]{{highlight
+          qs-perspective-switcher}} at the top of the navigation and select
           **Administrator**.
 
           1. In the main navigation menu, select [Home]{{highlight qs-nav-home}} and select **Software Catalog**.

--- a/quickstarts/install-helmchartrepo-ns.yaml
+++ b/quickstarts/install-helmchartrepo-ns.yaml
@@ -35,11 +35,7 @@ spec:
     - description: >-
         Follow these steps to create a ProjectHelmChartRepository CR:
 
-        1. Click on the [perspective switcher]{{highlight
-        qs-perspective-switcher}} at the top of the navigation, and select
-        **Developer**.
-
-        1. In the navigation menu, click [Search]{{highlight qs-nav-search}}.
+        1. In the main navigation menu, select [Home]{{highlight qs-nav-home}} and select **Search**.
 
         1. In the project selector, select the project to populate with the new
         Helm Charts.
@@ -71,14 +67,13 @@ spec:
         instructions: >-
           Verify that the ProjectHelmChartRepository was successfully installed:
 
-          1. Click on the [perspective switcher]{{highlight
+          1. If present click on the [perspective switcher]{{highlight
           qs-perspective-switcher}} at the top of the navigation, and select
-          **Developer**.
+          **Administrator**.
 
-          1. In the navigation menu, click [Add]{{highlight qs-nav-add}}.
+          1. In the main navigation menu, select [Home]{{highlight qs-nav-home}} and select **Software Catalog**.
 
-          1. On the **+Add** page, click **Helm Chart** in the **Developer
-          Catalog** tile. 
+          1. On the **Software Catalog** page, click **Helm Charts** in the **Type** filter. 
 
           1. Do you see **My Helm Chart Repo** in the
           **Chart Repositories** filter?

--- a/quickstarts/install-helmchartrepo-ns.yaml
+++ b/quickstarts/install-helmchartrepo-ns.yaml
@@ -67,9 +67,7 @@ spec:
         instructions: >-
           Verify that the ProjectHelmChartRepository was successfully installed:
 
-          1. If present, click on the [perspective switcher]{{highlight
-          qs-perspective-switcher}} at the top of the navigation and select
-          **Administrator**.
+          1. If present, click on the [perspective switcher]{{highlight qs-perspective-switcher}} at the top of the navigation and select **Administrator**.
 
           1. In the main navigation menu, select [Home]{{highlight qs-nav-home}} and select **Software Catalog**.
 

--- a/quickstarts/jboss-eap7-with-helm.yaml
+++ b/quickstarts/jboss-eap7-with-helm.yaml
@@ -35,7 +35,7 @@ spec:
     - description: >-
         To create a JBoss EAP 7 application:
         
-        1. If present click on the [perspective switcher]{{highlight qs-perspective-switcher}} and select **Administrator**.
+        1. If present, click on the [perspective switcher]{{highlight qs-perspective-switcher}} and select **Administrator**.
         
         1. In the main navigation menu, select [Home]{{highlight qs-nav-home}} and select **Software Catalog**.
 

--- a/quickstarts/jboss-eap7-with-helm.yaml
+++ b/quickstarts/jboss-eap7-with-helm.yaml
@@ -35,12 +35,11 @@ spec:
     - description: >-
         To create a JBoss EAP 7 application:
         
-        1. In the main navigation, click the dropdown menu [perspective switcher]{{highlight qs-perspective-switcher}} and select **Developer**.
+        1. If present click on the [perspective switcher]{{highlight qs-perspective-switcher}} and select **Administrator**.
         
-        1. In the navigation menu, click [Add]{{highlight qs-nav-add}}.  
-           The **Add** page opens.
+        1. In the main navigation menu, select [Home]{{highlight qs-nav-home}} and select **Software Catalog**.
 
-        1. In the **Add** page, click **Helm Chart**.
+        1. In the **Software Catalog** page, click **Helm Charts** in the **Type** filter.
         
         1. In the **Helm Charts** catalog, search for **JBoss EAP 7.4**.
         
@@ -86,7 +85,7 @@ spec:
     - description: >-
         To view the Helm release:
 
-        1. In the navigation menu, click [Helm]{{highlight qs-nav-helm}}.
+        1. In the main navigation menu, select [Helm]{{highlight qs-admin-nav-helm}} and select **Releases**.
 
         1. Click **eap74** Helm release.  
            The **Helm Release details** page opens. It shows all the information related to the Helm release that you installed.
@@ -105,7 +104,7 @@ spec:
     - description: >-
         To view the associated code:
 
-        1. In the navigation menu, click [Topology]{{highlight qs-nav-topology}}.  
+        1. In the main navigation menu, select [Workloads]{{highlight qs-nav-workloads}} and select **Topology**.  
            In the Topology view, the **eap74** deployment displays a code icon in the bottom right-hand corner. This icon either represents the Git repository
            of the associated code, or if the appropriate operators are installed, it will bring up the associated code in your IDE.
 
@@ -126,7 +125,7 @@ spec:
     - description: >-
         To view the build status of the JBoss EAP 7 application:
 
-        1. In the navigation menu, click [Topology]{{highlight qs-nav-topology}}.
+        1. In the main navigation menu, select [Workloads]{{highlight qs-nav-workloads}} and select **Topology**.  
 
         1. In the Topology view, click **D eap74**.  
            A side panel opens with detailed information about the application.
@@ -165,7 +164,7 @@ spec:
     - description: >-
         To view the pod status:
 
-        1. In the navigation menu, click [Topology]{{highlight qs-nav-topology}}.
+        1. In the main navigation menu, select [Workloads]{{highlight qs-nav-workloads}} and select **Topology**.  
 
         1. In the **Topology** view, click **D eap74**.  
            A side panel opens with detailed information about the application.

--- a/quickstarts/manage-helm-repos.yaml
+++ b/quickstarts/manage-helm-repos.yaml
@@ -66,11 +66,9 @@ spec:
         instructions: >-
           Verify that the HelmChartRepository was successfully installed:
 
-          1. Click on the [perspective switcher]{{highlight qs-perspective-switcher}} at the top of the navigation, and select **Developer**.
+          1. In the main navigation menu, select [Home]{{highlight qs-nav-home}} and select **Software Catalog**.
 
-          1. In the navigation menu, click [Add]{{highlight qs-nav-add}}.
-          
-          1. On the **+Add** page, click **Helm Chart**. 
+          1. On the **Software Catalog** page, click **Helm Charts** in the **Type** filter.
           
           1. Confirm that the **azure-sample-repo** is an available catalog.
 

--- a/quickstarts/manage-helm-repos.yaml
+++ b/quickstarts/manage-helm-repos.yaml
@@ -33,7 +33,7 @@ spec:
     - description: >-
         Follow these steps to create a HelmChartRepository CR:
 
-        1. Click on the [perspective switcher]{{highlight qs-perspective-switcher}} at the top of the navigation, and select **Administrator**.
+        1. If present, click on the [perspective switcher]{{highlight qs-perspective-switcher}} at the top of the navigation and select **Administrator**.
         
         1. In the navigation menu, click [Home]{{highlight qs-nav-home}}.
         
@@ -48,16 +48,13 @@ spec:
             ```
             apiVersion: helm.openshift.io/v1beta1
             kind: HelmChartRepository
-
             metadata:
               name: azure-sample-repo
-
             spec:
               name: azure-sample-repo
-
               connectionConfig:
                 url: https://raw.githubusercontent.com/Azure-Samples/helm-charts/master/docs
-            ```
+            ```{{copy}}
 
         1. Click **Create**.
 

--- a/quickstarts/monitor-sampleapp-quickstart.yaml
+++ b/quickstarts/monitor-sampleapp-quickstart.yaml
@@ -24,7 +24,7 @@ spec:
         
         1. Go to the project your sample application was created in.
         
-        1. If present click on the [perspective switcher]{{highlight qs-perspective-switcher}} at the top of the navigation, and select **Administrator**.
+        1. If present, click on the [perspective switcher]{{highlight qs-perspective-switcher}} at the top of the navigation and select **Administrator**.
         
         1. In the main navigation menu, select [Workloads]{{highlight qs-nav-workloads}} and select **Topology**.
 

--- a/quickstarts/monitor-sampleapp-quickstart.yaml
+++ b/quickstarts/monitor-sampleapp-quickstart.yaml
@@ -24,9 +24,9 @@ spec:
         
         1. Go to the project your sample application was created in.
         
-        1. Click on the [perspective switcher]{{highlight qs-perspective-switcher}} at the top of the navigation, and select **Developer**.
+        1. If present click on the [perspective switcher]{{highlight qs-perspective-switcher}} at the top of the navigation, and select **Administrator**.
         
-        1. In the navigation menu, click [Topology]{{highlight qs-nav-topology}}.
+        1. In the main navigation menu, select [Workloads]{{highlight qs-nav-workloads}} and select **Topology**.
 
         1. Click on the **nodejs-basic** deployment to view its details.
         

--- a/quickstarts/node-with-s2i.yaml
+++ b/quickstarts/node-with-s2i.yaml
@@ -34,7 +34,7 @@ spec:
     - description: >-
         To create a Node application:
         
-        1. If present click on the [perspective switcher]{{highlight qs-perspective-switcher}} at the top of the navigation, and select **Administrator**.
+        1. If present, click on the [perspective switcher]{{highlight qs-perspective-switcher}} at the top of the navigation and select **Administrator**.
         
         1. In the main navigation menu, select [Home]{{highlight qs-nav-home}} and select **Projects**.
         

--- a/quickstarts/node-with-s2i.yaml
+++ b/quickstarts/node-with-s2i.yaml
@@ -42,7 +42,7 @@ spec:
 
         1. In the **Name** field, enter a name for your new project. Then click **Create**.
         
-        1. In the masthead, click **+** icon and select **Import from Git**. 
+        1. In the masthead, click [plus icon]{{highlight qs-masthead-import}} button and select **Import from Git**. 
         
         1. In the **Git Repo URL** field, add 
         

--- a/quickstarts/node-with-s2i.yaml
+++ b/quickstarts/node-with-s2i.yaml
@@ -34,15 +34,15 @@ spec:
     - description: >-
         To create a Node application:
         
-        1. Click on the [perspective switcher]{{highlight qs-perspective-switcher}} at the top of the navigation, and select **Developer**.
+        1. If present click on the [perspective switcher]{{highlight qs-perspective-switcher}} at the top of the navigation, and select **Administrator**.
         
-        1. In the navigation menu, click [Add]{{highlight qs-nav-add}}.
+        1. In the main navigation menu, select [Home]{{highlight qs-nav-home}} and select **Projects**.
         
-        1. Click the **Project** dropdown menu and select **Create Project** to create a project for your Node application.
+        1. Click the **Create Project** button to create a project for your Node application.
 
         1. In the **Name** field, enter a name for your new project. Then click **Create**.
         
-        1. On the **+Add page**, click **Import from Git** on the **Git Repository** tile. 
+        1. In the masthead, click **+** icon and select **Import from Git**. 
         
         1. In the **Git Repo URL** field, add 
         
@@ -90,7 +90,7 @@ spec:
     - description: >-
         To view the associated code:
         
-        1. In the navigation menu, click [Topology]{{highlight qs-nav-topology}}.
+        1. In the main navigation menu, select [Workloads]{{highlight qs-nav-workloads}} and select **Topology**.
         
         1. The icon on the bottom right quadrant of the **nodejs-rest-http** deployment either represents the Git repository of the associated code, OR if the appropriate operators are installed, it will bring up the associated code in your IDE.
                   

--- a/quickstarts/quarkus-with-helm.yaml
+++ b/quickstarts/quarkus-with-helm.yaml
@@ -32,15 +32,17 @@ spec:
     - description: >-
         To create a Quarkus application:
         
-        1. Click on the [perspective switcher]{{highlight qs-perspective-switcher}} at the top of the navigation, and select **Developer**.
-        
-        1. In the navigation menu, click [Add]{{highlight qs-nav-add}}.
+        1. If present click on the [perspective switcher]{{highlight qs-perspective-switcher}} at the top of the navigation, and select **Administrator**.
                 
-        1. Click the **Project** dropdown menu and select **Create Project** to create a project for your Quarkus application.
+        1. In the main navigation menu, select [Home]{{highlight qs-nav-home}} and select **Projects**.
+
+        1. Click the **Create Project** button to create a project for your Quarkus application.
 
         1. In the **Name** field, enter a name for your new project. Then click **Create**.
         
-        1. On the **+Add** page, click **Helm Chart**. 
+        1. In the main navigation menu, select [Helm]{{highlight qs-admin-nav-helm}} and select **Releases**.
+
+        1. On the **Helm Releases** page, click **Create Helm Release** button.
         
         1. In the Helm Chart catalog, click the **Quarkus** tile.
         
@@ -89,7 +91,7 @@ spec:
     - description: >-
         To view the pod status:
 
-        1. In the navigation menu, click [Topology]{{highlight qs-nav-topology}}.
+        1. In the main navigation menu, select [Workloads]{{highlight qs-nav-workloads}} and select **Topology**.
         
         1. Hover over the pod donut to see the pod status in a tooltip.
 

--- a/quickstarts/quarkus-with-helm.yaml
+++ b/quickstarts/quarkus-with-helm.yaml
@@ -32,7 +32,7 @@ spec:
     - description: >-
         To create a Quarkus application:
         
-        1. If present click on the [perspective switcher]{{highlight qs-perspective-switcher}} at the top of the navigation, and select **Administrator**.
+        1. If present, click on the [perspective switcher]{{highlight qs-perspective-switcher}} at the top of the navigation and select **Administrator**.
                 
         1. In the main navigation menu, select [Home]{{highlight qs-nav-home}} and select **Projects**.
 

--- a/quickstarts/quarkus-with-s2i.yaml
+++ b/quickstarts/quarkus-with-s2i.yaml
@@ -46,7 +46,7 @@ spec:
 
         1. In the **Name** field, enter a name for your new project. Then click **Create**.
         
-        1. In the masthead, click [+ plus icon]{{highlight qs-masthead-import}} icon and select **Import from Git**. 
+        1. In the masthead, click [plus icon]{{highlight qs-masthead-import}} button and select **Import from Git**. 
         
         1. In the **Git Repo URL** field, add 
           

--- a/quickstarts/quarkus-with-s2i.yaml
+++ b/quickstarts/quarkus-with-s2i.yaml
@@ -38,7 +38,7 @@ spec:
     - description: >-
         To create a Quarkus application:  
 
-        1. If peresnt click on the [perspective switcher]{{highlight qs-perspective-switcher}} at the top of the navigation, and select **Administrator**.
+        1. If present, click on the [perspective switcher]{{highlight qs-perspective-switcher}} at the top of the navigation and select **Administrator**.
         
         1. In the main navigation menu, select [Home]{{highlight qs-nav-home}} and select **Projects**.
         

--- a/quickstarts/quarkus-with-s2i.yaml
+++ b/quickstarts/quarkus-with-s2i.yaml
@@ -38,15 +38,15 @@ spec:
     - description: >-
         To create a Quarkus application:  
 
-        1. Click on the [perspective switcher]{{highlight qs-perspective-switcher}} at the top of the navigation, and select **Developer**.
+        1. If peresnt click on the [perspective switcher]{{highlight qs-perspective-switcher}} at the top of the navigation, and select **Administrator**.
         
-        1. In the navigation menu, click [Add]{{highlight qs-nav-add}}.
+        1. In the main navigation menu, select [Home]{{highlight qs-nav-home}} and select **Projects**.
         
-        1. Click the **Project** dropdown menu and select **Create Project** to create a project for your Quarkus application.
+        1. Click the **Create Project** button to create a project for your Quarkus application.
 
         1. In the **Name** field, enter a name for your new project. Then click **Create**.
         
-        1. On the **+Add page**, click **Import from Git** on the **Git Repository** tile. 
+        1. In the masthead, click [+ plus icon]{{highlight qs-masthead-import}} icon and select **Import from Git**. 
         
         1. In the **Git Repo URL** field, add 
           
@@ -109,7 +109,7 @@ spec:
     - description: >-
         To view the associated code: 
 
-        1. In the navigation menu, click [Topology]{{highlight qs-nav-topology}}.
+        1. In the main navigation menu, select [Workloads]{{highlight qs-nav-workloads}} and select **Topology**.
         
         1. The icon on the bottom right quadrant of the **quarkus-quickstarts** deployment either represents the Git repository of the associated code, OR if the appropriate operators are installed, it will bring up the associated code in your IDE.
                   

--- a/quickstarts/rhdh-installation-via-helm.yaml
+++ b/quickstarts/rhdh-installation-via-helm.yaml
@@ -111,7 +111,7 @@ spec:
       description: |-
         To install Red Hat Developer Hub via Helm:
 
-        1. If present click on the [perspective switcher]{{highlight qs-perspective-switcher}} at the top of the navigation and select **Administrator**.
+        1. If present, click on the [perspective switcher]{{highlight qs-perspective-switcher}} at the top of the navigation and select **Administrator**.
         2. In the main navigation menu, select [Helm]{{highlight qs-admin-nav-helm}} and select **Releases**.
         3. If needed, switch or create a new project from the **Project dropdown**.
         4. On the **Helm Releases** page, click **Create Helm Release** button.

--- a/quickstarts/rhdh-installation-via-helm.yaml
+++ b/quickstarts/rhdh-installation-via-helm.yaml
@@ -173,7 +173,7 @@ spec:
         4. You can apply the following configuration with the Form view by clicking on **Root Schema > Global**
            or in the YAML view by applying as shown below:
 
-           ```
+        ```
         global:
           clusterRouterBase: developer-hub.example.com
           host: developer-hub.example.com
@@ -209,8 +209,8 @@ spec:
         2. Click on the [plus icon]{{highlight qs-masthead-import}} button and select **Import YAML** at the top of the navigation.
         3. **Insert the YAML** below into the YAML editor, add your Red Hat Developer Hub URL as `href`, and update the link `text` if needed.
 
-            ```
-            apiVersion: console.openshift.io/v1
+        ```
+        apiVersion: console.openshift.io/v1
         kind: ConsoleLink
         metadata:
           name: developer-hub-link

--- a/quickstarts/rhdh-installation-via-helm.yaml
+++ b/quickstarts/rhdh-installation-via-helm.yaml
@@ -111,12 +111,13 @@ spec:
       description: |-
         To install Red Hat Developer Hub via Helm:
 
-        1. Click on the [perspective switcher]{{highlight qs-perspective-switcher}} at the top of the navigation and select **Developer**.
-        2. In the navigation menu, click [Add]{{highlight qs-nav-add}} and then select **Helm Chart**.
+        1. If present click on the [perspective switcher]{{highlight qs-perspective-switcher}} at the top of the navigation and select **Administrator**.
+        2. In the main navigation menu, select [Helm]{{highlight qs-admin-nav-helm}} and select **Releases**.
         3. If needed, switch or create a new project from the **Project dropdown**.
-        4. Search for **Red Hat Developer Hub**
-        5. Select the card **Red Hat Developer Hub, Provided by Red Hat**, and press **Create** to open a page to configure the Helm Chart.
-        6. **Optional:** Change the default configuration via the form (click on Root Schema to expand the configuration) or YAML based on your needs.
+        4. On the **Helm Releases** page, click **Create Helm Release** button.
+        5. Search for **Red Hat Developer Hub**
+        6. Select the card **Red Hat Developer Hub, Provided by Red Hat**, and press **Create** to open a page to configure the Helm Chart.
+        7. **Optional:** Change the default configuration via the form (click on Root Schema to expand the configuration) or YAML based on your needs.
            
            You can update the configuration later as well.
         7. Click **Create** to install the Red Hat Developer Hub Helm Chart.
@@ -143,7 +144,7 @@ spec:
         To update your Red Hat Developer Hub installation:
 
         1. Ensure you have a **backup** of your installation.
-        2. In the navigation menu, click [Helm]{{highlight qs-nav-helm}}.
+        2. In the main navigation menu, select [Helm]{{highlight qs-admin-nav-helm}} and select **Releases**.
         3. Select your **developer-hub** Helm Release. You can see your current version under **Chart version**.
         4. Click the **Actions** menu button in the top right corner and select **Upgrade**.
         5. Switch to the **YAML view** and **save your current YAML configuration.**
@@ -154,7 +155,7 @@ spec:
         instructions: |-
           #### To verify the application was successfully upgraded:
 
-          1. Navigate back to [Helm]{{highlight qs-nav-helm}} and select your "developer-hub" Helm Release.
+          1. In the main navigation menu, select [Helm]{{highlight qs-admin-nav-helm}} and select **Releases**.
           2. Your Helm Chart should show "Deployed" again and an updated **Chart version**.
           3. The **Revision history** tab should show a new revision with the message "Upgrade complete".
         failedTaskHelp: |-
@@ -166,7 +167,7 @@ spec:
       description: |-
         To use a custom domain name, you must change some of **Helm Chart values**:
 
-        1. In the navigation menu, click [Helm]{{highlight qs-nav-helm}}.
+        1. In the main navigation menu, select [Helm]{{highlight qs-admin-nav-helm}} and select **Releases**.
         2. Select your **developer-hub** Helm Release.
         3. Click the **Actions** menu button in the top right corner and select **Upgrade**.
         4. You can apply the following configuration with the Form view by clicking on **Root Schema > Global**
@@ -189,7 +190,7 @@ spec:
         instructions: |-
           #### To verify the application was successfully updated:
 
-          1. Navigate to [Topology]{{highlight qs-nav-topology}}
+          1. In the main navigation menu, select [Workloads]{{highlight qs-nav-workloads}} and select **Topology**.
           2. Click on the URL decorator in the top-right corner of the "developer-hub" Deployment to open your Red Hat Developer Hub instance.
           3. Verify that the correct URL is used and the Red Hat Developer Hub installation works fine.
         failedTaskHelp: |-
@@ -204,8 +205,8 @@ spec:
         This resource is not created automatically because you can have multiple Red Hat Developer Hub installations on one cluster.
         And this way, you can also link a single RHDH instance from multiple OpenShift clusters.
 
-        1. Please copy the actual **Red Hat Developer Hub URL** from [Topology]{{highlight qs-nav-topology}}, or open it in another browser tab.
-        2. Click on the [Import YAML (plus icon)]{{highlight qs-masthead-import}} button at the top of the navigation.
+        1. Please copy the actual **Red Hat Developer Hub URL** from [Workloads]{{highlight qs-nav-workloads}} select **Topology**, or open it in another browser tab.
+        2. Click on the [+ plus icon]{{highlight qs-masthead-import}} button and select **Import YAML** at the top of the navigation.
         3. **Insert the YAML** below into the YAML editor, add your Red Hat Developer Hub URL as `href`, and update the link `text` if needed.
 
             ```

--- a/quickstarts/rhdh-installation-via-helm.yaml
+++ b/quickstarts/rhdh-installation-via-helm.yaml
@@ -206,7 +206,7 @@ spec:
         And this way, you can also link a single RHDH instance from multiple OpenShift clusters.
 
         1. Please copy the actual **Red Hat Developer Hub URL** from [Workloads]{{highlight qs-nav-workloads}} select **Topology**, or open it in another browser tab.
-        2. Click on the [+ plus icon]{{highlight qs-masthead-import}} button and select **Import YAML** at the top of the navigation.
+        2. Click on the [plus icon]{{highlight qs-masthead-import}} button and select **Import YAML** at the top of the navigation.
         3. **Insert the YAML** below into the YAML editor, add your Red Hat Developer Hub URL as `href`, and update the link `text` if needed.
 
             ```

--- a/quickstarts/rhdh-installation-via-operator.yaml
+++ b/quickstarts/rhdh-installation-via-operator.yaml
@@ -174,8 +174,8 @@ spec:
         instructions: |-
           #### To verify the application was successfully created:
 
-          1. In the **Administrator** perspective you should now see a RHDH "backstage-my-rhdh” Deployment under Workloads > Deployments,
-             or in the [Topology]{{highlight qs-nav-topology}} view of the **Developer** perspective.
+          1. In the **Administrator** perspective you should now see a RHDH "backstage-my-rhdh” Deployment under [Workloads]{{highlight qs-nav-workloads}} > Deployments,
+             or in the [Workloads]{{highlight qs-nav-workloads}} **Topology** view.
           2. It might take a moment for your deployment status to update to "Running".
           3. In the **Administrator** perspective, you can find the URL of your RHDH instance under Networking > Routes.
              In the **Developer** perspective Topology, you can click on the URL decorator in the Deployment to open your RHDH instance.
@@ -308,7 +308,7 @@ spec:
         This way, you can also link a single RHDH instance from multiple OpenShift clusters.
 
         1. Please copy the actual **Red Hat Developer Hub URL** from [Topology]{{highlight qs-nav-topology}}, or open it in another browser tab.
-        2. Click on the [Import YAML (plus icon)]{{highlight qs-masthead-import}} button at the top of the navigation.
+        2. Click on the [+ plus icon]{{highlight qs-masthead-import}} button and select **Import YAML** at the top of the navigation.
         3. **Insert the YAML** below into the YAML editor, add your Red Hat Developer Hub URL as `href`, and update the link `text` if needed.
 
             ```

--- a/quickstarts/rhdh-installation-via-operator.yaml
+++ b/quickstarts/rhdh-installation-via-operator.yaml
@@ -111,7 +111,7 @@ spec:
       description: |-
         To install the Red Hat Developer Hub Operator:
 
-        1. Click on the [perspective switcher]{{highlight qs-perspective-switcher}} at the top of the navigation and select **Administrator**.
+        1. If present, click on the [perspective switcher]{{highlight qs-perspective-switcher}} at the top of the navigation and select **Administrator**.
         2. In the Administrator perspective, go to the **OperatorHub** page from the [Operators]{{highlight qs-nav-operators}} section of the navigation.
         3. Search for **Red Hat Developer Hub**
         4. Select the card **Red Hat Developer Hub** with the **Red Hat** badge and press **Install** to open a page to install the Operator.
@@ -308,7 +308,7 @@ spec:
         This way, you can also link a single RHDH instance from multiple OpenShift clusters.
 
         1. Please copy the actual **Red Hat Developer Hub URL** from [Topology]{{highlight qs-nav-topology}}, or open it in another browser tab.
-        2. Click on the [+ plus icon]{{highlight qs-masthead-import}} button and select **Import YAML** at the top of the navigation.
+        2. Click on the [plus icon]{{highlight qs-masthead-import}} button and select **Import YAML** at the top of the navigation.
         3. **Insert the YAML** below into the YAML editor, add your Red Hat Developer Hub URL as `href`, and update the link `text` if needed.
 
             ```

--- a/quickstarts/rhdh-installation-via-operator.yaml
+++ b/quickstarts/rhdh-installation-via-operator.yaml
@@ -200,7 +200,7 @@ spec:
 
         1. To **create a random secret** for the backend auth key, use this command:
 
-            ```
+        ```
         node -p 'require("crypto").randomBytes(24).toString("base64")'
         ```{{copy}}
 
@@ -212,7 +212,7 @@ spec:
 
            Enter ConfigMap name `my-rhdh-app-config`, key `app-config-extras.yaml` and the following `app-config` YAML:
 
-            ```
+        ```
         app:
           title: Acme Inc. Developer Hub
         organization:
@@ -225,7 +225,7 @@ spec:
 
         4. **Update the `Backstage` resource** and use the new Secret and ConfigMap by adding additional options like:
 
-            ```
+        ```
         ...
         spec:
           ...
@@ -311,8 +311,8 @@ spec:
         2. Click on the [plus icon]{{highlight qs-masthead-import}} button and select **Import YAML** at the top of the navigation.
         3. **Insert the YAML** below into the YAML editor, add your Red Hat Developer Hub URL as `href`, and update the link `text` if needed.
 
-            ```
-            apiVersion: console.openshift.io/v1
+        ```
+        apiVersion: console.openshift.io/v1
         kind: ConsoleLink
         metadata:
           name: developer-hub-link

--- a/quickstarts/sample-application-quickstart.yaml
+++ b/quickstarts/sample-application-quickstart.yaml
@@ -20,6 +20,8 @@ spec:
       description: |-
         To create a sample application:
         
+        1. As a cluster admin enable the **Developer** perspective by following the "Enable the Developer Perspective" quick start. 
+        
         1. Click on the [perspective switcher]{{highlight qs-perspective-switcher}} at the top of the navigation, and select **Developer**.
         
         1. In the navigation menu, click [Add]{{highlight qs-nav-add}}.

--- a/quickstarts/spring-with-s2i.yaml
+++ b/quickstarts/spring-with-s2i.yaml
@@ -38,15 +38,15 @@ spec:
     - description: >-
         To create a Spring application:
         
-        1. Click on the [perspective switcher]{{highlight qs-perspective-switcher}} at the top of the navigation, and select **Developer**.
+        1. If present click on the [perspective switcher]{{highlight qs-perspective-switcher}} at the top of the navigation, and select **Administrator**.
         
-        1. In the navigation menu, click [Add]{{highlight qs-nav-add}}.
+        1. In the main navigation menu, select [Home]{{highlight qs-nav-home}} and select **Projects**.
         
-        1. Click the **Project** dropdown menu and select **Create Project** to create a project for your Spring application.
+        1. Click the **Create Project** button to create a project for your Quarkus application.
 
         1. In the **Name** field, enter a name for your new project. Then click **Create**.
         
-        1. On the **+Add page**, click **Import from Git** on the **Git Repository** tile. 
+        1. In the masthead, click [+ plus icon]{{highlight qs-masthead-import}} icon and select **Import from Git**.
         
         1. In the **Git Repo URL** field, add 
           
@@ -68,7 +68,7 @@ spec:
       review:
         failedTaskHelp: This task isn’t verified yet. Try the task again.
         instructions: >-
-          The application is represented by the light grey area with the white border.  The deployment is a white circle.  Verify that the application was successfully created:
+          The application is represented by the light grey area with the white border. The deployment is a white circle. Verify that the application was successfully created:
           
           1. Do you see a **rest-http-example-app** application?
           
@@ -103,7 +103,7 @@ spec:
     - description: >-
         To view the associated code:
         
-        1. In the navigation menu, click [Topology]{{highlight qs-nav-topology}}.
+        1. In the main navigation menu, select [Workloads]{{highlight qs-nav-workloads}} and select **Topology**.
         
         1. The icon on the bottom right quadrant of the **rest-http-example** deployment either represents the Git repository of the associated code, OR if the appropriate operators are installed, it will bring up the associated code in your IDE.
                   

--- a/quickstarts/spring-with-s2i.yaml
+++ b/quickstarts/spring-with-s2i.yaml
@@ -46,7 +46,7 @@ spec:
 
         1. In the **Name** field, enter a name for your new project. Then click **Create**.
         
-        1. In the masthead, click [+ plus icon]{{highlight qs-masthead-import}} icon and select **Import from Git**.
+        1. In the masthead, click [plus icon]{{highlight qs-masthead-import}} button and select **Import from Git**.
         
         1. In the **Git Repo URL** field, add 
           

--- a/quickstarts/spring-with-s2i.yaml
+++ b/quickstarts/spring-with-s2i.yaml
@@ -38,7 +38,7 @@ spec:
     - description: >-
         To create a Spring application:
         
-        1. If present click on the [perspective switcher]{{highlight qs-perspective-switcher}} at the top of the navigation, and select **Administrator**.
+        1. If present, click on the [perspective switcher]{{highlight qs-perspective-switcher}} at the top of the navigation and select **Administrator**.
         
         1. In the main navigation menu, select [Home]{{highlight qs-nav-home}} and select **Projects**.
         


### PR DESCRIPTION
Update the following quick starts to make it work in the converged perspective

1. Add health checks to your sample application
2. Add Helm Chart Repositories to extend the Developer Catalog for your project
3. Get started with JBoss EAP 7 using a Helm Chart
4. Manage available content in the Helm Chart Catalog
5. Monitor your sample application
6. Get started with Node
7. Get started with Quarkus using a Helm Chart
8. Get started with Quarkus using s2i
9. Install Red Hat Developer Hub (RHDH) using Helm Chart
10. Install Red Hat Developer Hub (RHDH) using the Operator
11. Get started with Spring