### PR TITLE
OCPBUGS-58320: Fix deprecated API Version in RHDH Operator Quickstart

### DIFF
--- a/quickstarts/rhdh-installation-via-operator.yaml
+++ b/quickstarts/rhdh-installation-via-operator.yaml
@@ -156,7 +156,7 @@ spec:
         For example, a minimal YAML configuration could be:
 
         ```
-        apiVersion: rhdh.redhat.com/v1alpha1
+        apiVersion: rhdh.redhat.com/v1alpha3
         kind: Backstage
         metadata:
           name: my-rhdh
@@ -270,7 +270,7 @@ spec:
                 keys:
                   - secret: "${BACKEND_SECRET}"
         ---
-        apiVersion: rhdh.redhat.com/v1alpha1
+        apiVersion: rhdh.redhat.com/v1alpha3
         kind: Backstage
         metadata:
           name: my-rhdh


### PR DESCRIPTION
This PR fixes the references to a deprecated `Backstage` API Version in the `Install Red Hat Developer Hub (RHDH) using the Operator` Quickstart.

ref: https://issues.redhat.com/browse/RHDHBUGS-247

/cc @christoph-jerolimov @logonoff 