### PR TITLE
RFE-4149: Read only filesystem - temp directory mount

### DIFF
--- a/manifests/07-operator-ibm-cloud-managed.yaml
+++ b/manifests/07-operator-ibm-cloud-managed.yaml
@@ -75,6 +75,8 @@ spec:
           name: serving-cert
         - mountPath: /etc/pki/ca-trust/extracted/pem
           name: trusted-ca
+        - mountPath: /tmp
+          name: temp-dir
       priorityClassName: system-cluster-critical
       securityContext:
         runAsNonRoot: true
@@ -107,3 +109,5 @@ spec:
             path: tls-ca-bundle.pem
           name: trusted-ca
         name: trusted-ca
+      - emptyDir: {}
+        name: temp-dir

--- a/manifests/07-operator.yaml
+++ b/manifests/07-operator.yaml
@@ -66,6 +66,8 @@ spec:
               name: serving-cert
             - mountPath: /etc/pki/ca-trust/extracted/pem
               name: trusted-ca
+            - mountPath: /tmp
+              name: temp-dir
           env:
             - name: CONSOLE_IMAGE
               value: registry.svc.ci.openshift.org/openshift:console
@@ -107,3 +109,5 @@ spec:
             items:
             - key: ca-bundle.crt
               path: tls-ca-bundle.pem
+        - name: temp-dir
+          emptyDir: {}


### PR DESCRIPTION
Add mounted temp dir so that the operator can write temp files, since the container fs is readonly.

This is due to an error encountered:
```
{"container":"console-operator","host":"ip-10-0-113-202.us-east-2.compute.internal","pod":"console-operator-56f7988cd4-25x75","_entry":"F0710 00:51:07.785045       1 cmd.go:182] mkdir /tmp/serving-cert-3208951600: read-only file system"}
```