### PR TITLE
OCPBUGS-87348: Fix ConfigMapSyncDegraded when cloud.openshift.com is absent from pull-secret

### DIFF
--- a/pkg/console/operator/sync_v400.go
+++ b/pkg/console/operator/sync_v400.go
@@ -481,6 +481,9 @@ func (co *consoleOperator) GetTelemetryConfiguration(ctx context.Context, operat
 	if err != nil {
 		return nil, err
 	}
+	if accessToken == "" {
+		return telemetryConfig, nil
+	}
 	organizationID, accountMail, refreshCache := telemetry.GetOrganizationMeta(telemetryConfig, co.trackables.organizationID, co.trackables.accountMail, clusterID, accessToken)
 	// cache fetched ORGANIZATION_ID and ACCOUNT_MAIL
 	if refreshCache {

--- a/pkg/console/telemetry/telemetry.go
+++ b/pkg/console/telemetry/telemetry.go
@@ -87,7 +87,7 @@ func GetAccessToken(secretsLister v1.SecretLister) (string, error) {
 	}
 	authsBytes, ok := config.Auths["cloud.openshift.com"]
 	if !ok {
-		return "", fmt.Errorf("failed to parse 'cloud.openshift.com' field from pull-secret")
+		return "", nil
 	}
 	return authsBytes.Auth, nil
 }

--- a/pkg/console/telemetry/telemetry.go
+++ b/pkg/console/telemetry/telemetry.go
@@ -82,8 +82,8 @@ func GetAccessToken(secretsLister v1.SecretLister) (string, error) {
 	var config DockerConfig
 	err = json.Unmarshal(configBytes, &config)
 	if err != nil {
-		fmt.Println("Error decoding JSON:", err)
-		return "", err
+		klog.Errorf("error decoding pull-secret JSON: %v", err)
+		return "", fmt.Errorf("error decoding pull-secret JSON: %w", err)
 	}
 	authsBytes, ok := config.Auths["cloud.openshift.com"]
 	if !ok {

--- a/pkg/console/telemetry/telemetry_test.go
+++ b/pkg/console/telemetry/telemetry_test.go
@@ -3,6 +3,13 @@ package telemetry
 import (
 	"testing"
 	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/openshift/console-operator/pkg/api"
 )
 
 // Helpers to set rate-limit timestamps and restore after test
@@ -16,6 +23,49 @@ func withLastSuccessTime(t *testing.T, ts time.Time) {
 	prev := lastSuccessTime
 	lastSuccessTime = ts
 	t.Cleanup(func() { lastSuccessTime = prev })
+}
+
+func newFakeSecretLister(t *testing.T, secrets ...*corev1.Secret) corev1listers.SecretLister {
+	t.Helper()
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	for _, s := range secrets {
+		if err := indexer.Add(s.DeepCopy()); err != nil {
+			t.Fatalf("failed to add secret to indexer: %v", err)
+		}
+	}
+	return corev1listers.NewSecretLister(indexer)
+}
+
+func TestGetAccessToken_MissingCloudEntry(t *testing.T) {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: PullSecretName, Namespace: api.OpenShiftConfigNamespace},
+		Data:       map[string][]byte{".dockerconfigjson": []byte(`{"auths":{}}`)},
+	}
+	lister := newFakeSecretLister(t, secret)
+
+	token, err := GetAccessToken(lister)
+	if err != nil {
+		t.Fatalf("expected no error for missing cloud.openshift.com, got: %v", err)
+	}
+	if token != "" {
+		t.Fatalf("expected empty token, got %q", token)
+	}
+}
+
+func TestGetAccessToken_PresentCloudEntry(t *testing.T) {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: PullSecretName, Namespace: api.OpenShiftConfigNamespace},
+		Data:       map[string][]byte{".dockerconfigjson": []byte(`{"auths":{"cloud.openshift.com":{"auth":"my-token"}}}`)},
+	}
+	lister := newFakeSecretLister(t, secret)
+
+	token, err := GetAccessToken(lister)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if token != "my-token" {
+		t.Fatalf("expected %q, got %q", "my-token", token)
+	}
 }
 
 func TestGetOrganizationMeta_UsesCustomOverrides(t *testing.T) {

--- a/pkg/console/telemetry/telemetry_test.go
+++ b/pkg/console/telemetry/telemetry_test.go
@@ -1,14 +1,17 @@
 package telemetry
 
 import (
+	// standard lib
 	"testing"
 	"time"
 
+	// kube
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	corev1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 
+	// operator
 	"github.com/openshift/console-operator/pkg/api"
 )
 


### PR DESCRIPTION
EDIT 2026-06-24: this changes are now part of #1173  

===

**Analysis / Root cause**:

Regression of OCPBUGS-33021. `GetAccessToken` treats a missing `cloud.openshift.com` key in the pull-secret as an error, degrading the operator with `FailedGetTelemetryConfig`. In disconnected clusters this key is intentionally absent.

**Solution description**:

- `pkg/console/telemetry/telemetry.go`: Return `("", nil)` instead of an error when `cloud.openshift.com` is missing.
- `pkg/console/operator/sync_v400.go`: Skip OCM fetch when access token is empty.
- `pkg/console/telemetry/telemetry_test.go`: Two unit tests for `GetAccessToken` covering both missing and present key.

**Test setup:**

Unit tests or disconnected cluster with `cloud.openshift.com` removed from pull-secret.

**Test cases:**

- [x] `TestGetAccessToken_MissingCloudEntry`
- [x] `TestGetAccessToken_PresentCloudEntry`

**Browser conformance**:

N/A

**Additional info:**

- Relates to: OCPBUGS-33021
- cc @jhadvig — hint from Slack: "I believe the bug is still in the operator. The main issue is that we are trying to get and parse the pull-secret for the cloud.openshift.com which is not present in the Secret anymore, we should be not erroring out when unable to parse the pull-secret."

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Telemetry token retrieval now returns an empty token instead of an error when expected cloud auth is missing.
  * Telemetry configuration skips extra metadata fetching when no valid token is available, avoiding unintended fields being set.
  * Improved error handling and logging around telemetry token parsing.

* **Tests**
  * Added unit tests covering missing and present cloud auth scenarios for telemetry token handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->