### PR TITLE
OCPBUGS-84254: Redeploy console pods upon cert rotation

### DIFF
--- a/pkg/console/operator/operator.go
+++ b/pkg/console/operator/operator.go
@@ -247,7 +247,7 @@ func NewConsoleOperator(
 		factory.NamesFilter(api.OAuthClientName),
 		oauthClientSwitchedInformer.Informer(),
 	).WithFilteredEventsInformers(
-		util.IncludeNamesFilter(deployment.ConsoleOauthConfigName),
+		util.IncludeNamesFilter(deployment.ConsoleOauthConfigName, api.ConsoleServingCertName),
 		secretsInformer.Informer(),
 	).WithFilteredEventsInformers(
 		util.IncludeNamesFilter(telemetry.TelemetryConfigMapName),

--- a/pkg/console/operator/sync_v400.go
+++ b/pkg/console/operator/sync_v400.go
@@ -176,6 +176,12 @@ func (co *consoleOperator) sync_v400(ctx context.Context, controllerContext fact
 		return statusHandler.FlushAndReturn(secErr)
 	}
 
+	consoleServingCertSecret, servingCertErr := co.secretsLister.Secrets(api.TargetNamespace).Get(api.ConsoleServingCertName)
+	statusHandler.AddConditions(status.HandleProgressingOrDegraded("ConsoleServingCertSecretGet", "FailedGet", servingCertErr))
+	if servingCertErr != nil {
+		return statusHandler.FlushAndReturn(servingCertErr)
+	}
+
 	actualDeployment, depChanged, depErrReason, depErr := co.SyncDeployment(
 		ctx,
 		set.Operator,
@@ -186,6 +192,7 @@ func (co *consoleOperator) sync_v400(ctx context.Context, controllerContext fact
 		trustedCAConfigMap,
 		clientSecret,
 		sessionSecret,
+		consoleServingCertSecret,
 		set.Proxy,
 		set.Infrastructure,
 		controllerContext.Recorder(),
@@ -289,6 +296,7 @@ func (co *consoleOperator) SyncDeployment(
 	trustedCAConfigMap *corev1.ConfigMap,
 	sec *corev1.Secret,
 	sessionSecret *corev1.Secret,
+	consoleServingCertSecret *corev1.Secret,
 	proxyConfig *configv1.Proxy,
 	infrastructureConfig *configv1.Infrastructure,
 	recorder events.Recorder,
@@ -303,6 +311,7 @@ func (co *consoleOperator) SyncDeployment(
 		trustedCAConfigMap,
 		sec,
 		sessionSecret,
+		consoleServingCertSecret,
 		proxyConfig,
 		infrastructureConfig,
 	)

--- a/pkg/console/subresource/deployment/deployment.go
+++ b/pkg/console/subresource/deployment/deployment.go
@@ -39,6 +39,7 @@ const (
 	authnConfigVersionAnnotation                   = "console.openshift.io/authentication-config-version"
 	authnCATrustConfigMapResourceVersionAnnotation = "console.openshift.io/authn-ca-trust-config-version"
 	sessionSecretRVAnnotation                      = "console.openshift.io/session-secret-version"
+	servingCertSecretResourceVersionAnnotation     = "console.openshift.io/serving-cert-secret-version"
 )
 
 var (
@@ -51,6 +52,7 @@ var (
 		trustedCAConfigMapResourceVersionAnnotation,
 		secretResourceVersionAnnotation,
 		consoleImageAnnotation,
+		servingCertSecretResourceVersionAnnotation,
 	}
 )
 
@@ -73,6 +75,7 @@ func DefaultDeployment(
 	trustedCAConfigMap *corev1.ConfigMap,
 	oAuthClientSecret *corev1.Secret,
 	sessionSecret *corev1.Secret,
+	consoleServingCertSecret *corev1.Secret,
 	proxyConfig *configv1.Proxy,
 	infrastructureConfig *configv1.Infrastructure,
 ) *appsv1.Deployment {
@@ -93,6 +96,7 @@ func DefaultDeployment(
 		trustedCAConfigMap,
 		oAuthClientSecret,
 		sessionSecret,
+		consoleServingCertSecret,
 		proxyConfig,
 		infrastructureConfig,
 	)
@@ -200,6 +204,7 @@ func withConsoleAnnotations(
 	trustedCAConfigMap *corev1.ConfigMap,
 	oAuthClientSecret *corev1.Secret,
 	sessionSecret *corev1.Secret,
+	consoleServingCertSecret *corev1.Secret,
 	proxyConfig *configv1.Proxy,
 	infrastructureConfig *configv1.Infrastructure,
 ) {
@@ -211,6 +216,7 @@ func withConsoleAnnotations(
 		infrastructureConfigResourceVersionAnnotation: infrastructureConfig.GetResourceVersion(),
 		secretResourceVersionAnnotation:               oAuthClientSecret.GetResourceVersion(),
 		consoleImageAnnotation:                        util.GetImageEnv("CONSOLE_IMAGE"),
+		servingCertSecretResourceVersionAnnotation:    consoleServingCertSecret.GetResourceVersion(),
 	}
 
 	if authServerCAConfigMap != nil {

--- a/pkg/console/subresource/deployment/deployment_test.go
+++ b/pkg/console/subresource/deployment/deployment_test.go
@@ -675,6 +675,83 @@ func TestWithConsoleAnnotations(t *testing.T) {
 	}
 }
 
+func TestServingCertAnnotationChangesOnRotation(t *testing.T) {
+	consoleConfigMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{ResourceVersion: "1"},
+	}
+	serviceCAConfigMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{ResourceVersion: "2"},
+	}
+	trustedCAConfigMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{ResourceVersion: "3"},
+	}
+	oAuthClientSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{ResourceVersion: "4"},
+	}
+	proxyConfig := &configv1.Proxy{
+		ObjectMeta: metav1.ObjectMeta{ResourceVersion: "5"},
+	}
+	infrastructureConfig := &configv1.Infrastructure{
+		ObjectMeta: metav1.ObjectMeta{ResourceVersion: "6"},
+	}
+
+	makeDeployment := func() *appsv1.Deployment {
+		return &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{}},
+			Spec: appsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{}},
+				},
+			},
+		}
+	}
+
+	oldCert := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{ResourceVersion: "111111"},
+	}
+	newCert := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{ResourceVersion: "222222"},
+	}
+
+	depBefore := makeDeployment()
+	withConsoleAnnotations(depBefore, consoleConfigMap, serviceCAConfigMap, nil, trustedCAConfigMap, oAuthClientSecret, nil, oldCert, proxyConfig, infrastructureConfig)
+
+	depAfter := makeDeployment()
+	withConsoleAnnotations(depAfter, consoleConfigMap, serviceCAConfigMap, nil, trustedCAConfigMap, oAuthClientSecret, nil, newCert, proxyConfig, infrastructureConfig)
+
+	oldVal := depBefore.ObjectMeta.Annotations[servingCertSecretResourceVersionAnnotation]
+	newVal := depAfter.ObjectMeta.Annotations[servingCertSecretResourceVersionAnnotation]
+
+	if oldVal != "111111" {
+		t.Errorf("expected annotation value '111111' for old cert, got %q", oldVal)
+	}
+	if newVal != "222222" {
+		t.Errorf("expected annotation value '222222' for new cert, got %q", newVal)
+	}
+	if oldVal == newVal {
+		t.Error("annotation value did not change after cert rotation")
+	}
+
+	oldPodVal := depBefore.Spec.Template.ObjectMeta.Annotations[servingCertSecretResourceVersionAnnotation]
+	newPodVal := depAfter.Spec.Template.ObjectMeta.Annotations[servingCertSecretResourceVersionAnnotation]
+	if oldPodVal == newPodVal {
+		t.Error("pod template annotation value did not change after cert rotation — rollout would not be triggered")
+	}
+}
+
+func TestServingCertAnnotationInResourceAnnotations(t *testing.T) {
+	found := false
+	for _, a := range resourceAnnotations {
+		if a == servingCertSecretResourceVersionAnnotation {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("servingCertSecretResourceVersionAnnotation (%q) is not in resourceAnnotations — LogDeploymentAnnotationChanges will not detect cert rotation", servingCertSecretResourceVersionAnnotation)
+	}
+}
+
 func TestWithReplicas(t *testing.T) {
 	var (
 		singleNodeReplicaCount int32 = SingleNodeConsoleReplicas

--- a/test/e2e/cert_rotation_test.go
+++ b/test/e2e/cert_rotation_test.go
@@ -1,0 +1,106 @@
+package e2e
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/openshift/console-operator/pkg/api"
+	"github.com/openshift/console-operator/test/e2e/framework"
+)
+
+const servingCertAnnotation = "console.openshift.io/serving-cert-secret-version"
+
+// TestCertRotationTriggersRollout verifies that deleting the console-serving-cert
+// secret (simulating a service-CA cert rotation) causes the operator to detect
+// the new secret and roll out a new console deployment with the updated
+// resource version annotation.
+func TestCertRotationTriggersRollout(t *testing.T) {
+	client, _ := framework.StandardSetup(t)
+	defer framework.StandardCleanup(t, client)
+
+	// 1. Record the current state of the deployment and secret.
+	deployment, err := framework.GetConsoleDeployment(client)
+	if err != nil {
+		t.Fatalf("failed to get console deployment: %v", err)
+	}
+	oldAnnotation := deployment.Spec.Template.ObjectMeta.Annotations[servingCertAnnotation]
+	oldGeneration := deployment.ObjectMeta.Generation
+	t.Logf("before rotation: annotation=%q, generation=%d", oldAnnotation, oldGeneration)
+
+	oldSecret, err := client.Core.Secrets(api.TargetNamespace).Get(context.TODO(), api.ConsoleServingCertName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("failed to get console-serving-cert secret: %v", err)
+	}
+	oldSecretRV := oldSecret.ResourceVersion
+	t.Logf("before rotation: secret resourceVersion=%q", oldSecretRV)
+
+	// 2. Delete the secret to trigger service-CA to regenerate it with a new resourceVersion.
+	t.Log("deleting console-serving-cert secret to simulate cert rotation...")
+	err = client.Core.Secrets(api.TargetNamespace).Delete(context.TODO(), api.ConsoleServingCertName, metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatalf("failed to delete console-serving-cert secret: %v", err)
+	}
+
+	// 3. Wait for the secret to be recreated by service-CA with a new resourceVersion.
+	t.Log("waiting for service-CA to recreate the secret...")
+	var newSecretRV string
+	err = wait.PollImmediate(2*time.Second, framework.AsyncOperationTimeout, func() (bool, error) {
+		secret, err := client.Core.Secrets(api.TargetNamespace).Get(context.TODO(), api.ConsoleServingCertName, metav1.GetOptions{})
+		if err != nil {
+			return false, nil
+		}
+		if secret.ResourceVersion != oldSecretRV {
+			newSecretRV = secret.ResourceVersion
+			return true, nil
+		}
+		return false, nil
+	})
+	if err != nil {
+		t.Fatalf("timed out waiting for console-serving-cert secret to be recreated: %v", err)
+	}
+	t.Logf("secret recreated with new resourceVersion=%q", newSecretRV)
+
+	// 4. Wait for the operator to reconcile and update the deployment annotation.
+	t.Log("waiting for operator to update deployment annotation...")
+	err = wait.PollImmediate(2*time.Second, framework.AsyncOperationTimeout, func() (bool, error) {
+		dep, err := framework.GetConsoleDeployment(client)
+		if err != nil {
+			return false, nil
+		}
+		currentAnnotation := dep.Spec.Template.ObjectMeta.Annotations[servingCertAnnotation]
+		return currentAnnotation != oldAnnotation && currentAnnotation != "", nil
+	})
+	if err != nil {
+		t.Fatalf("timed out waiting for deployment annotation to update after cert rotation: %v", err)
+	}
+
+	// 5. Verify the new annotation matches the new secret's resourceVersion.
+	updatedDeployment, err := framework.GetConsoleDeployment(client)
+	if err != nil {
+		t.Fatalf("failed to get updated console deployment: %v", err)
+	}
+	newAnnotation := updatedDeployment.Spec.Template.ObjectMeta.Annotations[servingCertAnnotation]
+	t.Logf("after rotation: annotation=%q, generation=%d", newAnnotation, updatedDeployment.ObjectMeta.Generation)
+
+	if newAnnotation != newSecretRV {
+		t.Errorf("expected deployment annotation %q to match new secret resourceVersion %q", newAnnotation, newSecretRV)
+	}
+
+	if updatedDeployment.ObjectMeta.Generation <= oldGeneration {
+		t.Errorf("expected deployment generation to increase after cert rotation: old=%d, new=%d", oldGeneration, updatedDeployment.ObjectMeta.Generation)
+	}
+
+	// 6. Wait for operator to settle after the rollout.
+	t.Log("waiting for operator to reach settled state...")
+	settled, err := framework.WaitForSettledState(t, client, "cert-rotation")
+	if err != nil {
+		t.Fatalf("operator did not settle after cert rotation: %v", err)
+	}
+	if !settled {
+		t.Error("operator did not reach settled state after cert rotation")
+	}
+}


### PR DESCRIPTION
## Root cause

  When the `console-serving-cert` secret is rotated (by service-ca operator), the console-operator does not detect the change. The console pods continue
   running with the old certificate mounted at `/var/serving-cert`, leading to TLS errors and console unavailability until pods are manually restarted.

  ## Solution

  Register an informer for the `console-serving-cert` secret so the operator watches it for changes. When the secret's `resourceVersion` changes, the
  operator stamps the new value as a `console.openshift.io/serving-cert-secret-version` annotation on the console Deployment, which triggers an
  automatic pod rollout with the new certificate.

  Backport of https://github.com/openshift/console-operator/pull/1093

  ## Test cases

  ### Scenario 1: Verify secret informer registration

  $ oc get secret console-serving-cert -n openshift-console -o jsonpath='{.metadata.resourceVersion}'
  36546
  $ oc get deployment console -n openshift-console -o jsonpath='{.spec.template.metadata.annotations.console.openshift.io/serving-cert-secret-version}'
  36546

  **Expected:** The deployment annotation matches the secret's `resourceVersion`.

  ### Scenario 2: Automatic pod restart on certificate rotation

  Delete the serving cert to simulate rotation

  $ oc delete secret console-serving-cert -n openshift-console

  Wait for service-ca to regenerate it, then verify

  $ oc get secret console-serving-cert -n openshift-console -o jsonpath='{.metadata.resourceVersion}'
  38672

  $ oc get deployment console -n openshift-console -o jsonpath='{.spec.template.metadata.annotations.console.openshift.io/serving-cert-secret-version}'
  38672

  $ oc get pods -n openshift-console
  NAME                         READY   STATUS    RESTARTS   AGE
  console-75d8bfcdf6-6w2wf     1/1     Running   0          55s   <-- redeployed
  console-75d8bfcdf6-9zn7z     1/1     Running   0          55s   <-- redeployed
  downloads-6d94488dc7-rnqts   1/1     Running   0          52m
  downloads-6d94488dc7-tb4bz   1/1     Running   0          52m

  **Expected:** The annotation updates to the new `resourceVersion` and console pods are automatically redeployed. Downloads pods remain untouched.

/assign @Leo6Leo 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved console operator's serving certificate handling to ensure deployments properly track and respond to certificate changes. The operator now monitors serving certificate secrets and automatically triggers deployment updates when certificates are modified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->