### PR TITLE
OCPBUGS-52556: Remove SVM console instance if v1alpha1 ConsolePlugin version in present in the CRDs status

### DIFF
--- a/manifests/03-rbac-role-cluster.yaml
+++ b/manifests/03-rbac-role-cluster.yaml
@@ -135,7 +135,7 @@ rules:
       - list
       - watch
   - apiGroups:
-      - migration.k8s.io
+      - storagemigration.k8s.io
     resources:
       - storageversionmigrations
       - storageversionmigrations/status

--- a/manifests/03-rbac-role-cluster.yaml
+++ b/manifests/03-rbac-role-cluster.yaml
@@ -135,7 +135,7 @@ rules:
       - list
       - watch
   - apiGroups:
-      - storagemigration.k8s.io
+      - migration.k8s.io
     resources:
       - storageversionmigrations
       - storageversionmigrations/status

--- a/manifests/03-rbac-role-cluster.yaml
+++ b/manifests/03-rbac-role-cluster.yaml
@@ -134,6 +134,16 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - storagemigration.k8s.io
+    resources:
+      - storageversionmigrations
+      - storageversionmigrations/status
+    verbs:
+      - get
+      - list
+      - watch
+      - delete
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1

--- a/pkg/console/controllers/storageversionmigration/controller.go
+++ b/pkg/console/controllers/storageversionmigration/controller.go
@@ -22,6 +22,10 @@ const (
 	resourceName                = "storageversionmigrations"
 )
 
