### PR TITLE
OCPBUGS-74872: Sort plugin list to make them deterministic

### DIFF
--- a/pkg/console/subresource/configmap/configmap.go
+++ b/pkg/console/subresource/configmap/configmap.go
@@ -179,6 +179,8 @@ func pluginsWithI18nNamespace(availablePlugins []*v1.ConsolePlugin) []string {
 			i18nNamespaces = append(i18nNamespaces, fmt.Sprintf("plugin__%s", plugin.Name))
 		}
 	}
+	// Sort to ensure deterministic YAML output
+	sort.Strings(i18nNamespaces)
 	return i18nNamespaces
 }
 
@@ -192,6 +194,9 @@ func getPluginsEndpointMap(availablePlugins []*v1.ConsolePlugin) map[string]stri
 			klog.Errorf("unknown backend type for %q plugin: %q. Currently only %q backend type is supported.", plugin.Name, plugin.Spec.Backend.Type, v1.Service)
 		}
 	}
+	// Note: Here the YAML output is deterministic because:
+	// - availablePlugins are sorted by name in GetAvailablePlugins()
+	// - sigs.k8s.io/yaml uses json.Marshal which sorts map keys
 	return pluginsEndpointMap
 }
 
@@ -214,6 +219,10 @@ func getPluginsProxyServices(availablePlugins []*v1.ConsolePlugin) []consoleserv
 			}
 		}
 	}
+	// Sort by ConsoleAPIPath to ensure deterministic YAML output
+	sort.Slice(proxyServices, func(i, j int) bool {
+		return proxyServices[i].ConsoleAPIPath < proxyServices[j].ConsoleAPIPath
+	})
 	return proxyServices
 }
 

--- a/pkg/console/subresource/configmap/configmap_test.go
+++ b/pkg/console/subresource/configmap/configmap_test.go
@@ -979,9 +979,9 @@ providers: {}
 				},
 				inactivityTimeoutSeconds: 0,
 				availablePlugins: []*consolev1.ConsolePlugin{
+					testPluginsWithI18nPreloadType("plugin3", "service3", "service-namespace3"),
 					testPluginsWithProxy("plugin1", "service1", "service-namespace1"),
 					testPluginsWithProxy("plugin2", "service2", "service-namespace2"),
-					testPluginsWithI18nPreloadType("plugin3", "service3", "service-namespace3"),
 				},
 			},
 			want: &corev1.ConfigMap{
@@ -1626,6 +1626,106 @@ func TestAggregateCSPDirectives(t *testing.T) {
 				t.Error(diff)
 				t.Errorf("Got: %v \n", result)
 				t.Errorf("Want: %v \n", tt.output)
+			}
+		})
+	}
+}
+
+func TestPluginsWithI18nNamespaceSorting(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  []*consolev1.ConsolePlugin
+		output []string
+	}{
+		{
+			name: "Returns sorted i18n namespaces from unsorted plugins",
+			input: []*consolev1.ConsolePlugin{
+				testPluginsWithI18nPreloadType("zeta-plugin", "svc-z", "ns-z"),
+				testPluginsWithI18nPreloadType("alpha-plugin", "svc-a", "ns-a"),
+				testPluginsWithI18nPreloadType("mu-plugin", "svc-m", "ns-m"),
+			},
+			output: []string{
+				"plugin__alpha-plugin",
+				"plugin__mu-plugin",
+				"plugin__zeta-plugin",
+			},
+		},
+		{
+			name: "Skips plugins without Preload i18n type",
+			input: []*consolev1.ConsolePlugin{
+				testPluginsWithI18nPreloadType("zeta-plugin", "svc-z", "ns-z"),
+				testPlugins("beta-plugin", "svc-b", "ns-b"),
+				testPluginsWithI18nPreloadType("alpha-plugin", "svc-a", "ns-a"),
+			},
+			output: []string{
+				"plugin__alpha-plugin",
+				"plugin__zeta-plugin",
+			},
+		},
+		{
+			name:   "Returns empty slice for no plugins",
+			input:  []*consolev1.ConsolePlugin{},
+			output: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := pluginsWithI18nNamespace(tt.input)
+			if diff := deep.Equal(tt.output, result); diff != nil {
+				t.Error(diff)
+			}
+		})
+	}
+}
+
+func TestGetPluginsProxyServicesSorting(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  []*consolev1.ConsolePlugin
+		output []string
+	}{
+		{
+			name: "Returns proxy services sorted by ConsoleAPIPath from unsorted plugins",
+			input: []*consolev1.ConsolePlugin{
+				testPluginsWithProxy("zeta-plugin", "svc-z", "ns-z"),
+				testPluginsWithProxy("alpha-plugin", "svc-a", "ns-a"),
+				testPluginsWithProxy("mu-plugin", "svc-m", "ns-m"),
+			},
+			output: []string{
+				"/api/proxy/plugin/alpha-plugin/alpha-plugin-alias/",
+				"/api/proxy/plugin/mu-plugin/mu-plugin-alias/",
+				"/api/proxy/plugin/zeta-plugin/zeta-plugin-alias/",
+			},
+		},
+		{
+			name: "Returns sorted proxy services when plugins have no proxies mixed in",
+			input: []*consolev1.ConsolePlugin{
+				testPluginsWithProxy("zeta-plugin", "svc-z", "ns-z"),
+				testPlugins("beta-plugin", "svc-b", "ns-b"),
+				testPluginsWithProxy("alpha-plugin", "svc-a", "ns-a"),
+			},
+			output: []string{
+				"/api/proxy/plugin/alpha-plugin/alpha-plugin-alias/",
+				"/api/proxy/plugin/zeta-plugin/zeta-plugin-alias/",
+			},
+		},
+		{
+			name:   "Returns empty slice for no plugins",
+			input:  []*consolev1.ConsolePlugin{},
+			output: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := getPluginsProxyServices(tt.input)
+			actualPaths := make([]string, len(result))
+			for i, ps := range result {
+				actualPaths[i] = ps.ConsoleAPIPath
+			}
+			if diff := deep.Equal(tt.output, actualPaths); diff != nil {
+				t.Error(diff)
 			}
 		})
 	}


### PR DESCRIPTION
**Problem**
After enabling console plugins (particularly odf-console), the Console Operator gets stuck in a reconciliation loop with repeated console-config ConfigMap updates, causing console pods to restart every few minutes.

**Root Cause**
Non-deterministic YAML generation in the ConfigMap. Plugin-related data structures weren't consistently ordered, causing the ConfigMap content to vary between reconciliation cycles even when no actual changes occurred.

**Solution**
Fixed plugin data ordering:
- Sort i18nNamespaces and proxyServices slices for deterministic output
- Sort availablePlugins by name before processing

**Added retry logic:**
Wrap ApplyConfigMap() with retry.RetryOnConflict() to handle concurrent updates


/assign @TheRealJon 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ConfigMap update resilience with automatic retry on conflicts.
  * Fixed non-deterministic ordering of plugins and i18n namespaces to ensure consistent, predictable behavior.
  * Enhanced proxy service processing reliability through deterministic sorting.

* **Tests**
  * Added test coverage for plugin sorting and i18n namespace ordering verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->