### PR TITLE
OCPBUGS-99943: set API-server-defaulted fields on deployment specs to prevent excessive update events

### DIFF
--- a/bindata/assets/deployments/console-deployment.yaml
+++ b/bindata/assets/deployments/console-deployment.yaml
@@ -7,6 +7,8 @@ metadata:
     app: console
     component: ui
 spec:
+  progressDeadlineSeconds: 600
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       app: console
@@ -23,10 +25,12 @@ spec:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
         openshift.io/required-scc: restricted-v2
     spec:
+      dnsPolicy: ClusterFirst
       nodeSelector:
         node-role.kubernetes.io/master: ""
       restartPolicy: Always
       serviceAccountName: console
+      serviceAccount: console
       schedulerName: default-scheduler
       securityContext:
         runAsNonRoot: true

--- a/bindata/assets/deployments/downloads-deployment.yaml
+++ b/bindata/assets/deployments/downloads-deployment.yaml
@@ -8,6 +8,8 @@ metadata:
     component: downloads
   annotations: {}
 spec:
+  progressDeadlineSeconds: 600
+  revisionHistoryLimit: 10
   selector:
     matchLabels:
       app: console
@@ -24,7 +26,9 @@ spec:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
         openshift.io/required-scc: restricted-v2
     spec:
+      dnsPolicy: ClusterFirst
       serviceAccountName: downloads
+      serviceAccount: downloads
       nodeSelector:
         kubernetes.io/os: linux
         node-role.kubernetes.io/master: ""

--- a/pkg/console/subresource/deployment/deployment.go
+++ b/pkg/console/subresource/deployment/deployment.go
@@ -182,7 +182,10 @@ func withAffinity(
 }
 
 func withStrategy(deployment *appsv1.Deployment, infrastructureConfig *configv1.Infrastructure) {
-	rollingUpdateParams := &appsv1.RollingUpdateDeployment{}
+	rollingUpdateParams := &appsv1.RollingUpdateDeployment{
+		MaxSurge:       &intstr.IntOrString{Type: intstr.String, StrVal: "25%"},
+		MaxUnavailable: &intstr.IntOrString{Type: intstr.String, StrVal: "25%"},
+	}
 	if ShouldDeployHA(infrastructureConfig) {
 		rollingUpdateParams = &appsv1.RollingUpdateDeployment{
 			MaxSurge: &intstr.IntOrString{

--- a/pkg/console/subresource/deployment/deployment_test.go
+++ b/pkg/console/subresource/deployment/deployment_test.go
@@ -238,7 +238,9 @@ func TestDefaultDeployment(t *testing.T) {
 						Annotations: consoleDeploymentTemplateAnnotations,
 					},
 						Spec: corev1.PodSpec{
-							ServiceAccountName: "console",
+							DNSPolicy:                corev1.DNSClusterFirst,
+							ServiceAccountName:       "console",
+							DeprecatedServiceAccount: "console",
 							// we want to deploy on master nodes
 							NodeSelector: map[string]string{"node-role.kubernetes.io/master": ""},
 							Affinity:     consoleDeploymentAffinity,
@@ -272,9 +274,9 @@ func TestDefaultDeployment(t *testing.T) {
 						},
 					},
 					MinReadySeconds:         0,
-					RevisionHistoryLimit:    nil,
+					RevisionHistoryLimit:    ptr.To(int32(10)),
 					Paused:                  false,
-					ProgressDeadlineSeconds: nil,
+					ProgressDeadlineSeconds: ptr.To(int32(600)),
 				},
 				Status: appsv1.DeploymentStatus{},
 			},
@@ -317,7 +319,9 @@ func TestDefaultDeployment(t *testing.T) {
 						Annotations: consoleDeploymentTemplateAnnotations,
 					},
 						Spec: corev1.PodSpec{
-							ServiceAccountName: "console",
+							DNSPolicy:                corev1.DNSClusterFirst,
+							ServiceAccountName:       "console",
+							DeprecatedServiceAccount: "console",
 							// we want to deploy on master nodes
 							NodeSelector: map[string]string{"node-role.kubernetes.io/master": ""},
 							Affinity:     consoleDeploymentAffinity,
@@ -351,9 +355,9 @@ func TestDefaultDeployment(t *testing.T) {
 						},
 					},
 					MinReadySeconds:         0,
-					RevisionHistoryLimit:    nil,
+					RevisionHistoryLimit:    ptr.To(int32(10)),
 					Paused:                  false,
-					ProgressDeadlineSeconds: nil,
+					ProgressDeadlineSeconds: ptr.To(int32(600)),
 				},
 				Status: appsv1.DeploymentStatus{},
 			},
