### PR TITLE
OCPBUGS-85060: feat: use 2 replicas for console on tnf

### DIFF
--- a/pkg/console/subresource/deployment/deployment.go
+++ b/pkg/console/subresource/deployment/deployment.go
@@ -137,9 +137,11 @@ func DefaultDownloadsDeployment(
 //
 // On HighlyAvailableArbiter control plane topologies, with a minimum of two full sized master nodes, we also deploy HA
 // since the default for HA is 2 pods.
+// On DualReplica control plane topologies, we are deploying on two nodes and should be deployed in HA mode.
 func ShouldDeployHA(infrastructureConfig *configv1.Infrastructure) bool {
 	return infrastructureConfig.Status.ControlPlaneTopology == configv1.HighlyAvailableTopologyMode ||
 		infrastructureConfig.Status.ControlPlaneTopology == configv1.HighlyAvailableArbiterMode ||
+		infrastructureConfig.Status.ControlPlaneTopology == configv1.DualReplicaTopologyMode ||
 		(infrastructureConfig.Status.ControlPlaneTopology == configv1.ExternalTopologyMode &&
 			infrastructureConfig.Status.InfrastructureTopology == configv1.HighlyAvailableTopologyMode)
 }


### PR DESCRIPTION
<!--
  Please fill in every section below before requesting review. Filled-in descriptions are
  required for the OpenShift Console team to triage the pull request, review the code, and
  verify the behavior end-to-end.

  The pull request title must be prefixed with a Jira issue in order to be merged. For example:

  For e.g Features: https://redhat.atlassian.net/browse/CONSOLE-XXXX
  - CONSOLE-XXXX: <title>
  For e.g Jira Bug Fixes: https://redhat.atlassian.net/browse/OCPBUGS-XXXX
  - OCPBUGS-XXXX: <title>
-->

**Analysis / Root cause**:
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

In TNF (Two Node Fencing) clusters we are currently only deploying a single replica console, this is causing issues during upgrade as one pod moves over to the other node and causes disruption. For all intents and purposes TNF should be considered like Arbiter and thus will require 2 replicas.

**Solution description**:
<!-- Describe your code changes in detail and explain the solution or functionality -->

Updating the function to create the deployment with 2 replicas instead of 1.

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->

Executing two node fencing upgrade payload job should not trigger 
`[Monitor:legacy-cvo-invariants][bz-Management Console] clusteroperator/console should not change condition/Available` failure

**Test cases:**
<!-- List possible test cases to validate the changes. -->

**Browser conformance**:
<!-- To mark tested browsers, use [x] -->
N/A

**Additional info:**
<!-- Add any additional info here -->

**Reviewers and assignees:**
<!--
- Tag an OCP console engineer to review the changes and verify the functionality.
- If there are visual, content, or interaction changes in the PR, tag "@openshift/team-ux-review"
- If the PR is implementing a story, assign Docs, and PX approvers:
  Console Approver:
  /assign <gh-user>

  Docs approver:
  /assign <gh-user>

  PX approver:
  /assign <gh-user>
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Console now correctly deploys in high availability mode when using dual replica topology, improving system resilience and availability across replica distribution and updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->