### PR TITLE
OCPBUGS-93982: skip generation check when deployment was just updated

### DIFF
--- a/pkg/console/operator/sync_v400.go
+++ b/pkg/console/operator/sync_v400.go
@@ -185,7 +185,7 @@ func (co *consoleOperator) sync_v400(ctx context.Context, controllerContext fact
 		return statusHandler.FlushAndReturn(servingCertErr)
 	}
 
-	actualDeployment, depErrReason, depErr := co.SyncDeployment(
+	actualDeployment, depChanged, depErrReason, depErr := co.SyncDeployment(
 		ctx,
 		set.Operator,
 		cm,
@@ -211,8 +211,17 @@ func (co *consoleOperator) sync_v400(ctx context.Context, controllerContext fact
 
 	statusHandler.AddCondition(status.HandleProgressing("SyncLoopRefresh", "InProgress", func() error {
 		version := os.Getenv("OPERATOR_IMAGE_VERSION")
-		if err := checkDeploymentGenerationProgress(actualDeployment); err != nil {
-			return err
+		// Skip the generation check when SyncDeployment just applied changes.
+		// The generation gap is guaranteed immediately after an update (the API
+		// server bumps Generation but ObservedGeneration lags until the deployment
+		// controller processes it). Reporting Progressing=True for this sub-second
+		// gap provides no signal and causes OTA invariant test failures during
+		// upgrades. The next sync loop will check with depChanged=false and catch
+		// any persistent gap. See https://issues.redhat.com/browse/OCPBUGS-93982
+		if !depChanged {
+			if err := checkDeploymentGenerationProgress(actualDeployment); err != nil {
+				return err
+			}
 		}
 
 		if co.versionGetter.GetVersions()["operator"] != version {
@@ -297,7 +306,7 @@ func (co *consoleOperator) SyncDeployment(
 	proxyConfig *configv1.Proxy,
 	infrastructureConfig *configv1.Infrastructure,
 	recorder events.Recorder,
-) (consoleDeployment *appsv1.Deployment, reason string, err error) {
+) (consoleDeployment *appsv1.Deployment, changed bool, reason string, err error) {
 	updatedOperatorConfig := operatorConfig.DeepCopy()
 	requiredDeployment := deploymentsub.DefaultDeployment(
 		operatorConfig,
@@ -320,9 +329,10 @@ func (co *consoleOperator) SyncDeployment(
 	deploymentsub.LogDeploymentAnnotationChanges(co.deploymentClient, requiredDeployment, ctx)
 
 	var deployment *appsv1.Deployment
+	var deploymentChanged bool
 	applyDepErr := controllersutil.RetryOnTransientError(func() error {
 		var e error
-		deployment, _, e = resourceapply.ApplyDeployment(
+		deployment, deploymentChanged, e = resourceapply.ApplyDeployment(
 			ctx,
 			co.deploymentClient,
 			recorder,
@@ -333,9 +343,9 @@ func (co *consoleOperator) SyncDeployment(
 	})
 
 	if applyDepErr != nil {
-		return nil, "FailedApply", applyDepErr
+		return nil, false, "FailedApply", applyDepErr
 	}
-	return deployment, "", nil
+	return deployment, deploymentChanged, "", nil
 }
 
 // apply configmap (needs route)

--- a/pkg/console/operator/sync_v400_test.go
+++ b/pkg/console/operator/sync_v400_test.go
@@ -229,6 +229,71 @@ func TestGetNodeComputeEnvironments(t *testing.T) {
 // report Progressing=True when the deployment controller has not yet processed
 // a spec change (ObservedGeneration < Generation), NOT when replica counts
 // fluctuate due to external disruptions like node reboots.
+// TestDeploymentProgressingSkippedWhenChanged verifies the guard logic from
+// OCPBUGS-93982: when SyncDeployment reports changed=true, the generation check
+// is skipped because the operator itself caused the generation gap.
+func TestDeploymentProgressingSkippedWhenChanged(t *testing.T) {
+	tests := []struct {
+		name               string
+		depChanged         bool
+		generation         int64
+		observedGeneration int64
+		wantProgressing    bool
+	}{
+		{
+			name:               "changed=true with generation gap: skip check, not progressing",
+			depChanged:         true,
+			generation:         7,
+			observedGeneration: 6,
+			wantProgressing:    false,
+		},
+		{
+			name:               "changed=false with generation gap: run check, progressing",
+			depChanged:         false,
+			generation:         7,
+			observedGeneration: 6,
+			wantProgressing:    true,
+		},
+		{
+			name:               "changed=false with no generation gap: run check, not progressing",
+			depChanged:         false,
+			generation:         7,
+			observedGeneration: 7,
+			wantProgressing:    false,
+		},
+		{
+			name:               "changed=true with no generation gap: skip check, not progressing",
+			depChanged:         true,
+			generation:         7,
+			observedGeneration: 7,
+			wantProgressing:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			deployment := &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Generation: tt.generation,
+				},
+				Status: appsv1.DeploymentStatus{
+					ObservedGeneration: tt.observedGeneration,
+				},
+			}
+
+			var progressingErr error
+			if !tt.depChanged {
+				progressingErr = checkDeploymentGenerationProgress(deployment)
+			}
+
+			gotProgressing := progressingErr != nil
+			if gotProgressing != tt.wantProgressing {
+				t.Errorf("progressing = %v, want %v (err: %v)", gotProgressing, tt.wantProgressing, progressingErr)
+			}
+		})
+	}
+}
+
 func TestDeploymentProgressingByGeneration(t *testing.T) {
 	tests := []struct {
 		name               string


### PR DESCRIPTION
## Summary

During upgrades, the console operator updates the console deployment spec 2-4 times (new image, config changes). Each update bumps `Generation`, but `ObservedGeneration` lags by 257ms-1s until the deployment controller processes it. The generation check (introduced by [PR #1169](https://github.com/openshift/console-operator/pull/1169) for [OCPBUGS-64688](https://issues.redhat.com/browse/OCPBUGS-64688)) sees this gap and reports `Progressing=True` — even though the operator itself just caused the gap.

These sub-second blips coincide with MCO's `Progressing=True` window, failing the OTA invariant test (`clusteroperator/console should stay Progressing=False while MCO is Progressing=True`) in ~5% of upgrade jobs.

## Changes

`SyncDeployment` already calls `ApplyDeployment`, which returns a `changed` boolean — but it was being discarded (removed by [PR #1074](https://github.com/openshift/console-operator/pull/1074) for [OCPBUGS-64685](https://issues.redhat.com/browse/OCPBUGS-64685)). This PR re-introduces it:

- **`SyncDeployment`**: Captures `changed` from `ApplyDeployment` and returns it to the caller
- **`sync_v400`**: Skips the generation check when `changed=true` (self-inflicted gap, guaranteed transient)

When `changed=false`, the generation check runs normally — catching genuine deployment rollout delays. The next sync loop always runs with `changed=false` if no new changes are needed, so persistent gaps are still detected.

## Context

This is the 4th fix in a chain of Progressing-related bugs:

| Bug | Problem | Fix |
|-----|---------|-----|
| [OCPBUGS-36830](https://issues.redhat.com/browse/OCPBUGS-36830) / [OCPBUGS-64685](https://issues.redhat.com/browse/OCPBUGS-64685) | Any resource change → false Progressing | Removed change tracking, used replica count |
| [OCPBUGS-64688](https://issues.redhat.com/browse/OCPBUGS-64688) | Node reboots → false Progressing (30s+) | Switched to generation check |
| **[OCPBUGS-93982](https://issues.redhat.com/browse/OCPBUGS-93982)** | **Self-inflicted spec updates → false Progressing (<1s)** | **Guard generation check with `changed` flag** |

## Tests

- [ ] New unit tests: `TestDeploymentProgressingSkippedWhenChanged` — 4 cases covering changed/unchanged x gap/no-gap
- [ ] Existing unit tests: `TestDeploymentProgressingByGeneration` — 5 cases unchanged and passing
- [ ] `make test-unit` passes (all packages, gofmt, govet)
- [ ] CI e2e: verify no `SyncLoopRefreshProgressing` blips during upgrade window


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment status handling to avoid brief, misleading “Progressing” updates right after changes are applied.
  * Deployment updates now report more consistently when a change was made, helping status checks reflect the latest state.
  * Added coverage to ensure progress reporting behaves correctly across updated and unchanged deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->