@@ -396,7 +400,9 @@ func TestDefaultDeployment(t *testing.T) {
 						Annotations: consoleDeploymentTemplateAnnotations,
 					},
 						Spec: corev1.PodSpec{
-							ServiceAccountName: "console",
+							DNSPolicy:                corev1.DNSClusterFirst,
+							ServiceAccountName:       "console",
+							DeprecatedServiceAccount: "console",
 							// we want to deploy on master nodes
 							NodeSelector: map[string]string{"node-role.kubernetes.io/master": ""},
 							Affinity:     &corev1.Affinity{},
@@ -419,13 +425,16 @@ func TestDefaultDeployment(t *testing.T) {
 						},
 					},
 					Strategy: appsv1.DeploymentStrategy{
-						Type:          appsv1.RollingUpdateDeploymentStrategyType,
-						RollingUpdate: &appsv1.RollingUpdateDeployment{},
+						Type: appsv1.RollingUpdateDeploymentStrategyType,
+						RollingUpdate: &appsv1.RollingUpdateDeployment{
+							MaxSurge:       &intstr.IntOrString{Type: intstr.String, StrVal: "25%"},
+							MaxUnavailable: &intstr.IntOrString{Type: intstr.String, StrVal: "25%"},
+						},
 					},
 					MinReadySeconds:         0,
-					RevisionHistoryLimit:    nil,
+					RevisionHistoryLimit:    ptr.To(int32(10)),
 					Paused:                  false,
-					ProgressDeadlineSeconds: nil,
+					ProgressDeadlineSeconds: ptr.To(int32(600)),
 				},
 				Status: appsv1.DeploymentStatus{},
 			},
@@ -468,7 +477,9 @@ func TestDefaultDeployment(t *testing.T) {
 						Annotations: consoleDeploymentTemplateAnnotations,
 					},
 						Spec: corev1.PodSpec{
-							ServiceAccountName: "console",
+							DNSPolicy:                corev1.DNSClusterFirst,
+							ServiceAccountName:       "console",
+							DeprecatedServiceAccount: "console",
 							// we do not want to deploy on master nodes
 							NodeSelector: map[string]string{},
 							Affinity:     consoleDeploymentAffinity,
@@ -502,9 +513,9 @@ func TestDefaultDeployment(t *testing.T) {
 						},
 					},
 					MinReadySeconds:         0,
-					RevisionHistoryLimit:    nil,
+					RevisionHistoryLimit:    ptr.To(int32(10)),
 					Paused:                  false,
-					ProgressDeadlineSeconds: nil,
+					ProgressDeadlineSeconds: ptr.To(int32(600)),
 				},
 				Status: appsv1.DeploymentStatus{},
 			},
