### PR TITLE
OCPBUGS-77026: DNS optimization, add trailing dots

### DIFF
--- a/pkg/console/subresource/configmap/configmap.go
+++ b/pkg/console/subresource/configmap/configmap.go
@@ -231,7 +231,7 @@ func getProxyAuthorization(authorizationType v1.AuthorizationType) bool {
 func getProxyServiceURL(service *v1.ConsolePluginProxyServiceConfig) string {
 	pluginURL := &url.URL{
 		Scheme: "https",
-		Host:   fmt.Sprintf("%s.%s.svc.cluster.local:%d", service.Name, service.Namespace, service.Port),
+		Host:   fmt.Sprintf("%s.%s.svc.cluster.local.:%d", service.Name, service.Namespace, service.Port),
 	}
 	return pluginURL.String()
 }
@@ -239,7 +239,7 @@ func getProxyServiceURL(service *v1.ConsolePluginProxyServiceConfig) string {
 func getServiceURL(pluginBackend *v1.ConsolePluginBackend) string {
 	pluginURL := &url.URL{
 		Scheme: "https",
-		Host:   fmt.Sprintf("%s.%s.svc.cluster.local:%d", pluginBackend.Service.Name, pluginBackend.Service.Namespace, pluginBackend.Service.Port),
+		Host:   fmt.Sprintf("%s.%s.svc.cluster.local.:%d", pluginBackend.Service.Name, pluginBackend.Service.Namespace, pluginBackend.Service.Port),
 		Path:   pluginBackend.Service.BasePath,
 	}
 	return pluginURL.String()

--- a/pkg/console/subresource/configmap/configmap_test.go
+++ b/pkg/console/subresource/configmap/configmap_test.go
@@ -1027,9 +1027,9 @@ servingInfo:
   keyFile: /var/serving-cert/tls.key
 providers: {}
 plugins:
-  plugin1: https://service1.service-namespace1.svc.cluster.local:8443/
-  plugin2: https://service2.service-namespace2.svc.cluster.local:8443/
-  plugin3: https://service3.service-namespace3.svc.cluster.local:8443/
+  plugin1: https://service1.service-namespace1.svc.cluster.local.:8443/
+  plugin2: https://service2.service-namespace2.svc.cluster.local.:8443/
+  plugin3: https://service3.service-namespace3.svc.cluster.local.:8443/
 proxy:
   services:
   - authorize: true
@@ -1049,7 +1049,7 @@ nV5cXbp9W1bC12Tc8nnNXn4ypLE2JTQAvyp51zoZ8hQoSnRVx/VCY55Yu+br8gQZ` + "\n" + `
 +tW+O/PoE7B3tuY=` + "\n" + `
 -----END CERTIFICATE-----'
     consoleAPIPath: /api/proxy/plugin/plugin1/plugin1-alias/
-    endpoint: https://proxy-service1.proxy-service-namespace1.svc.cluster.local:9991
+    endpoint: https://proxy-service1.proxy-service-namespace1.svc.cluster.local.:9991
   - authorize: true
     caCertificate: '-----BEGIN CERTIFICATE-----` + "\n" + `
 MIICRzCCAfGgAwIBAgIJAIydTIADd+yqMA0GCSqGSIb3DQEBCwUAMH4xCzAJBgNV` + "\n" + `
@@ -1067,7 +1067,7 @@ nV5cXbp9W1bC12Tc8nnNXn4ypLE2JTQAvyp51zoZ8hQoSnRVx/VCY55Yu+br8gQZ` + "\n" + `
 +tW+O/PoE7B3tuY=` + "\n" + `
 -----END CERTIFICATE-----'
     consoleAPIPath: /api/proxy/plugin/plugin2/plugin2-alias/
-    endpoint: https://proxy-service2.proxy-service-namespace2.svc.cluster.local:9991
+    endpoint: https://proxy-service2.proxy-service-namespace2.svc.cluster.local.:9991
 `,
 				},
 			},

--- a/test/e2e/plugins_test.go
+++ b/test/e2e/plugins_test.go
@@ -21,7 +21,7 @@ import (
 const (
 	availablePluginName           = "test-plugin"
 	unavailablePluginName         = "missing-test-plugin"
-	expectedPluginServiceEndpoint = "https://test-plugin-service-name.test-plugin-service-namespace.svc.cluster.local:8443/manifest"
+	expectedPluginServiceEndpoint = "https://test-plugin-service-name.test-plugin-service-namespace.svc.cluster.local.:8443/manifest"
 	expectedPluginNamespace       = "plugin__test-plugin"
 )
 


### PR DESCRIPTION
Update getProxyServiceURL and getServiceURL to generate URLs with trailing dots, such as
"my-service.my-namespace.svc.cluster.local.:3000", which makes it unambiguous to the DNS resolver, speeding up DNS resolution by avoiding unnecessary queries.