### PR TITLE
OCPBUGS-64688: use ObservedGeneration to determine Progressing status

### DIFF
--- a/pkg/console/operator/sync_v400.go
+++ b/pkg/console/operator/sync_v400.go
@@ -211,13 +211,13 @@ func (co *consoleOperator) sync_v400(ctx context.Context, controllerContext fact
 
 	statusHandler.AddCondition(status.HandleProgressing("SyncLoopRefresh", "InProgress", func() error {
 		version := os.Getenv("OPERATOR_IMAGE_VERSION")
-		// Only report Progressing=True when the deployment is actually rolling out
-		// or the operator version is changing. Do NOT report Progressing just because
-		// resources were updated during reconciliation, as per the API guidelines:
-		// "Operators should not report Progressing when they are reconciling (without action)
-		// a previously known state."
-		if !deploymentsub.IsAvailableAndUpdated(actualDeployment) {
-			return fmt.Errorf("working toward version %s, %v replicas available", version, actualDeployment.Status.AvailableReplicas)
+		// Only report Progressing when the deployment controller hasn't yet
+		// processed a spec change made by the operator. Do not use replica
+		// counts — they fluctuate during external disruptions (node reboots)
+		// that the operator did not cause. See https://issues.redhat.com/browse/OCPBUGS-64688
+		if actualDeployment.Status.ObservedGeneration < actualDeployment.Generation {
+			return fmt.Errorf("deployment generation %d not yet observed (current: %d)",
+				actualDeployment.Generation, actualDeployment.Status.ObservedGeneration)
 		}
 
 		if co.versionGetter.GetVersions()["operator"] != version {


### PR DESCRIPTION
## Summary
- Replace `IsAvailableAndUpdated` with `ObservedGeneration < Generation` check for the Progressing condition
- `IsAvailableAndUpdated` used `UpdatedReplicas == Replicas`, which falsely triggers during node reboots when pods are temporarily disrupted — even though the operator made no spec changes
- `ObservedGeneration < Generation` only fires when the operator has updated the deployment spec and the deployment controller hasn't processed it yet

## Root Cause
During node reboots (MCO draining nodes), console pods are terminated and replacements are created. During the ~30-second gap, `UpdatedReplicas != Replicas`, causing `IsAvailableAndUpdated` to return false and the operator to report `Progressing=True`. The operator made no changes — the disruption is external.

## Why This Fix
`ObservedGeneration < Generation` precisely detects operator-initiated spec changes:
- **Node reboot (no spec change):** Generation unchanged → Progressing=False ✓
- **Real upgrade (operator updates spec):** Generation bumps → Progressing=True ✓
- **Fresh install:** Generation=1, ObservedGeneration=0 → Progressing=True ✓

The Available condition (`IsAvailable` at line 231) independently monitors pod readiness and is unaffected.

## Test plan
- [x] `make` builds successfully
- [x] `make test-unit` all tests pass
- [x] `gofmt` / `go vet` clean
- [ ] CI e2e upgrade test `[Monitor:legacy-cvo-invariants][bz-Management Console] clusteroperator/console should stay Progressing=False while MCO is Progressing=True` should stop failing (~8% failure rate on Sippy currently)

Assisted-by: Claude Code (Opus 4.6)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment progressing status detection to use generation tracking instead of availability checks, providing more accurate and stable status reporting. Updated related error messaging to better reflect actual synchronization state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->