### PR TITLE
MON-4510: Migrate Prometheus targets discovering from Endpoints to EndpointSlices

### DIFF
--- a/manifests/0000_90_console-operator_01_prometheusrbac.yaml
+++ b/manifests/0000_90_console-operator_01_prometheusrbac.yaml
@@ -21,6 +21,14 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - list
+      - watch
 ---
 # Grant cluster-monitoring access to console-operator metrics
 apiVersion: rbac.authorization.k8s.io/v1

--- a/manifests/0000_90_console-operator_02_servicemonitor.yaml
+++ b/manifests/0000_90_console-operator_02_servicemonitor.yaml
@@ -26,4 +26,5 @@ spec:
   selector:
     matchLabels:
       name: console-operator
+  serviceDiscoveryRole: EndpointSlice
 

--- a/manifests/0000_90_console_01_prometheusrbac.yaml
+++ b/manifests/0000_90_console_01_prometheusrbac.yaml
@@ -21,6 +21,14 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - list
+      - watch
 ---
 # Grant cluster-monitoring access to console metrics
 apiVersion: rbac.authorization.k8s.io/v1

--- a/manifests/0000_90_console_02_servicemonitor.yaml
+++ b/manifests/0000_90_console_02_servicemonitor.yaml
@@ -26,3 +26,4 @@ spec:
   selector:
     matchLabels:
       app: console
+  serviceDiscoveryRole: EndpointSlice


### PR DESCRIPTION
This PR migrates Prometheus service discovery from the deprecated Endpoints API to the EndpointSlices API, by:

- Setting `serviceDiscoveryRole: EndpointSlice` on ServiceMonitors.
- Granting Prometheus `endpointslices` permissions.

We're taking a conservative approach by keeping the existing `endpoints` permissions alongside the new `endpointslices` ones. This provides a safety net in case any ServiceMonitors, whether deployed from this repo or from another source, still rely on the same Role and were missed during the migration.

That said, since both resources provide essentially the same data, keeping both isn't meaningfully more permissive from a security standpoint.

**These changes target OpenShift 4.22+ and should not be backported to earlier releases.**

Due to the scope of changes across multiple repositories, these modifications were generated with Claude assistance.
