### PR TITLE
OCPBUGS-91663: Clean up old temp directories in downloads pod

### DIFF
--- a/bindata/assets/deployments/downloads-deployment.yaml
+++ b/bindata/assets/deployments/downloads-deployment.yaml
@@ -79,7 +79,7 @@ spec:
             - '-c'
             - |
               cat <<EOF >/tmp/serve.py
-              import errno, http.server, os, re, signal, socket, sys, tarfile, tempfile, threading, time, zipfile
+              import errno, http.server, os, re, shutil, signal, socket, sys, tarfile, tempfile, threading, time, zipfile
 
               def shutdown_handler(signum, frame):
                 print("Received signal {}, shutting down...".format(signum), flush=True)
@@ -124,7 +124,22 @@ spec:
                   httpd.serve_forever()
 
               print('Starting downloads server...', flush=True)
-              temp_dir = tempfile.mkdtemp()
+
+              # Clean up any existing download-* directories
+              TEMP_DIR_PREFIX = 'download-'
+              tmp_base = tempfile.gettempdir()
+              print('Cleaning up old temp directories in {}...'.format(tmp_base), flush=True)
+              for item in os.listdir(tmp_base):
+                if item.startswith(TEMP_DIR_PREFIX):
+                  old_dir = os.path.join(tmp_base, item)
+                  try:
+                    if os.path.isdir(old_dir):
+                      print('  Removing old directory: {}'.format(old_dir), flush=True)
+                      shutil.rmtree(old_dir)
+                  except Exception as e:
+                    print('  WARNING: Failed to remove {}: {}'.format(old_dir, str(e)), flush=True)
+
+              temp_dir = tempfile.mkdtemp(prefix=TEMP_DIR_PREFIX)
               print('Serving from: {}'.format(temp_dir), flush=True)
               os.chdir(temp_dir)
               


### PR DESCRIPTION
Add cleanup logic to remove old download-* temp directories before creating a new one. This prevents accumulation of stale temp directories from previous pod instances.

Changes:
- Define TEMP_DIR_PREFIX constant for 'download-' prefix
- Add cleanup logic to remove existing download-* directories on startup
- Use prefix parameter in tempfile.mkdtemp() for easier identification

<!--
  Please fill in every section below before requesting review. Filled-in descriptions are
  required for the OpenShift Console team to triage the pull request, review the code, and
  verify the behavior end-to-end.

  The pull request title must be prefixed with a Jira issue in order to be merged. For example:

  For e.g Features: https://redhat.atlassian.net/browse/CONSOLE-XXXX
  - CONSOLE-XXXX: <title>
  For e.g Jira Bug Fixes: https://redhat.atlassian.net/browse/OCPBUGS-XXXX
  - OCPBUGS-XXXX: <title>
-->

**Analysis / Root cause**:
<!-- Briefly describe analysis of US/Task or root cause of Defect -->

When the pod is killed with `oc -n openshift-console exec <downloads-pod> -- kill 1`, it is like simulating _A container crashing does not remove a Pod from a node. The data in an emptyDir volume is safe across container crashes._ as in https://kubernetes.io/docs/concepts/storage/volumes/#emptydir.

The data from the previous container are reserved and thus could cause out-of-disk issue after a loop of such actions.

**Solution description**:
<!-- Describe your code changes in detail and explain the solution or functionality -->

See the PR description above.


**Test setup:**
<!-- If any setup required to test this PR, mention the details -->

**Test cases:**
<!-- List possible test cases to validate the changes. -->

I will verify manually with the steps in the associated bug.

**Browser conformance**:
<!-- To mark tested browsers, use [x] -->
- [ ] Chrome
- [ ] Firefox
- [ ] Safari (or Epiphany on Linux)

**Additional info:**
<!-- Add any additional info here -->

**Reviewers and assignees:**
<!--
- Tag an OCP console engineer to review the changes and verify the functionality.
- If there are visual, content, or interaction changes in the PR, tag "@openshift/team-ux-review"
- If the PR is implementing a story, assign Docs, and PX approvers:
  Console Approver:
  /assign <gh-user>

  Docs approver:
  /assign <gh-user>

  PX approver:
  /assign <gh-user>
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Downloads service now includes automatic cleanup of temporary directories from previous operations, improving resource management and preventing disk space accumulation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->