### PR TITLE
HELM-639: Update Helm download manifests for Helm 3 and Helm 4.

### DIFF
--- a/manifests/07-downloads-helm.yaml
+++ b/manifests/07-downloads-helm.yaml
@@ -1,7 +1,7 @@
 apiVersion: console.openshift.io/v1
 kind: ConsoleCLIDownload
 metadata:
-  name: helm-download-links-v3
+  name: helm-download-links
   annotations:
     include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
@@ -10,28 +10,9 @@ metadata:
     capability.openshift.io/name: Console
 spec:
   description: |
-    Helm 3 is a package manager for Kubernetes applications which enables defining,
+    Helm 4 is a package manager for Kubernetes applications which enables defining,
     installing, and upgrading applications packaged as Helm Charts.
-  displayName: helm - Helm 3 CLI
-  links:
-    - href: 'https://mirror.openshift.com/pub/openshift-v4/clients/helm/latest'
-      text: Download Helm
----
-apiVersion: console.openshift.io/v1
-kind: ConsoleCLIDownload
-metadata:
-  name: helm-download-links-v4
-  annotations:
-    include.release.openshift.io/hypershift: "true"
-    include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/single-node-developer: "true"
-    capability.openshift.io/name: Console
-spec:
-  description: |
-    Helm 4 is the next major release of Helm and, compared to Helm 3, includes
-    updated workflows for defining, installing, and upgrading Helm Charts.
   displayName: helm - Helm 4 CLI
   links:
     - href: 'https://mirror.openshift.com/pub/cgw/helm/4.1.4'
-      text: Download Helm
+      text: Download Helm v4

--- a/manifests/07-downloads-helm.yaml
+++ b/manifests/07-downloads-helm.yaml
@@ -1,7 +1,7 @@
 apiVersion: console.openshift.io/v1
 kind: ConsoleCLIDownload
 metadata:
-  name: helm-download-links
+  name: helm-download-links-v3
   annotations:
     include.release.openshift.io/hypershift: "true"
     include.release.openshift.io/ibm-cloud-managed: "true"
@@ -15,4 +15,23 @@ spec:
   displayName: helm - Helm 3 CLI
   links:
     - href: 'https://mirror.openshift.com/pub/openshift-v4/clients/helm/latest'
+      text: Download Helm
+---
+apiVersion: console.openshift.io/v1
+kind: ConsoleCLIDownload
+metadata:
+  name: helm-download-links-v4
+  annotations:
+    include.release.openshift.io/hypershift: "true"
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    capability.openshift.io/name: Console
+spec:
+  description: |
+    Helm 4 is the next major release of Helm and, compared to Helm 3, includes
+    updated workflows for defining, installing, and upgrading Helm Charts.
+  displayName: helm - Helm 4 CLI
+  links:
+    - href: 'https://mirror.openshift.com/pub/cgw/helm/4.1.4'
       text: Download Helm


### PR DESCRIPTION
Split the CLI download entries and clarify Helm 4 description relative to Helm 3 so users can distinguish versions.

<!--
  Please fill in every section below before requesting review. Filled-in descriptions are
  required for the OpenShift Console team to triage the pull request, review the code, and
  verify the behavior end-to-end.

  The pull request title must be prefixed with a Jira issue in order to be merged. For example:

  For e.g Features: https://redhat.atlassian.net/browse/CONSOLE-XXXX
  - CONSOLE-XXXX: <title>
  For e.g Jira Bug Fixes: https://redhat.atlassian.net/browse/OCPBUGS-XXXX
  - OCPBUGS-XXXX: <title>
-->

**Analysis / Root cause**:
Helm 4 has been released recently. Update Command Line Tools to reflect that. 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Updated the Helm CLI download option to Helm v4 (with the version-specific Helm 4.1.4 mirror link).
* **Bug Fixes**
  * Refreshed the Helm CLI entry details (description and display name) to match Helm v4 instead of Helm v3.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->