### PR TITLE
CONSOLE-5431: Add allow-all NetworkPolicy to openshift-console namespace

### DIFF
--- a/manifests/03-networkpolicy-console.yaml
+++ b/manifests/03-networkpolicy-console.yaml
@@ -1,0 +1,25 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-all
+  namespace: openshift-console
+  annotations:
+    include.release.openshift.io/hypershift: "true"
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    capability.openshift.io/name: Console
+    kubernetes.io/description: >-
+      Allow all ingress and egress traffic in the openshift-console
+      namespace. The console requires network access to serve the UI
+      and communicate with the Kubernetes API and other cluster
+      services.
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  - {}
+  egress:
+  - {}


### PR DESCRIPTION
Add an operator-managed NetworkPolicy that allows all ingress and egress traffic in the openshift-console namespace. This ensures console pods have an explicit allow-all policy so that other default-deny policies do not block console traffic.

/cc @wking @TheRealJon 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added network access configuration for the console interface, supporting communication with the Kubernetes API and related services.
  - Enabled both inbound and outbound connectivity for console components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->