### PR TITLE
OCPBUGS-58434: Console-operator should report plugin services as relatedObjects

### DIFF
--- a/pkg/console/starter/starter_test.go
+++ b/pkg/console/starter/starter_test.go
@@ -1,0 +1,46 @@
+package starter
+
+import (
+	"reflect"
+	"testing"
+
+	configv1 "github.com/openshift/api/config/v1"
+)
+
+func TestDeduplicateObjectReferences(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []configv1.ObjectReference
+		expected []configv1.ObjectReference
+	}{
+		{
+			name:     "no duplicates",
+			input:    []configv1.ObjectReference{{Group: "g1", Resource: "r1", Name: "n1"}, {Group: "g2", Resource: "r2", Name: "n2"}},
+			expected: []configv1.ObjectReference{{Group: "g1", Resource: "r1", Name: "n1"}, {Group: "g2", Resource: "r2", Name: "n2"}},
+		},
+		{
+			name:     "with duplicates",
+			input:    []configv1.ObjectReference{{Group: "g1", Resource: "r1", Name: "n1"}, {Group: "g1", Resource: "r1", Name: "n1"}},
+			expected: []configv1.ObjectReference{{Group: "g1", Resource: "r1", Name: "n1"}},
+		},
+		{
+			name:     "different namespace not duplicate",
+			input:    []configv1.ObjectReference{{Group: "g1", Resource: "r1", Name: "n1", Namespace: "ns1"}, {Group: "g1", Resource: "r1", Name: "n1", Namespace: "ns2"}},
+			expected: []configv1.ObjectReference{{Group: "g1", Resource: "r1", Name: "n1", Namespace: "ns1"}, {Group: "g1", Resource: "r1", Name: "n1", Namespace: "ns2"}},
+		},
+		{
+			name:     "all fields equal",
+			input:    []configv1.ObjectReference{{Group: "g1", Resource: "r1", Name: "n1", Namespace: "ns1"}, {Group: "g1", Resource: "r1", Name: "n1", Namespace: "ns1"}},
+			expected: []configv1.ObjectReference{{Group: "g1", Resource: "r1", Name: "n1", Namespace: "ns1"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := deduplicateObjectReferences(tt.input)
+			if !reflect.DeepEqual(got, tt.expected) {
+				t.Errorf("deduplicateObjectReferences() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Console-operator should be reporting plugin's services and its namespace as relatedObjects, which means that the whole namespace should be scrapped when generating must-gather for debug purposes.
Currently we are only gathering the plugins and not their services.

/assign @TheRealJon @Leo6Leo 