+var (
+	storageVersionMigrationGVR = storagemigrationv1alpha1.SchemeGroupVersion.WithResource(resourceName)
+)
+
 type StorageVersionMigrationController struct {
 	dynamicClient  dynamic.Interface
 	operatorClient v1helpers.OperatorClient
@@ -40,7 +44,7 @@ func NewStorageVersionMigrationController(
 
 	return factory.New().
 		WithInformers(
-			dynamicInformers.ForResource(storagemigrationv1alpha1.SchemeGroupVersion.WithResource(resourceName)).Informer(),
+			dynamicInformers.ForResource(storageVersionMigrationGVR).Informer(),
 		).
 		WithSync(c.sync).
 		ToController("StorageVersionMigrationController", recorder)
@@ -50,7 +54,7 @@ func (c *StorageVersionMigrationController) sync(ctx context.Context, syncContex
 	statusHandler := status.NewStatusHandler(c.operatorClient)
 
 	// Get the StorageVersionMigration instance
-	svm, err := c.dynamicClient.Resource(storagemigrationv1alpha1.SchemeGroupVersion.WithResource(resourceName)).Get(ctx, storageVersionMigrationName, metav1.GetOptions{})
+	svm, err := c.dynamicClient.Resource(storageVersionMigrationGVR).Get(ctx, storageVersionMigrationName, metav1.GetOptions{})
 	if err != nil {
 		// Error reading the object - requeue the request.
 		klog.Errorf("Failed to get StorageVersionMigration: %v", err)
@@ -70,7 +74,7 @@ func (c *StorageVersionMigrationController) sync(ctx context.Context, syncContex
 
 	if slices.Contains(storedVersions, "v1alpha1") {
 		klog.Infof("Found v1alpha1 in storedVersions, deleting StorageVersionMigration")
-		err = c.dynamicClient.Resource(storagemigrationv1alpha1.SchemeGroupVersion.WithResource(resourceName)).Delete(ctx, storageVersionMigrationName, metav1.DeleteOptions{})
+		err = c.dynamicClient.Resource(storageVersionMigrationGVR).Delete(ctx, storageVersionMigrationName, metav1.DeleteOptions{})
 		statusHandler.AddCondition(status.HandleDegraded("StorageVersionMigration", "FailedDelete", err))
 		if err != nil {
 			klog.Errorf("Failed to delete StorageVersionMigration: %v", err)

--- a/pkg/console/controllers/storageversionmigration/controller.go
+++ b/pkg/console/controllers/storageversionmigration/controller.go
@@ -1,0 +1,82 @@
+package storageversionmigration
+
+import (
+	"context"
+	"slices"
+
+	storagemigrationv1alpha1 "k8s.io/api/storagemigration/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/dynamic/dynamicinformer"
+	"k8s.io/klog/v2"
+
+	"github.com/openshift/console-operator/pkg/console/status"
+	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+)
+
+const (
+	storageVersionMigrationName = "console-plugin-storage-version-migration"
+	resourceName                = "storageversionmigrations"
+)
+
+type StorageVersionMigrationController struct {
+	dynamicClient  dynamic.Interface
+	operatorClient v1helpers.OperatorClient
+}
+
+func NewStorageVersionMigrationController(
+	operatorClient v1helpers.OperatorClient,
+	dynamicClient dynamic.Interface,
+	dynamicInformers dynamicinformer.DynamicSharedInformerFactory,
+	recorder events.Recorder,
+) factory.Controller {
+	c := &StorageVersionMigrationController{
+		dynamicClient:  dynamicClient,
+		operatorClient: operatorClient,
+	}
+
+	return factory.New().
+		WithInformers(
+			dynamicInformers.ForResource(storagemigrationv1alpha1.SchemeGroupVersion.WithResource(resourceName)).Informer(),
+		).
+		WithSync(c.sync).
+		ToController("StorageVersionMigrationController", recorder)
+}
+
+func (c *StorageVersionMigrationController) sync(ctx context.Context, syncContext factory.SyncContext) error {
+	statusHandler := status.NewStatusHandler(c.operatorClient)
+
+	// Get the StorageVersionMigration instance
+	svm, err := c.dynamicClient.Resource(storagemigrationv1alpha1.SchemeGroupVersion.WithResource(resourceName)).Get(ctx, storageVersionMigrationName, metav1.GetOptions{})
+	if err != nil {
+		// Error reading the object - requeue the request.
+		klog.Errorf("Failed to get StorageVersionMigration: %v", err)
+		return statusHandler.FlushAndReturn(err)
+	}
+
+	// Check if status.storedVersions contains v1alpha1
+	storedVersions, found, err := unstructured.NestedStringSlice(svm.Object, "status", "storedVersions")
+	if err != nil {
+		klog.Errorf("Failed to get storedVersions for the StorageVersionMigration: %v", err)
+		return statusHandler.FlushAndReturn(err)
+	}
+	if !found {
+		klog.Errorf("Failed to get storedVersions for the StorageVersionMigration")
+		return statusHandler.FlushAndReturn(nil)
+	}
+
+	if slices.Contains(storedVersions, "v1alpha1") {
+		klog.Infof("Found v1alpha1 in storedVersions, deleting StorageVersionMigration")
+		err = c.dynamicClient.Resource(storagemigrationv1alpha1.SchemeGroupVersion.WithResource(resourceName)).Delete(ctx, storageVersionMigrationName, metav1.DeleteOptions{})
+		statusHandler.AddCondition(status.HandleDegraded("StorageVersionMigration", "FailedDelete", err))
+		if err != nil {
+			klog.Errorf("Failed to delete StorageVersionMigration: %v", err)
+			return statusHandler.FlushAndReturn(err)
+		}
+	}
+
+	return statusHandler.FlushAndReturn(nil)
+}

--- a/pkg/console/starter/starter.go
+++ b/pkg/console/starter/starter.go
@@ -36,6 +36,7 @@ import (
 	pdb "github.com/openshift/console-operator/pkg/console/controllers/poddisruptionbudget"
 	"github.com/openshift/console-operator/pkg/console/controllers/route"
 	"github.com/openshift/console-operator/pkg/console/controllers/service"
+	"github.com/openshift/console-operator/pkg/console/controllers/storageversionmigration"
 	upgradenotification "github.com/openshift/console-operator/pkg/console/controllers/upgradenotification"
 	"github.com/openshift/console-operator/pkg/console/controllers/util"
 	"github.com/openshift/library-go/pkg/controller/controllercmd"
@@ -532,6 +533,14 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 		recorder,
 	)
 
+	// Create the StorageVersionMigration controller
+	storageversionmigrationController := storageversionmigration.NewStorageVersionMigrationController(
+		operatorClient,
+		dynamicClient,
+		dynamicInformers,
+		recorder,
+	)
+
 	configUpgradeableController := unsupportedconfigoverridescontroller.NewUnsupportedConfigOverridesController("UnsupportedConfigOverridesController", operatorClient, controllerContext.EventRecorder)
 	logLevelController := loglevel.NewClusterOperatorLoggingController(operatorClient, controllerContext.EventRecorder)
 	managementStateController := managementstatecontroller.NewOperatorManagementStateController(api.ClusterOperatorName, operatorClient, controllerContext.EventRecorder)
@@ -580,6 +589,7 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 		cliOIDCClientStatusController,
 		upgradeNotificationController,
 		staleConditionsController,
+		storageversionmigrationController,
 	} {
 		go controller.Run(ctx, 1)
 	}


### PR DESCRIPTION
If the `console-plugin-storage-version-migration` SVM `status.storedVersions` contains `v1alpha1` version we need to delete the SVM so the CVO will recreate without it.

@assign @TheRealJon