@@ -1519,7 +1530,10 @@ func TestWithStrategy(t *testing.T) {
 	infrastructureConfigExternalTopologyHighlyAvailable := infrastructureConfigWithTopology(configv1.ExternalTopologyMode, configv1.HighlyAvailableTopologyMode)
 	infrastructureConfigExternalTopologySingleReplica := infrastructureConfigWithTopology(configv1.ExternalTopologyMode, configv1.SingleReplicaTopologyMode)
 
-	singleReplicaStrategy := appsv1.RollingUpdateDeployment{}
+	singleReplicaStrategy := appsv1.RollingUpdateDeployment{
+		MaxSurge:       &intstr.IntOrString{Type: intstr.String, StrVal: "25%"},
+		MaxUnavailable: &intstr.IntOrString{Type: intstr.String, StrVal: "25%"},
+	}
 	highAvailStrategy := appsv1.RollingUpdateDeployment{
 		MaxSurge: &intstr.IntOrString{
 			IntVal: int32(3),
@@ -1719,7 +1733,9 @@ func TestDefaultDownloadsDeployment(t *testing.T) {
 		configv1.SingleReplicaTopologyMode)
 
 	downloadsDeploymentPodSpecSingleReplica := corev1.PodSpec{
-		ServiceAccountName: "downloads",
+		DNSPolicy:                corev1.DNSClusterFirst,
+		ServiceAccountName:       "downloads",
+		DeprecatedServiceAccount: "downloads",
 		NodeSelector: map[string]string{
 			"kubernetes.io/os":               "linux",
 			"node-role.kubernetes.io/master": "",
@@ -1850,10 +1866,15 @@ func TestDefaultDownloadsDeployment(t *testing.T) {
 				},
 				ObjectMeta: downloadsDeploymentObjectMeta,
 				Spec: appsv1.DeploymentSpec{
-					Replicas: &singleNodeReplicaCount,
+					Replicas:                &singleNodeReplicaCount,
+					RevisionHistoryLimit:    ptr.To(int32(10)),
+					ProgressDeadlineSeconds: ptr.To(int32(600)),
 					Strategy: appsv1.DeploymentStrategy{
-						Type:          appsv1.RollingUpdateDeploymentStrategyType,
-						RollingUpdate: &appsv1.RollingUpdateDeployment{},
+						Type: appsv1.RollingUpdateDeploymentStrategyType,
+						RollingUpdate: &appsv1.RollingUpdateDeployment{
+							MaxSurge:       &intstr.IntOrString{Type: intstr.String, StrVal: "25%"},
+							MaxUnavailable: &intstr.IntOrString{Type: intstr.String, StrVal: "25%"},
+						},
 					},
 					Selector: &metav1.LabelSelector{
 						MatchLabels: labels,
@@ -1886,7 +1907,9 @@ func TestDefaultDownloadsDeployment(t *testing.T) {
 				},
 				ObjectMeta: downloadsDeploymentObjectMeta,
 				Spec: appsv1.DeploymentSpec{
-					Replicas: &defaultReplicaCount,
+					Replicas:                &defaultReplicaCount,
+					RevisionHistoryLimit:    ptr.To(int32(10)),
+					ProgressDeadlineSeconds: ptr.To(int32(600)),
 					Strategy: appsv1.DeploymentStrategy{
 						Type: appsv1.RollingUpdateDeploymentStrategyType,
 						RollingUpdate: &appsv1.RollingUpdateDeployment{


### PR DESCRIPTION
## What

Set API-server-defaulted fields explicitly in both deployment YAML templates (`console-deployment.yaml`, `downloads-deployment.yaml`) and in the non-HA rolling update strategy code to prevent pathological `DeploymentUpdated` events.

**Fields added to YAML templates:**
- `progressDeadlineSeconds: 600`
- `revisionHistoryLimit: 10`
- `dnsPolicy: ClusterFirst`
- `serviceAccount: <name>`

**Code change:**
- `withStrategy()` now sets `MaxSurge: "25%"` and `MaxUnavailable: "25%"` for non-HA topologies instead of an empty struct

## Why

The console-operator generates pathological `DeploymentUpdated` events in a tight reconciliation loop, causing **79% of test failures** (15/19 runs) in `periodic-ci-openshift-release-main-nightly-5.0-e2e-vsphere-ovn-techpreview-serial` with a **1.9% overall pass rate**.

Library-go's `ApplyDeploymentWithForce` replaces the entire deployment spec on every metadata-triggered update (e.g., when a ConfigMap ResourceVersion changes due to plugin registration). Fields the operator didn't set are written as null, and the API server re-defaults them — creating unnecessary spec churn that doubles the update event count per trigger. With ~14 plugin registrations in a TechPreview test run, this produces ~30 events, exceeding the pathological threshold.

Setting these fields explicitly makes the operator's desired spec match what the API server already stores, eliminating the null-field overwrite. Each legitimate trigger now produces exactly 1 deployment update instead of ~2.

All values are existing API server defaults — no behavioral change.

## Verification

- Spec hash verified locally: required spec hash matches API-server-defaulted spec hash for both HA and SingleNode topologies
- All unit tests pass (`make test-unit`)
- Build succeeds

Fixes [OCPBUGS-99943](https://issues.redhat.com/browse/OCPBUGS-99943)

Assisted by: Claude Code (Opus 4.6)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Deployment rollouts now use explicit progress deadlines and retain a defined number of previous revisions.
  - Standard rolling updates now use balanced percentage-based surge and availability settings for smoother deployments.
  - Console and downloads workloads now apply their designated service accounts consistently.
  - Deployment networking and service account configuration are more explicit, improving predictability across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->