### PR TITLE
OCPBUGS-61432: fix(oidc): fix OIDC client secret lookup, validation, and condition cleanup

### DIFF
--- a/pkg/console/operator/sync_v400.go
+++ b/pkg/console/operator/sync_v400.go
@@ -117,6 +117,9 @@ func (co *consoleOperator) sync_v400(ctx context.Context, controllerContext fact
 		if err != nil {
 			return statusHandler.FlushAndReturn(err)
 		}
+	default:
+		// Clear OIDC-related conditions when auth type is not OIDC
+		statusHandler.AddConditions(status.HandleProgressingOrDegraded("OIDCProviderTrustedAuthorityConfigGet", "", nil))
 	}
 
 	customLogosErr, customLogosErrReason := co.SyncCustomLogos(updatedOperatorConfig)

--- a/pkg/console/starter/starter.go
+++ b/pkg/console/starter/starter.go
@@ -296,6 +296,7 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 		configClient.ConfigV1().Authentications(),
 		operatorConfigInformers.Operator().V1().Consoles(),
 		kubeInformersConfigNamespaced.Core().V1().ConfigMaps(),
+		kubeInformersConfigNamespaced.Core().V1().Secrets(),
 		kubeInformersNamespaced.Core().V1().Secrets(),
 		kubeInformersNamespaced.Core().V1().ConfigMaps(),
 		kubeInformersNamespaced.Apps().V1().Deployments(),


### PR DESCRIPTION
This PR addresses three issues related to OIDC authentication:

1. Fixed OIDC client secret lookup in oidcsetup controller to use the correct informer (configSecretsLister), namespace (openshift-config), and dynamic secret name from the Authentication CR, instead of hardcoded values.

2. Fixed secret revision validation to compare the TARGET secret (openshift-console/console-oauth-config) with the deployment annotation, following the same pattern as ConfigMap CA trust validation. This ensures proper verification of secret sync status.

3. Added condition cleanup in sync_v400 to properly clear the OIDCProviderTrustedAuthorityConfigGet degraded condition when authentication type changes from OIDC to non-OIDC (e.g., IntegratedOAuth). This prevents the Console Operator from remaining in a Degraded state indefinitely during rollback scenarios.