### PR TITLE
CONSOLE-4765: Automate console tech preview flag via cluster FeatureSet

### DIFF
--- a/pkg/console/operator/operator.go
+++ b/pkg/console/operator/operator.go
@@ -67,6 +67,7 @@ type consoleOperator struct {
 	oauthConfigLister    configlistersv1.OAuthLister
 	authnConfigLister    configlistersv1.AuthenticationLister
 	clusterVersionLister configlistersv1.ClusterVersionLister
+	featureGateLister    configlistersv1.FeatureGateLister
 	dynamicClient        dynamic.Interface
 	// core kube
 	secretsClient            coreclientv1.SecretsGetter
@@ -165,6 +166,7 @@ func NewConsoleOperator(
 		proxyConfigLister:     configInformer.Config().V1().Proxies().Lister(),
 		oauthConfigLister:     configInformer.Config().V1().OAuths().Lister(),
 		clusterVersionLister:  configInformer.Config().V1().ClusterVersions().Lister(),
+		featureGateLister:     configInformer.Config().V1().FeatureGates().Lister(),
 		authnConfigLister:     configV1Informers.Authentications().Lister(),
 		// console resources
 		// core kube
@@ -202,6 +204,7 @@ func NewConsoleOperator(
 		configV1Informers.Proxies().Informer(),
 		configV1Informers.OAuths().Informer(),
 		configV1Informers.Authentications().Informer(),
+		configV1Informers.FeatureGates().Informer(),
 	}
 
 	olmGroupVersionResource := schema.GroupVersionResource{
@@ -415,3 +418,4 @@ func (c *consoleOperator) removeConsole(ctx context.Context, operatorConfig *ope
 	statusHandler.AddConditions(statusHandler.ResetConditions(operatorConfig.Status.Conditions))
 	return statusHandler.FlushAndReturn(err)
 }
+

--- a/pkg/console/operator/sync_v400.go
+++ b/pkg/console/operator/sync_v400.go
@@ -125,6 +125,12 @@ func (co *consoleOperator) sync_v400(ctx context.Context, controllerContext fact
 		return statusHandler.FlushAndReturn(customLogosErr)
 	}
 
+	techPreviewEnabled, techPreviewErrReason, techPreviewErr := co.SyncTechPreview()
+	statusHandler.AddConditions(status.HandleProgressingOrDegraded("TechPreviewSync", techPreviewErrReason, techPreviewErr))
+	if techPreviewErr != nil {
+		return statusHandler.FlushAndReturn(techPreviewErr)
+	}
+
 	cm, cmChanged, cmErrReason, cmErr := co.SyncConfigMap(
 		ctx,
 		set.Operator,
@@ -135,6 +141,7 @@ func (co *consoleOperator) sync_v400(ctx context.Context, controllerContext fact
 		consoleRoute,
 		controllerContext.Recorder(),
 		consoleURL.Hostname(),
+		techPreviewEnabled,
 	)
 	toUpdate = toUpdate || cmChanged
 	statusHandler.AddConditions(status.HandleProgressingOrDegraded("ConfigMapSync", cmErrReason, cmErr))
@@ -340,6 +347,7 @@ func (co *consoleOperator) SyncConfigMap(
 	activeConsoleRoute *routev1.Route,
 	recorder events.Recorder,
 	consoleHost string,
+	techPreviewEnabled bool,
 ) (consoleConfigMap *corev1.ConfigMap, changed bool, reason string, err error) {
 
 	managedConfig, mcErr := co.managedNSConfigMapLister.ConfigMaps(api.OpenShiftConfigManagedNamespace).Get(api.OpenShiftConsoleConfigMapName)
@@ -414,6 +422,7 @@ func (co *consoleOperator) SyncConfigMap(
 		co.contentSecurityPolicyEnabled,
 		telemetryConfig,
 		consoleHost,
+		techPreviewEnabled,
 	)
 	if err != nil {
 		return nil, false, "FailedConsoleConfigBuilder", err
@@ -550,6 +559,22 @@ func (co *consoleOperator) SyncTrustedCAConfigMap(ctx context.Context, operatorC
 	}
 	klog.V(4).Infoln("trusted-ca-bundle configmap updated")
 	return actual, true, "", err
+}
+
+// SyncTechPreview determines if tech preview features should be enabled based on cluster FeatureSet
+func (co *consoleOperator) SyncTechPreview() (techPreviewEnabled bool, reason string, err error) {
+	featureGate, err := co.featureGateLister.Get(api.ConfigResourceName)
+	if err != nil {
+		klog.V(4).Infof("failed to get FeatureGate resource: %v", err)
+		return false, "FailedGet", err
+	}
+
+	techPreviewEnabled = featureGate.Spec.FeatureSet == configv1.TechPreviewNoUpgrade
+
+	if techPreviewEnabled {
+		klog.V(4).Infoln("console tech preview features enabled based on cluster FeatureSet TechPreviewNoUpgrade")
+	}
+	return techPreviewEnabled, "", nil
 }
 
 func (co *consoleOperator) SyncCustomLogos(operatorConfig *operatorv1.Console) (error, string) {

--- a/pkg/console/subresource/configmap/configmap.go
+++ b/pkg/console/subresource/configmap/configmap.go
@@ -49,6 +49,7 @@ func DefaultConfigMap(
 	contentSecurityPolicyEnabled bool,
 	telemeterConfig map[string]string,
 	consoleHost string,
+	techPreviewEnabled bool,
 ) (consoleConfigMap *corev1.ConfigMap, unsupportedOverridesHaveMerged bool, err error) {
 
 	apiServerURL := infrastructuresub.GetAPIServerURL(infrastructureConfig)
@@ -65,6 +66,7 @@ func DefaultConfigMap(
 		NodeArchitectures(nodeArchitectures).
 		NodeOperatingSystems(nodeOperatingSystems).
 		CopiedCSVsDisabled(copiedCSVsDisabled).
+		TechPreviewEnabled(techPreviewEnabled).
 		ConfigYAML()
 	if err != nil {
 		klog.Errorf("failed to generate default console-config config: %v", err)
@@ -105,6 +107,7 @@ func DefaultConfigMap(
 		NodeOperatingSystems(nodeOperatingSystems).
 		AuthConfig(authConfig, apiServerURL).
 		Capabilities(operatorConfig.Spec.Customization.Capabilities).
+		TechPreviewEnabled(techPreviewEnabled).
 		ConfigYAML()
 	if err != nil {
 		klog.Errorf("failed to generate user defined console-config config: %v", err)

--- a/pkg/console/subresource/configmap/configmap_test.go
+++ b/pkg/console/subresource/configmap/configmap_test.go
@@ -1306,6 +1306,7 @@ providers: {}
 				tt.args.contentSecurityPolicyEnabled,
 				tt.args.telemetryConfig,
 				tt.args.rt.Spec.Host,
+				false, // techPreviewEnabled - default to false for tests
 			)
 
 			// marshall the exampleYaml to map[string]interface{} so we can use it in diff below

--- a/pkg/console/subresource/configmap/tech_preview_test.go
+++ b/pkg/console/subresource/configmap/tech_preview_test.go
@@ -1,0 +1,122 @@
+package configmap
+
+import (
+	"testing"
+
+	"gopkg.in/yaml.v2"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	configv1 "github.com/openshift/api/config/v1"
+	consolev1 "github.com/openshift/api/console/v1"
+	operatorv1 "github.com/openshift/api/operator/v1"
+	routev1 "github.com/openshift/api/route/v1"
+	"github.com/openshift/console-operator/pkg/console/subresource/consoleserver"
+)
+
+func TestTechPreviewEnabled(t *testing.T) {
+	type args struct {
+		techPreviewEnabled bool
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "Tech preview enabled",
+			args: args{
+				techPreviewEnabled: true,
+			},
+			want: true,
+		},
+		{
+			name: "Tech preview disabled",
+			args: args{
+				techPreviewEnabled: false,
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create minimal test configuration
+			operatorConfig := &operatorv1.Console{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cluster",
+				},
+				Spec: operatorv1.ConsoleSpec{},
+			}
+
+			consoleConfig := &configv1.Console{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cluster",
+				},
+			}
+
+			authConfig := &configv1.Authentication{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cluster",
+				},
+			}
+
+			infrastructureConfig := &configv1.Infrastructure{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cluster",
+				},
+				Status: configv1.InfrastructureStatus{
+					APIServerURL: "https://api.test.cluster:6443",
+				},
+			}
+
+			route := &routev1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "console",
+				},
+				Spec: routev1.RouteSpec{
+					Host: "console.test.cluster",
+				},
+			}
+
+			// Generate configmap with tech preview setting
+			cm, _, err := DefaultConfigMap(
+				operatorConfig,
+				consoleConfig,
+				authConfig,
+				&corev1.ConfigMap{},
+				&corev1.ConfigMap{},
+				infrastructureConfig,
+				route,
+				0,                         // inactivityTimeoutSeconds
+				[]*consolev1.ConsolePlugin{}, // availablePlugins
+				[]string{"amd64"},         // nodeArchitectures
+				[]string{"linux"},         // nodeOperatingSystems
+				false,                     // copiedCSVsDisabled
+				false,                     // contentSecurityPolicyEnabled
+				map[string]string{},       // telemetryConfig
+				"console.test.cluster",    // consoleHost
+				tt.args.techPreviewEnabled,
+			)
+
+			if err != nil {
+				t.Errorf("DefaultConfigMap() error = %v", err)
+				return
+			}
+
+			// Parse the generated config
+			var config consoleserver.Config
+			err = yaml.Unmarshal([]byte(cm.Data["console-config.yaml"]), &config)
+			if err != nil {
+				t.Errorf("Failed to unmarshal config: %v", err)
+				return
+			}
+
+			// Verify tech preview setting
+			if config.ClusterInfo.TechPreviewEnabled != tt.want {
+				t.Errorf("TechPreviewEnabled = %v, want %v", config.ClusterInfo.TechPreviewEnabled, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/console/subresource/consoleserver/config_builder.go
+++ b/pkg/console/subresource/consoleserver/config_builder.go
@@ -83,6 +83,7 @@ type ConsoleServerCLIConfigBuilder struct {
 	contentSecurityPolicyEnabled bool
 	contentSecurityPolicyList    map[v1.DirectiveType][]string
 	logos                        []operatorv1.Logo
+	techPreviewEnabled           bool
 }
 
 func (b *ConsoleServerCLIConfigBuilder) Host(host string) *ConsoleServerCLIConfigBuilder {
@@ -311,6 +312,11 @@ func (b *ConsoleServerCLIConfigBuilder) CopiedCSVsDisabled(copiedCSVsDisabled bo
 	return b
 }
 
+func (b *ConsoleServerCLIConfigBuilder) TechPreviewEnabled(techPreviewEnabled bool) *ConsoleServerCLIConfigBuilder {
+	b.techPreviewEnabled = techPreviewEnabled
+	return b
+}
+
 func (b *ConsoleServerCLIConfigBuilder) Config() Config {
 	return Config{
 		Kind:                         "ConsoleConfig",
@@ -381,6 +387,7 @@ func (b *ConsoleServerCLIConfigBuilder) clusterInfo() ClusterInfo {
 		conf.NodeOperatingSystems = b.nodeOperatingSystems
 	}
 	conf.CopiedCSVsDisabled = b.copiedCSVsDisabled
+	conf.TechPreviewEnabled = b.techPreviewEnabled
 	return conf
 }
 

--- a/pkg/console/subresource/consoleserver/types.go
+++ b/pkg/console/subresource/consoleserver/types.go
@@ -75,6 +75,7 @@ type ClusterInfo struct {
 	NodeArchitectures    []string              `yaml:"nodeArchitectures,omitempty"`
 	NodeOperatingSystems []string              `yaml:"nodeOperatingSystems,omitempty"`
 	CopiedCSVsDisabled   bool                  `yaml:"copiedCSVsDisabled,omitempty"`
+	TechPreviewEnabled   bool                  `yaml:"techPreviewEnabled,omitempty"`
 }
 
 // MonitoringInfo holds configuration for monitoring related services


### PR DESCRIPTION
Implement automatic enabling of console tech preview features when the cluster FeatureSet is configured to TechPreviewNoUpgrade. The console operator now monitors the cluster's FeatureGate resource and sets the TechPreviewEnabled flag in the console-config ConfigMap accordingly.

Key changes:
- Add FeatureGate informer to console operator
- Implement SyncTechPreview function following established patterns
- Add TechPreviewEnabled field to ClusterInfo in console config
- Update config builder to support tech preview flag
- Add comprehensive test coverage

🤖 Generated with [Claude Code](https://claude.ai/code)