### PR TITLE
CONSOLE-5204: Add PR template

### DIFF
--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -1,0 +1,48 @@
+<!--
+  Please fill in every section below before requesting review. Filled-in descriptions are
+  required for the OpenShift Console team to triage the pull request, review the code, and
+  verify the behavior end-to-end.
+
+  The pull request title must be prefixed with a Jira issue in order to be merged. For example:
+
+  For e.g Features: https://redhat.atlassian.net/browse/CONSOLE-XXXX
+  - CONSOLE-XXXX: <title>
+  For e.g Jira Bug Fixes: https://redhat.atlassian.net/browse/OCPBUGS-XXXX
+  - OCPBUGS-XXXX: <title>
+-->
+
+**Analysis / Root cause**:
+<!-- Briefly describe analysis of US/Task or root cause of Defect -->
+
+**Solution description**:
+<!-- Describe your code changes in detail and explain the solution or functionality -->
+
+**Test setup:**
+<!-- If any setup required to test this PR, mention the details -->
+
+**Test cases:**
+<!-- List possible test cases to validate the changes. -->
+
+**Browser conformance**:
+<!-- To mark tested browsers, use [x] -->
+- [ ] Chrome
+- [ ] Firefox
+- [ ] Safari (or Epiphany on Linux)
+
+**Additional info:**
+<!-- Add any additional info here -->
+
+**Reviewers and assignees:**
+<!--
+- Tag an OCP console engineer to review the changes and verify the functionality.
+- If there are visual, content, or interaction changes in the PR, tag "@openshift/team-ux-review"
+- If the PR is implementing a story, assign Docs, and PX approvers:
+  Console Approver:
+  /assign <gh-user>
+
+  Docs approver:
+  /assign <gh-user>
+
+  PX approver:
+  /assign <gh-user>
+-->


### PR DESCRIPTION
Copied from console https://github.com/openshift/console/pull/16287

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a standardized pull request template that enforces Jira-prefixed titles, requires filled sections for analysis/root cause and solution, captures explicit test setup and test cases, includes browser conformance checkboxes (Chrome/Firefox/Safari), and provides reviewer/assignee guidance and assignment placeholders.

* **Note**
  * This is an internal process improvement with no direct impact on end-user functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->