### PR TITLE
OCPBUGS-45300: Wire synced OIDC Auth CM to Console

### DIFF
--- a/pkg/console/subresource/configmap/configmap.go
+++ b/pkg/console/subresource/configmap/configmap.go
@@ -37,7 +37,6 @@ func DefaultConfigMap(
 	operatorConfig *operatorv1.Console,
 	consoleConfig *configv1.Console,
 	authConfig *configv1.Authentication,
-	authServerCAConfig *corev1.ConfigMap,
 	managedConfig *corev1.ConfigMap,
 	monitoringSharedConfig *corev1.ConfigMap,
 	infrastructureConfig *configv1.Infrastructure,

--- a/pkg/console/subresource/configmap/configmap_test.go
+++ b/pkg/console/subresource/configmap/configmap_test.go
@@ -1294,7 +1294,6 @@ providers: {}
 				tt.args.operatorConfig,
 				tt.args.consoleConfig,
 				tt.args.authConfig,
-				tt.args.authServerCAConfig,
 				tt.args.managedConfig,
 				tt.args.monitoringSharedConfig,
 				tt.args.infrastructureConfig,


### PR DESCRIPTION
For OIDC Authentication, the IdP provider TrustedAuthority CM should first be read from the `openshift-config` namespace and synced to the `openshfit-console` namespace. 

This PR:

* Ensures using the correct lister to pull the CM from the target namespace (i.e `openshift-console`)
* Adds a progress condition for tracking any errors getting the CM similar to other resource conditions 