### PR TITLE
fix(oidc): fix  OIDCClientSecretGet condition

### DIFF
--- a/pkg/console/controllers/oidcsetup/oidcsetup.go
+++ b/pkg/console/controllers/oidcsetup/oidcsetup.go
@@ -200,7 +200,7 @@ func (c *oidcSetupController) syncAuthTypeOIDC(ctx context.Context, authnConfig 
 		return nil
 	}
 
-	clientSecret, err := c.targetNSSecretsLister.Secrets(api.TargetNamespace).Get("console-oauth-config")
+	clientSecret, err := c.targetNSSecretsLister.Secrets(api.OpenShiftConfigNamespace).Get(clientConfig.ClientSecret.Name)
 	if err != nil {
 		c.authStatusHandler.Degraded("OIDCClientSecretGet", err.Error())
 		return err


### PR DESCRIPTION
Since the `Authentication`  resource references CAs and Secrets in the `openshift-config` namespace, its validation should focus on the `openshift-config` namespace.

However the `OIDCClientSecretGet` condition logic checks for the synced client secret, namely `console-oauth-config ` under `openshift-console`, instead of the one referenced by the `Authentication` resource under  `openshift-config`.

This PR fixes this behavior. 