### PR TITLE
[release-4.18] OCPBUGS-58400: Disable LightSpeed dialog on non amd64

### DIFF
--- a/pkg/console/operator/sync_v400_test.go
+++ b/pkg/console/operator/sync_v400_test.go
@@ -201,13 +201,11 @@ func TestGetNodeComputeEnvironments(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			actualArchitectures, actualOperatingSystems := getNodeComputeEnvironments(tt.nodeList)
 			if diff := deep.Equal(tt.expectedArchitectures, actualArchitectures); diff != nil {
-				t.Error(diff)
-				return
+				t.Errorf("Architecture mismatch: %v", diff)
 			}
 
 			if diff := deep.Equal(tt.expectedOperatingSystems, actualOperatingSystems); diff != nil {
-				t.Error(diff)
-				return
+				t.Errorf("OS mismatch: %v", diff)
 			}
 		})
 	}

--- a/pkg/console/subresource/consoleserver/config_builder.go
+++ b/pkg/console/subresource/consoleserver/config_builder.go
@@ -25,6 +25,10 @@ const (
 	keyFilePath  = "/var/serving-cert/tls.key"
 )
 
+// SupportedLightspeedArchitectures defines the list of architectures that support Lightspeed.
+// Currently only amd64 is supported, but this can be expanded in the future.
+var SupportedLightspeedArchitectures = []string{"amd64"}
+
 // ConsoleServerCLIConfigBuilder
 // Director will be DefaultConfigMap()
 //
@@ -510,7 +514,8 @@ func (b *ConsoleServerCLIConfigBuilder) customization() Customization {
 		conf.Perspectives = perspectives
 	}
 
-	conf.Capabilities = b.capabilities
+	// Apply capabilities configuration. This will configure the capability based on the cluster architecture.
+	conf.Capabilities = b.buildCapabilities()
 
 	return conf
 }
