### PR TITLE
CNF-23047: Migrate away from deprecated ioutil

### DIFF
--- a/test/e2e/metrics_test.go
+++ b/test/e2e/metrics_test.go
@@ -6,7 +6,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -104,7 +104,7 @@ func metricsRequest(t *testing.T, routeForMetrics string) string {
 		}
 
 		defer resp.Body.Close()
-		bytes, err = ioutil.ReadAll(resp.Body)
+		bytes, err = io.ReadAll(resp.Body)
 		if err != nil {
 			t.Logf("error reading metrics response: %s\n", err)
 			return false, err

--- a/tools/import-verifier/import-verifier.go
+++ b/tools/import-verifier/import-verifier.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -303,7 +302,7 @@ func mergePackages(existingPackages, currPackages []Package) []Package {
 }
 
 func loadImportRestrictions(configFile string) ([]ImportRestriction, error) {
-	config, err := ioutil.ReadFile(configFile)
+	config, err := os.ReadFile(configFile)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load configuration from %s: %v", configFile, err)
 	}


### PR DESCRIPTION
`ioutil` has been deprecated since Go 1.16: https://go.dev/doc/go1.16#ioutil

Tracking issue: https://github.com/redhat-best-practices-for-k8s/telco-bot/issues/52

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Modernized internal file-reading and cleaned up imports to remove deprecated usage; no behavioral changes or public API impact.
* **Tests**
  * Updated end-to-end metrics test to use current reading APIs and refreshed imports so tests align with the modernized code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->