### PR TITLE
OCPBUGS-64688: use ObservedGeneration to determine Progressing status

### DIFF
--- a/pkg/console/operator/sync_v400.go
+++ b/pkg/console/operator/sync_v400.go
@@ -211,13 +211,8 @@ func (co *consoleOperator) sync_v400(ctx context.Context, controllerContext fact
 
 	statusHandler.AddCondition(status.HandleProgressing("SyncLoopRefresh", "InProgress", func() error {
 		version := os.Getenv("OPERATOR_IMAGE_VERSION")
-		// Only report Progressing=True when the deployment is actually rolling out
-		// or the operator version is changing. Do NOT report Progressing just because
-		// resources were updated during reconciliation, as per the API guidelines:
-		// "Operators should not report Progressing when they are reconciling (without action)
-		// a previously known state."
-		if !deploymentsub.IsAvailableAndUpdated(actualDeployment) {
-			return fmt.Errorf("working toward version %s, %v replicas available", version, actualDeployment.Status.AvailableReplicas)
+		if err := checkDeploymentGenerationProgress(actualDeployment); err != nil {
+			return err
 		}
 
 		if co.versionGetter.GetVersions()["operator"] != version {
@@ -754,6 +749,19 @@ func (co *consoleOperator) GetAvailablePlugins(enabledPluginsNames []string) []*
 		return availablePlugins[i].Name < availablePlugins[j].Name
 	})
 	return availablePlugins
+}
+
+// checkDeploymentGenerationProgress returns an error if the deployment controller
+// has not yet processed the latest spec change (ObservedGeneration < Generation).
+// This is used to determine Progressing status without relying on replica counts,
+// which fluctuate during external disruptions like node reboots.
+// See https://issues.redhat.com/browse/OCPBUGS-64688
+func checkDeploymentGenerationProgress(deployment *appsv1.Deployment) error {
+	if deployment.Status.ObservedGeneration < deployment.Generation {
+		return fmt.Errorf("deployment generation %d not yet observed (observed: %d)",
+			deployment.Generation, deployment.Status.ObservedGeneration)
+	}
+	return nil
 }
 
 func getNodeComputeEnvironments(nodes []*corev1.Node) ([]string, []string) {

--- a/pkg/console/operator/sync_v400_test.go
+++ b/pkg/console/operator/sync_v400_test.go
@@ -4,9 +4,12 @@ import (
 	"testing"
 
 	"github.com/go-test/deep"
-	"github.com/openshift/console-operator/pkg/api"
+
+	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openshift/console-operator/pkg/api"
 )
 
 func TestGetNodeComputeEnvironments(t *testing.T) {
@@ -206,6 +209,79 @@ func TestGetNodeComputeEnvironments(t *testing.T) {
 
 			if diff := deep.Equal(tt.expectedOperatingSystems, actualOperatingSystems); diff != nil {
 				t.Errorf("OS mismatch: %v", diff)
+			}
+		})
+	}
+}
+
+// TestDeploymentProgressingByGeneration tests the ObservedGeneration-based
+// Progressing check introduced in OCPBUGS-64688. The operator should only
+// report Progressing=True when the deployment controller has not yet processed
+// a spec change (ObservedGeneration < Generation), NOT when replica counts
+// fluctuate due to external disruptions like node reboots.
+func TestDeploymentProgressingByGeneration(t *testing.T) {
+	tests := []struct {
+		name               string
+		generation         int64
+		observedGeneration int64
+		wantErr            bool
+		wantErrMsg         string
+	}{
+		{
+			name:               "ObservedGeneration equals Generation: not progressing",
+			generation:         5,
+			observedGeneration: 5,
+			wantErr:            false,
+		},
+		{
+			name:               "ObservedGeneration less than Generation: progressing",
+			generation:         4,
+			observedGeneration: 3,
+			wantErr:            true,
+			wantErrMsg:         "deployment generation 4 not yet observed (observed: 3)",
+		},
+		{
+			name:               "ObservedGeneration greater than Generation: not progressing",
+			generation:         2,
+			observedGeneration: 3,
+			wantErr:            false,
+		},
+		{
+			name:               "both zero: not progressing (fresh deployment)",
+			generation:         0,
+			observedGeneration: 0,
+			wantErr:            false,
+		},
+		{
+			name:               "Generation 1, ObservedGeneration 0: progressing (initial rollout)",
+			generation:         1,
+			observedGeneration: 0,
+			wantErr:            true,
+			wantErrMsg:         "deployment generation 1 not yet observed (observed: 0)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			deployment := &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Generation: tt.generation,
+				},
+				Status: appsv1.DeploymentStatus{
+					ObservedGeneration: tt.observedGeneration,
+				},
+			}
+
+			err := checkDeploymentGenerationProgress(deployment)
+
+			if tt.wantErr && err == nil {
+				t.Errorf("expected error but got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("expected no error but got: %v", err)
+			}
+			if tt.wantErr && err != nil && err.Error() != tt.wantErrMsg {
+				t.Errorf("error message mismatch:\n  got:  %q\n  want: %q", err.Error(), tt.wantErrMsg)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- Replace `IsAvailableAndUpdated` with `ObservedGeneration < Generation` check for the Progressing condition
- `IsAvailableAndUpdated` used `UpdatedReplicas == Replicas`, which falsely triggers during node reboots when pods are temporarily disrupted — even though the operator made no spec changes
- `ObservedGeneration < Generation` only fires when the operator has updated the deployment spec and the deployment controller hasn't processed it yet
- Extract `checkDeploymentGenerationProgress` helper for testability and add unit tests

## Root Cause
During node reboots (MCO draining nodes), console pods are terminated and replacements are created. During the ~30-second gap, `UpdatedReplicas != Replicas`, causing `IsAvailableAndUpdated` to return false and the operator to report `Progressing=True`. The operator made no changes — the disruption is external.

## Why This Fix
`ObservedGeneration < Generation` precisely detects operator-initiated spec changes:
- **Node reboot (no spec change):** Generation unchanged → Progressing=False ✓
- **Real upgrade (operator updates spec):** Generation bumps → Progressing=True ✓
- **Fresh install:** Generation=1, ObservedGeneration=0 → Progressing=True ✓

The Available condition (`IsAvailable` at line 231) independently monitors pod readiness and is unaffected.

## Test plan
- [x] `make` builds successfully
- [x] `make test-unit` all tests pass
- [x] `gofmt` / `go vet` clean
- [x] Unit tests for `checkDeploymentGenerationProgress`: ObservedGeneration equal, less than, greater than Generation, both zero, and initial rollout
- [x] Manual verification on live OCP 4.22 cluster (node drain stays Progressing=False, spec change triggers Progressing=True)
- [ ] CI e2e upgrade test `[Monitor:legacy-cvo-invariants][bz-Management Console] clusteroperator/console should stay Progressing=False while MCO is Progressing=True` should stop failing (~8% failure rate on Sippy currently)

Assisted-by: Claude Code (Opus 4.6)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable rollout status: deployments are now marked "progressing" only when the cluster hasn’t observed the latest deployment generation, avoiding noisy status flips caused by fluctuating replica counts during external disruptions.

* **Tests**
  * Added tests covering observed-generation scenarios (equal, less-than, greater-than, and initial rollout) to validate consistent progression reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->