### PR TITLE
CNTRLPLANE-1544: manifest: Use restricted-v3 scc for the operator

### DIFF
--- a/manifests/07-operator-ibm-cloud-managed.yaml
+++ b/manifests/07-operator-ibm-cloud-managed.yaml
@@ -17,7 +17,7 @@ spec:
   template:
     metadata:
       annotations:
-        openshift.io/required-scc: restricted-v2
+        openshift.io/required-scc: restricted-v3
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         name: console-operator
@@ -75,6 +75,7 @@ spec:
           name: serving-cert
         - mountPath: /etc/pki/ca-trust/extracted/pem
           name: trusted-ca
+      hostUsers: false
       priorityClassName: system-cluster-critical
       securityContext:
         runAsNonRoot: true

--- a/manifests/07-operator.yaml
+++ b/manifests/07-operator.yaml
@@ -17,7 +17,7 @@ spec:
     metadata:
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
-        openshift.io/required-scc: restricted-v2
+        openshift.io/required-scc: restricted-v3
       labels:
         name: console-operator
     spec:
@@ -39,6 +39,7 @@ spec:
           operator: "Exists"
           effect: "NoExecute"
           tolerationSeconds: 120
+      hostUsers: false
       priorityClassName: system-cluster-critical
       serviceAccountName: console-operator
       containers:


### PR DESCRIPTION
This effectively enforces user namespaces.