### PR TITLE
OPRUN-4591: Add RBAC for console lifecycle-server API access

### DIFF
--- a/manifests/03-rbac-role-cluster-openshift-console-user-operator-lifecycle-reader.yaml
+++ b/manifests/03-rbac-role-cluster-openshift-console-user-operator-lifecycle-reader.yaml
@@ -1,0 +1,45 @@
+# RBAC required for the OpenShift Console to access the lifecycle-server API.
+#
+# The lifecycle-server authenticates callers via TokenReview and authorizes
+# them via SubjectAccessReview on nonResourceURLs. The console backend uses
+# its pod ServiceAccount token to authenticate, so that SA needs permission
+# to GET the lifecycle API paths.
+#
+# These resources should be managed by the console-operator. They are
+# provided here as a reference for development and testing.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:openshift:console:lifecycle-reader
+  annotations:
+    release.openshift.io/feature-set: "TechPreviewNoUpgrade"
+    include.release.openshift.io/hypershift: "true"
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    capability.openshift.io/name: Console
+rules:
+  - nonResourceURLs:
+      - "/api/*/lifecycles/*"
+    verbs:
+      - "get"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: console-lifecycle-reader
+  annotations:
+    release.openshift.io/feature-set: "TechPreviewNoUpgrade"
+    include.release.openshift.io/hypershift: "true"
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    capability.openshift.io/name: Console
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:console:lifecycle-reader
+subjects:
+  - kind: ServiceAccount
+    name: console
+    namespace: openshift-console


### PR DESCRIPTION
## Summary

- Adds a `ClusterRole` (`system:openshift:console:lifecycle-reader`) and `ClusterRoleBinding` that grant the console ServiceAccount `GET` access to lifecycle-server nonResourceURL paths (`/api/*/lifecycles/*`).
- The lifecycle-server uses `TokenReview` / `SubjectAccessReview` for authn/authz on nonResourceURLs, so the console pod SA needs explicit RBAC to call the API.
- Gated behind `TechPreviewNoUpgrade` feature set and scoped to the `Console` capability.

## Details

The lifecycle-server exposes operator lifecycle data (e.g. update risks, recommended actions) via nonResourceURL endpoints. The console backend needs to query these endpoints to surface lifecycle information in the UI.

Since nonResourceURLs are not covered by standard namespace-scoped RBAC, a dedicated `ClusterRole` with `nonResourceURLs` rules is required. The `ClusterRoleBinding` binds this role to the `console` ServiceAccount in the `openshift-console` namespace.

## Test plan

- [ ] Verify the ClusterRole and ClusterRoleBinding are created on a TechPreviewNoUpgrade cluster
- [ ] Confirm the console SA can `GET /api/*/lifecycles/*` endpoints on the lifecycle-server
- [ ] Confirm the resources are **not** created on a standard (non-TechPreview) cluster


🤖 Commit and PR descriptions generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added permissions for the OpenShift console to read lifecycle-related information from the platform API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->