### PR TITLE
NO-JIRA: feat: have CVO inject the centralized TLS configuration into the operator's config

### DIFF
--- a/manifests/05-config.yaml
+++ b/manifests/05-config.yaml
@@ -9,6 +9,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     capability.openshift.io/name: Console
+    config.openshift.io/inject-tls: "true"
 data:
   controller-config.yaml: |
     apiVersion: operator.openshift.io/v1alpha1

--- a/manifests/07-operator-ibm-cloud-managed.yaml
+++ b/manifests/07-operator-ibm-cloud-managed.yaml
@@ -25,6 +25,9 @@ spec:
       containers:
       - args:
         - --config=/var/run/configmaps/config/controller-config.yaml
+        - --terminate-on-files=/var/run/configmaps/config/controller-config.yaml
+        - --terminate-on-files=/var/run/secrets/serving-cert/tls.crt
+        - --terminate-on-files=/var/run/secrets/serving-cert/tls.key
         command:
         - console
         - operator

--- a/manifests/07-operator.yaml
+++ b/manifests/07-operator.yaml
@@ -58,6 +58,9 @@ spec:
             - operator
           args:
             - "--config=/var/run/configmaps/config/controller-config.yaml"
+            - "--terminate-on-files=/var/run/configmaps/config/controller-config.yaml"
+            - "--terminate-on-files=/var/run/secrets/serving-cert/tls.crt"
+            - "--terminate-on-files=/var/run/secrets/serving-cert/tls.key"
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - mountPath: /var/run/configmaps/config


### PR DESCRIPTION
Also, have the operator restart whenever the config changes.

wip-docs: https://github.com/openshift/enhancements/pull/2020

<!--
  Please fill in every section below before requesting review. Filled-in descriptions are
  required for the OpenShift Console team to triage the pull request, review the code, and
  verify the behavior end-to-end.

  The pull request title must be prefixed with a Jira issue in order to be merged. For example:

  For e.g Features: https://redhat.atlassian.net/browse/CONSOLE-XXXX
  - CONSOLE-XXXX: <title>
  For e.g Jira Bug Fixes: https://redhat.atlassian.net/browse/OCPBUGS-XXXX
  - OCPBUGS-XXXX: <title>
-->

**Analysis / Root cause**:
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

**Solution description**:
<!-- Describe your code changes in detail and explain the solution or functionality -->

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->

**Test cases:**
<!-- List possible test cases to validate the changes. -->

**Browser conformance**:
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari (or Epiphany on Linux)

**Additional info:**
<!-- Add any additional info here -->

**Reviewers and assignees:**
<!--
- Tag an OCP console engineer to review the changes and verify the functionality.
- If there are visual, content, or interaction changes in the PR, tag "@openshift/team-ux-review"
- If the PR is implementing a story, assign Docs, and PX approvers:
  Console Approver:
  /assign <gh-user>

  Docs approver:
  /assign <gh-user>

  PX approver:
  /assign <gh-user>
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved TLS certificate management and operator resilience through automatic configuration reload.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->