### PR TITLE
CNTRLPLANE-947: Make oauthclients relatedObject dynamic depending on auth type

### DIFF
--- a/pkg/console/starter/starter.go
+++ b/pkg/console/starter/starter.go
@@ -440,7 +440,6 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 			{Group: configv1.GroupName, Resource: "infrastructures", Name: api.ConfigResourceName},
 			{Group: configv1.GroupName, Resource: "proxies", Name: api.ConfigResourceName},
 			{Group: configv1.GroupName, Resource: "oauths", Name: api.ConfigResourceName},
-			{Group: oauth.GroupName, Resource: "oauthclients", Name: api.OAuthClientName},
 			{Group: corev1.GroupName, Resource: "namespaces", Name: api.OpenShiftConsoleOperatorNamespace},
 			{Group: corev1.GroupName, Resource: "namespaces", Name: api.OpenShiftConsoleNamespace},
 			{Group: corev1.GroupName, Resource: "configmaps", Name: api.OpenShiftConsolePublicConfigMapName, Namespace: api.OpenShiftConfigManagedNamespace},
@@ -489,6 +488,18 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 					})
 				}
 			}
+		}
+
+		authn, err := configInformers.Config().V1().Authentications().Lister().Get("cluster")
+		if err != nil {
+			return false, nil
+		}
+		switch authn.Spec.Type {
+		case "", configv1.AuthenticationTypeIntegratedOAuth:
+			relatedObjects = append(relatedObjects, configv1.ObjectReference{
+				Group:    oauth.GroupName,
+				Resource: "oauthclients",
+				Name:     api.OAuthClientName})
 		}
 
 		return true, deduplicateObjectReferences(relatedObjects)


### PR DESCRIPTION
This PR moves `oauthclients` operator relatedObject to the dynamic func as it depends on whether OAuth is configured or not (i.e. in OIDC, there is no oauthclients API).

This will also prevent [this cluster operators e2e test](https://github.com/openshift/origin/blob/92f0f58072daeecaf367e181fca17afebd395d6e/test/extended/operators/clusteroperators.go#L81) from failing when OIDC is configured.

Example failed run of conformance suite with OIDC configured: https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/66981/rehearse-66981-periodic-ci-openshift-cluster-authentication-operator-release-4.21-periodics-e2e-aws-external-oidc-conformance-parallel-techpreview/1970076671268622336