### PR TITLE
OSDOCS-20110: Add Helm 3 CLI download links alongside Helm 4

### DIFF
--- a/manifests/07-downloads-helm.yaml
+++ b/manifests/07-downloads-helm.yaml
@@ -29,8 +29,10 @@ metadata:
     capability.openshift.io/name: Console
 spec:
   description: |
-    Helm 3 is a package manager for Kubernetes that simplifies deploying and managing
-    applications using Helm Charts. Helm 3 remains available for existing workflows.
+    Helm 3 is a package manager for Kubernetes applications which enables defining,
+    installing, and upgrading applications packaged as Helm Charts. Helm 3 continues
+    to be provided for operational continuity, but it will not be compatible with
+    future releases of OCP and so customers are encouraged to upgrade to Helm 4.
   displayName: helm - Helm 3 CLI
   links:
     - href: 'https://mirror.openshift.com/pub/openshift-v4/clients/helm/latest'

--- a/manifests/07-downloads-helm.yaml
+++ b/manifests/07-downloads-helm.yaml
@@ -10,8 +10,8 @@ metadata:
     capability.openshift.io/name: Console
 spec:
   description: |
-    Helm 4 is a package manager for Kubernetes applications which enables defining,
-    installing, and upgrading applications packaged as Helm Charts.
+    You can use Helm 4 to define, install, and upgrade applications
+    packaged as Helm Charts.
   displayName: helm - Helm 4 CLI
   links:
     - href: 'https://mirror.openshift.com/pub/cgw/helm/4.2.3'
@@ -29,10 +29,10 @@ metadata:
     capability.openshift.io/name: Console
 spec:
   description: |
-    Helm 3 is a package manager for Kubernetes applications which enables defining,
-    installing, and upgrading applications packaged as Helm Charts. Helm 3 continues
-    to be provided for operational continuity, but it will not be compatible with
-    future releases of OCP and so customers are encouraged to upgrade to Helm 4.
+    You can use Helm 3 to define, install, and upgrade applications
+    packaged as Helm Charts. Helm 3 is provided for operational
+    continuity but will not be compatible with future releases of OCP.
+    We encourage you to upgrade to Helm 4.
   displayName: helm - Helm 3 CLI
   links:
     - href: 'https://mirror.openshift.com/pub/openshift-v4/clients/helm/latest'

--- a/manifests/07-downloads-helm.yaml
+++ b/manifests/07-downloads-helm.yaml
@@ -14,5 +14,24 @@ spec:
     installing, and upgrading applications packaged as Helm Charts.
   displayName: helm - Helm 4 CLI
   links:
-    - href: 'https://mirror.openshift.com/pub/cgw/helm/4.1.4'
+    - href: 'https://mirror.openshift.com/pub/cgw/helm/4.2.3'
       text: Download Helm v4
+---
+apiVersion: console.openshift.io/v1
+kind: ConsoleCLIDownload
+metadata:
+  name: helm3-download-links
+  annotations:
+    include.release.openshift.io/hypershift: "true"
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    capability.openshift.io/name: Console
+spec:
+  description: |
+    Helm 3 is a package manager for Kubernetes that simplifies deploying and managing
+    applications using Helm Charts. Helm 3 remains available for existing workflows.
+  displayName: helm - Helm 3 CLI
+  links:
+    - href: 'https://mirror.openshift.com/pub/openshift-v4/clients/helm/latest'
+      text: Download Helm v3


### PR DESCRIPTION
Helm 3 remains available for existing workflows. This adds a separate ConsoleCLIDownload resource so both versions appear on the CLI downloads page.



<!-- List possible test cases to validate the changes. -->



<img width="2042" height="536" alt="image" src="https://github.com/user-attachments/assets/83744ae6-46de-4efa-bcd9-e9dafc2e1fd6" />

**Reviewers and assignees:**
<!--
- Tag an OCP console engineer to review the changes and verify the functionality.
- If there are visual, content, or interaction changes in the PR, tag "@openshift/team-ux-review"
- If the PR is implementing a story, assign Docs, and PX approvers:
  Console Approver:
  /assign <gh-user>

  Docs approver:
  /assign <gh-user>

  PX approver:
  /assign <gh-user>
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Helm 3 CLI download information, including operational-continuity guidance and a link to the latest Helm 3 client bundle.
* **Updates**
  * Updated the Helm 4 CLI download description to highlight Helm 4.
  * Updated the Helm 4 download link to the newer Helm 4.2.3 client bundle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->