### PR TITLE
OCPBUGS-57129: Revert adding Console capability into SVM

### DIFF
--- a/manifests/0000_90_console-operator_03_console_plugin_storage_migration.yaml
+++ b/manifests/0000_90_console-operator_03_console_plugin_storage_migration.yaml
@@ -6,8 +6,6 @@ metadata:
     include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/single-node-developer: "true"
-    capability.openshift.io/name: Console
 spec:
   resource:
     group:  console.openshift.io


### PR DESCRIPTION
Also removed the `include.release.openshift.io/single-node-developer` due to [suggestion](https://github.com/openshift/console-operator/pull/992#discussion_r2144265810) from @wking 

/assign @linoyaslan 

