### PR TITLE
OCPBUGS-55082: Revert "Add rhel8 and rhel9 oc binaries for Linux OS in CLI downloads"

### DIFF
--- a/bindata/assets/deployments/downloads-deployment.yaml
+++ b/bindata/assets/deployments/downloads-deployment.yaml
@@ -125,26 +125,19 @@ spec:
 
               for arch, operating_system, path in [
                   ('amd64', 'linux', '/usr/share/openshift/linux_amd64/oc'),
-                  ('amd64', 'linux', '/usr/share/openshift/linux_amd64/oc.rhel8'),
-                  ('amd64', 'linux', '/usr/share/openshift/linux_amd64/oc.rhel9'),
                   ('amd64', 'mac', '/usr/share/openshift/mac/oc'),
                   ('amd64', 'windows', '/usr/share/openshift/windows/oc.exe'),
                   ('arm64', 'linux', '/usr/share/openshift/linux_arm64/oc'),
-                  ('arm64', 'linux', '/usr/share/openshift/linux_arm64/oc.rhel8'),
-                  ('arm64', 'linux', '/usr/share/openshift/linux_arm64/oc.rhel9'),
                   ('arm64', 'mac', '/usr/share/openshift/mac_arm64/oc'),
                   ('ppc64le', 'linux', '/usr/share/openshift/linux_ppc64le/oc'),
-                  ('ppc64le', 'linux', '/usr/share/openshift/linux_ppc64le/oc.rhel8'),
-                  ('ppc64le', 'linux', '/usr/share/openshift/linux_ppc64le/oc.rhel9'),
                   ('s390x', 'linux', '/usr/share/openshift/linux_s390x/oc'),
-                  ('s390x', 'linux', '/usr/share/openshift/linux_s390x/oc.rhel8'),
-                  ('s390x', 'linux', '/usr/share/openshift/linux_s390x/oc.rhel9'),
                   ]:
                 basename = os.path.basename(path)
                 target_path = os.path.join(arch, operating_system, basename)
-                os.makedirs(os.path.join(arch, operating_system), exist_ok=True)
+                os.mkdir(os.path.join(arch, operating_system))
                 os.symlink(path, target_path)
-                archive_path_root = os.path.join(arch, operating_system, basename)
+                base_root, _ = os.path.splitext(basename)
+                archive_path_root = os.path.join(arch, operating_system, base_root)
                 with tarfile.open('{}.tar'.format(archive_path_root), 'w') as tar:
                   tar.add(path, basename)
                 with zipfile.ZipFile('{}.zip'.format(archive_path_root), 'w') as zip:

--- a/pkg/console/controllers/clidownloads/controller.go
+++ b/pkg/console/controllers/clidownloads/controller.go
@@ -184,20 +184,12 @@ func PlatformBasedOCConsoleCLIDownloads(host, cliDownloadsName string) *v1.Conso
 		archType string
 	}{
 		{"Linux for x86_64", "amd64/linux", "oc.tar"},
-		{"Linux for x86_64 - RHEL 8", "amd64/linux", "oc.rhel8.tar"},
-		{"Linux for x86_64 - RHEL 9", "amd64/linux", "oc.rhel9.tar"},
 		{"Mac for x86_64", "amd64/mac", "oc.zip"},
-		{"Windows for x86_64", "amd64/windows", "oc.exe.zip"},
+		{"Windows for x86_64", "amd64/windows", "oc.zip"},
 		{"Linux for ARM 64", "arm64/linux", "oc.tar"},
-		{"Linux for ARM 64 - RHEL 8", "arm64/linux", "oc.rhel8.tar"},
-		{"Linux for ARM 64 - RHEL 9", "arm64/linux", "oc.rhel9.tar"},
 		{"Mac for ARM 64", "arm64/mac", "oc.zip"},
 		{"Linux for IBM Power, little endian", "ppc64le/linux", "oc.tar"},
-		{"Linux for IBM Power, little endian - RHEL 8", "ppc64le/linux", "oc.rhel8.tar"},
-		{"Linux for IBM Power, little endian - RHEL 9", "ppc64le/linux", "oc.rhel9.tar"},
 		{"Linux for IBM Z", "s390x/linux", "oc.tar"},
-		{"Linux for IBM Z - RHEL 8", "s390x/linux", "oc.rhel8.tar"},
-		{"Linux for IBM Z - RHEL 9", "s390x/linux", "oc.rhel9.tar"},
 	}
 
 	links := []v1.CLIDownloadLink{}
