### PR TITLE
OCPBUGS-60863: [Step 1] Rename Dockerfile to Dockerfile.ocp

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -1,0 +1,33 @@
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.24-openshift-4.20 AS builder
+ARG TAGS=ocp
+WORKDIR /go/src/github.com/openshift/console-operator
+COPY . .
+ENV GO_PACKAGE github.com/openshift/console-operator
+RUN go build -ldflags "-X $GO_PACKAGE/pkg/version.versionFromGit=$(git describe --long --tags --abbrev=7 --match 'v[0-9]*')" -tags="${TAGS}" -o console ./cmd/console
+
+FROM registry.ci.openshift.org/ocp/4.20:base-rhel9
+RUN useradd console-operator
+USER console-operator
+COPY --from=builder /go/src/github.com/openshift/console-operator/console /usr/bin/console
+
+# these manifests are necessary for the installer
+COPY manifests /manifests/
+
+# out-of-the-box quickstarts
+COPY quickstarts/*.yaml /manifests/
+
+# extensions manifests generated from openshift/api types
+COPY vendor/github.com/openshift/api/console/v1/zz_generated.crd-manifests/*.crd.yaml /manifests/
+COPY vendor/github.com/openshift/api/operator/*/zz_generated.crd-manifests/*console*.crd.yaml /manifests/
+COPY vendor/github.com/openshift/api/helm/*/zz_generated.crd-manifests/*crd.yaml /manifests/
+
+LABEL io.k8s.display-name="OpenShift console-operator" \
+      io.k8s.description="This is a component of OpenShift Container Platform and manages the lifecycle of the web console." \
+      io.openshift.tags="openshift" \
+      maintainer="Jakub Hadvig <jhadvig@redhat.com>"
+
+LABEL io.openshift.release.operator true
+
+# entrypoint specified in 03-operator.yaml as `console-operator`
+# CMD ["/usr/bin/console", "operator", "--kubeconfig", "path/to/config", "--config", "./install/config.yaml", "--v", "4"]
+# CMD ["/usr/bin/console", "operator", "--v", "4"]

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ docker build -t <registry>/<your-username>/console-operator:<version> .
 # following: docker.io/openshift/origin-console-operator:latest
 # for development, you are going to push to an alternate registry.
 # specifically it can look something like this:
-docker build -f Dockerfile.rhel7 -t quay.io/benjaminapetersen/console-operator:latest .
+docker build -f Dockerfile.ocp -t quay.io/<your-username>/console-operator:latest .
 ```
 You can optionally build a specific version.
 
@@ -187,7 +187,7 @@ Then, push your image:
 ```bash 
 docker push <registry>/<your-username>/console-operator:<version>
 # Be sure your repository is public else the image will not be able to be pulled later
-docker push quay.io/benjaminapetersen/console-operator:latest
+docker push quay.io/<your-username>/console-operator:latest
 ```
 Then, you will want to deploy your new container.  This means duplicating the `manifests/07-operator.yaml`
 and updating the line `image: docker.io/openshift/origin-console-operator:latest` to instead use the
@@ -206,7 +206,7 @@ image: docker.io/openshift/origin-console-operator:latest
 # after 
 # image: <registry>/<your-username>/console-operator:<version>
 replicas: 1
-image: quay.io/benjaminapetersen/console-operator:latest
+image: quay.io/<your-username>/console-operator:latest
 ```
 And ensure that the `imagePullPolicy` is still `Always`.  This will ensure a fast development feedback loop. 
 
@@ -229,9 +229,9 @@ Which looks like the following:
 
 ```bash
 # build binary + container
-docker build -t quay.io/benjaminapetersen/console-operator:latest .
+docker build -t quay.io/<your-username>/console-operator:latest .
 # push container
-docker push quay.io/benjaminapetersen/console-operator:latest
+docker push quay.io/<your-username>/console-operator:latest
 # delete pod, trigger a new pull & deploy
 oc delete pod console-operator --namespace openshift-console-operator
 ```


### PR DESCRIPTION
## Description
Rename Dockerfile from Dockerfile.rhel7 to Dockerfile.ocp. This is the first step, which is duplicating the file. After the PR in openshift/release get merged, we will delete the Dockerifle.rhel7 to ensure nothing will be broken.

/cc @TheRealJon @jhadvig @spadgett 