### PR TITLE
OCPBUGS-61483: Update DEFAULT_DOC_URL to point to OpenShift Container Platform 4.21

### DIFF
--- a/pkg/console/subresource/configmap/brand_ocp.go
+++ b/pkg/console/subresource/configmap/brand_ocp.go
@@ -5,5 +5,5 @@ package configmap
 
 const (
 	DEFAULT_BRAND   = "ocp"
-	DEFAULT_DOC_URL = "https://access.redhat.com/documentation/en-us/openshift_container_platform/4.20/"
+	DEFAULT_DOC_URL = "https://access.redhat.com/documentation/en-us/openshift_container_platform/4.21/"
 )


### PR DESCRIPTION
## Description
Currently documentationBaseURL still points to 4.20, this PR serves to update the link.