@@ -548,4 +553,47 @@ func (b *ConsoleServerCLIConfigBuilder) proxy() Proxy {
 
 func (b *ConsoleServerCLIConfigBuilder) Telemetry() map[string]string {
 	return b.telemetry
+}
+
+// buildCapabilities will configure the capabilities based on the cluster architecture.
+func (b *ConsoleServerCLIConfigBuilder) buildCapabilities() []operatorv1.Capability {
+	capabilities := b.capabilities
+
+	// Find and configure the LightspeedButton capability
+	for i := range capabilities {
+		if capabilities[i].Name == "LightspeedButton" {
+			if capabilities[i].Visibility.State == operatorv1.CapabilityEnabled && !b.isLightspeedSupportedArchitecture() {
+				capabilities[i].Visibility.State = operatorv1.CapabilityDisabled
+				klog.V(4).Infof("disabling LightspeedButton capability - unsupported or mixed architectures: %v", b.nodeArchitectures)
+			}
+			break
+		}
+	}
+
+	return capabilities
+}
+
+// isLightspeedSupportedArchitecture checks if all cluster architectures support Lightspeed.
+func (b *ConsoleServerCLIConfigBuilder) isLightspeedSupportedArchitecture() bool {
+	// No architectures means disabled
+	if len(b.nodeArchitectures) == 0 {
+		return false
+	}
+
+	// Check if all architectures are supported
+	isSupported := true
+	for _, clusterArch := range b.nodeArchitectures {
+		isSupported = false
+		for _, supportedArch := range SupportedLightspeedArchitectures {
+			if clusterArch == supportedArch {
+				isSupported = true
+				break
+			}
+		}
+		if !isSupported {
+			return false
+		}
+	}
+
+	return isSupported
 }

--- a/pkg/console/subresource/consoleserver/config_builder_test.go
+++ b/pkg/console/subresource/consoleserver/config_builder_test.go
@@ -13,6 +13,23 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+// defaultTestCapabilities represents the default capabilities as defined in the operator manifest
+// This mirrors the configuration in manifests/01-operator-config.yaml
+var defaultTestCapabilities = []v1.Capability{
+	{
+		Name: v1.LightspeedButton,
+		Visibility: v1.CapabilityVisibility{
+			State: v1.CapabilityEnabled,
+		},
+	},
+	{
+		Name: v1.GettingStartedBanner,
+		Visibility: v1.CapabilityVisibility{
+			State: v1.CapabilityEnabled,
+		},
+	},
+}
+
 // Tests that the builder will return a correctly structured
 // Console Server Config struct when builder.Config() is called
 func TestConsoleServerCLIConfigBuilder(t *testing.T) {
@@ -45,11 +62,13 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 				Customization: Customization{},
 				Providers:     Providers{},
 			},
-		}, {
+		},
+		{
 			name: "Config builder should handle customization with LightspeedButton capability",
 			input: func() Config {
 				b := &ConsoleServerCLIConfigBuilder{}
 				return b.
+					NodeArchitectures([]string{"amd64"}).
 					Capabilities([]v1.Capability{
 						{
 							Name: v1.LightspeedButton,
@@ -69,7 +88,8 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 					KeyFile:     keyFilePath,
 				},
 				ClusterInfo: ClusterInfo{
-					ConsoleBasePath: "",
+					ConsoleBasePath:   "",
+					NodeArchitectures: []string{"amd64"},
 				},
 				Auth: Auth{
 					ClientID:         api.OpenShiftConsoleName,
@@ -87,7 +107,8 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 				},
 				Providers: Providers{},
 			},
-		}, {
+		},
+		{
 			name: "Config builder should handle cluster info with internal OAuth",
 			input: func() Config {
 				b := &ConsoleServerCLIConfigBuilder{}
@@ -118,10 +139,19 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 					OAuthEndpointCAFile: "/var/oauth-serving-cert/ca-bundle.crt",
 					LogoutRedirect:      "https://foobar.com/logout",
 				},
-				Customization: Customization{},
-				Providers:     Providers{},
+				Customization: Customization{
+
+					Perspectives: []Perspective{
+						{
+							ID:         "dev",
+							Visibility: PerspectiveVisibility{State: PerspectiveDisabled},
+						},
+					},
+				},
+				Providers: Providers{},
 			},
-		}, {
+		},
+		{
 			name: "Config builder should handle cluster info with external OIDC",
 			input: func() Config {
 				b := &ConsoleServerCLIConfigBuilder{}
@@ -176,7 +206,8 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 				Customization: Customization{},
 				Providers:     Providers{},
 			},
-		}, {
+		},
+		{
 			name: "Config builder should handle monitoring and info",
 			input: func() Config {
 				b := &ConsoleServerCLIConfigBuilder{}
@@ -222,7 +253,8 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 				Customization: Customization{},
 				Providers:     Providers{},
 			},
-		}, {
+		},
+		{
 			name: "Config builder should handle StatuspageID",
 			input: func() Config {
 				b := &ConsoleServerCLIConfigBuilder{}
@@ -1508,7 +1540,7 @@ customization:
   capabilities:
   - name: LightspeedButton
     visibility:
-      state: Enabled
+      state: Disabled
 providers: {}
 `,
 		},
@@ -1517,7 +1549,104 @@ providers: {}
 		t.Run(tt.name, func(t *testing.T) {
 			input, _ := tt.input()
 			if diff := cmp.Diff(tt.output, string(input)); len(diff) > 0 {
+
 				t.Error(diff)
+			}
+		})
+	}
+}
+
+func TestBuildCapabilities(t *testing.T) {
+	tests := []struct {
+		name                 string
+		nodeArchitectures    []string
+		expectedCapabilities []v1.Capability
+	}{
+		{
+			name:              "Homogeneous AMD64 cluster - enables Lightspeed",
+			nodeArchitectures: []string{"amd64"},
+			expectedCapabilities: []v1.Capability{
+				{
+					Name: "LightspeedButton",
+					Visibility: v1.CapabilityVisibility{
+						State: v1.CapabilityEnabled,
+					},
+				},
+				{
+					Name: "GettingStartedBanner",
+					Visibility: v1.CapabilityVisibility{
+						State: v1.CapabilityEnabled,
+					},
+				},
+			},
+		},
+		{
+			name:              "Mixed architecture cluster - disables Lightspeed",
+			nodeArchitectures: []string{"amd64", "ppc64le"},
+			expectedCapabilities: []v1.Capability{
+				{
+					Name: "LightspeedButton",
+					Visibility: v1.CapabilityVisibility{
+						State: v1.CapabilityDisabled,
+					},
+				},
+				{
+					Name: "GettingStartedBanner",
+					Visibility: v1.CapabilityVisibility{
+						State: v1.CapabilityEnabled,
+					},
+				},
+			},
+		},
+		{
+			name:              "Power-only cluster - disables Lightspeed",
+			nodeArchitectures: []string{"ppc64le"},
+			expectedCapabilities: []v1.Capability{
+				{
+					Name: "LightspeedButton",
+					Visibility: v1.CapabilityVisibility{
+						State: v1.CapabilityDisabled,
+					},
+				},
+				{
+					Name: "GettingStartedBanner",
+					Visibility: v1.CapabilityVisibility{
+						State: v1.CapabilityEnabled,
+					},
+				},
+			},
+		},
+		{
+			name:              "Empty node architectures - disables Lightspeed",
+			nodeArchitectures: []string{},
+			expectedCapabilities: []v1.Capability{
+				{
+					Name: "LightspeedButton",
+					Visibility: v1.CapabilityVisibility{
+						State: v1.CapabilityDisabled,
+					},
+				},
+				{
+					Name: "GettingStartedBanner",
+					Visibility: v1.CapabilityVisibility{
+						State: v1.CapabilityEnabled,
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			builder := &ConsoleServerCLIConfigBuilder{
+				nodeArchitectures: tt.nodeArchitectures,
+				capabilities:      defaultTestCapabilities,
+			}
+
+			result := builder.buildCapabilities()
+
+			if diff := deep.Equal(tt.expectedCapabilities, result); diff != nil {
+				t.Errorf("Expected capabilities don't match: %v", diff)
 			}
 		})
 	}


### PR DESCRIPTION
This is an manual cherry-pick of https://github.com/openshift/console-operator/pull/1007