@@ -220,7 +212,7 @@ func PlatformBasedOCConsoleCLIDownloads(host, cliDownloadsName string) *v1.Conso
 		Spec: v1.ConsoleCLIDownloadSpec{
 			Description: `With the OpenShift command line interface, you can create applications and manage OpenShift projects from a terminal.
 
-The oc binary offers the same capabilities as the kubectl binary, but it is further extended to natively support OpenShift Container Platform features. You can download oc using the following links.
+The oc binary offers the same capabilities as the kubectl binary, but it is further extended to natively support OpenShift Container Platform features.
 `,
 			DisplayName: "oc - OpenShift Command Line Interface (CLI)",
 			Links:       links,

--- a/pkg/console/controllers/clidownloads/controller_test.go
+++ b/pkg/console/controllers/clidownloads/controller_test.go
@@ -116,7 +116,7 @@ func TestPlatformBasedOCConsoleCLIDownloads(t *testing.T) {
 				Spec: v1.ConsoleCLIDownloadSpec{
 					Description: `With the OpenShift command line interface, you can create applications and manage OpenShift projects from a terminal.
 
-The oc binary offers the same capabilities as the kubectl binary, but it is further extended to natively support OpenShift Container Platform features. You can download oc using the following links.
+The oc binary offers the same capabilities as the kubectl binary, but it is further extended to natively support OpenShift Container Platform features.
 `,
 					DisplayName: "oc - OpenShift Command Line Interface (CLI)",
 					Links: []v1.CLIDownloadLink{
@@ -125,32 +125,16 @@ The oc binary offers the same capabilities as the kubectl binary, but it is furt
 							Text: "Download oc for Linux for x86_64",
 						},
 						{
-							Href: "https://www.example.com/amd64/linux/oc.rhel8.tar",
-							Text: "Download oc for Linux for x86_64 - RHEL 8",
-						},
-						{
-							Href: "https://www.example.com/amd64/linux/oc.rhel9.tar",
-							Text: "Download oc for Linux for x86_64 - RHEL 9",
-						},
-						{
 							Href: "https://www.example.com/amd64/mac/oc.zip",
 							Text: "Download oc for Mac for x86_64",
 						},
 						{
-							Href: "https://www.example.com/amd64/windows/oc.exe.zip",
+							Href: "https://www.example.com/amd64/windows/oc.zip",
 							Text: "Download oc for Windows for x86_64",
 						},
 						{
 							Href: "https://www.example.com/arm64/linux/oc.tar",
 							Text: "Download oc for Linux for ARM 64",
-						},
-						{
-							Href: "https://www.example.com/arm64/linux/oc.rhel8.tar",
-							Text: "Download oc for Linux for ARM 64 - RHEL 8",
-						},
-						{
-							Href: "https://www.example.com/arm64/linux/oc.rhel9.tar",
-							Text: "Download oc for Linux for ARM 64 - RHEL 9",
 						},
 						{
 							Href: "https://www.example.com/arm64/mac/oc.zip",
@@ -161,24 +145,8 @@ The oc binary offers the same capabilities as the kubectl binary, but it is furt
 							Text: "Download oc for Linux for IBM Power, little endian",
 						},
 						{
-							Href: "https://www.example.com/ppc64le/linux/oc.rhel8.tar",
-							Text: "Download oc for Linux for IBM Power, little endian - RHEL 8",
-						},
-						{
-							Href: "https://www.example.com/ppc64le/linux/oc.rhel9.tar",
-							Text: "Download oc for Linux for IBM Power, little endian - RHEL 9",
-						},
-						{
 							Href: "https://www.example.com/s390x/linux/oc.tar",
 							Text: "Download oc for Linux for IBM Z",
-						},
-						{
-							Href: "https://www.example.com/s390x/linux/oc.rhel8.tar",
-							Text: "Download oc for Linux for IBM Z - RHEL 8",
-						},
-						{
-							Href: "https://www.example.com/s390x/linux/oc.rhel9.tar",
-							Text: "Download oc for Linux for IBM Z - RHEL 9",
 						},
 						{
 							Href: "https://www.example.com/oc-license",

--- a/test/e2e/downloads_test.go
+++ b/test/e2e/downloads_test.go
@@ -42,7 +42,6 @@ func TestDownloadsEndpoint(t *testing.T) {
 		req := getRequest(t, link.Href)
 		client := getInsecureClient()
 		resp, err := client.Do(req)
-		t.Logf("Requesting %s at %s\n", link.Text, link.Href)
 
 		if err != nil {
 			t.Fatalf("http error getting %s at %s: %s", link.Text, link.Href, err)


### PR DESCRIPTION
Reverts openshift/console-operator#976

The original PR is causing failures during minor version upgrades.

/assign @dgoodwin 
/cc @jhadvig 