### PR TITLE
OCPBUGS-85379: Bump documentationBaseURL to 4.22

### DIFF
--- a/pkg/console/subresource/configmap/brand_ocp.go
+++ b/pkg/console/subresource/configmap/brand_ocp.go
@@ -5,5 +5,5 @@ package configmap
 
 const (
 	DEFAULT_BRAND   = "ocp"
-	DEFAULT_DOC_URL = "https://access.redhat.com/documentation/en-us/openshift_container_platform/4.21/"
+	DEFAULT_DOC_URL = "https://access.redhat.com/documentation/en-us/openshift_container_platform/4.22/"
 )


### PR DESCRIPTION
## Description
Update `DEFAULT_DOC_URL` from 4.21 to 4.22, which is now the latest published documentation version on the Red Hat documentation site.

The current `documentationBaseURL` still points to 4.21 while 4.22 documentation is already available at:
https://access.redhat.com/documentation/en-us/openshift_container_platform/4.22/

## Changes
- `pkg/console/subresource/configmap/brand_ocp.go`: Update `DEFAULT_DOC_URL` constant from `4.21` to `4.22`

Bug: https://redhat.atlassian.net/browse/OCPBUGS-85379


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the default OpenShift Container Platform documentation link to point to version 4.22 resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->