### PR TITLE
OCPBUGS-71237: Generate session-secret for all auth types

### DIFF
--- a/pkg/console/operator/sync_v400.go
+++ b/pkg/console/operator/sync_v400.go
@@ -119,11 +119,11 @@ func (co *consoleOperator) sync_v400(ctx context.Context, controllerContext fact
 				}
 			}
 		}
+	}
 
-		sessionSecret, err = co.syncSessionSecret(ctx, updatedOperatorConfig, controllerContext.Recorder())
-		if err != nil {
-			return statusHandler.FlushAndReturn(err)
-		}
+	sessionSecret, err = co.syncSessionSecret(ctx, updatedOperatorConfig, controllerContext.Recorder())
+	if err != nil {
+		return statusHandler.FlushAndReturn(err)
 	}
 
 	customLogosErr, customLogosErrReason := co.SyncCustomLogos(updatedOperatorConfig)

--- a/pkg/console/operator/sync_v400.go
+++ b/pkg/console/operator/sync_v400.go
@@ -130,10 +130,6 @@ func (co *consoleOperator) sync_v400(ctx context.Context, controllerContext fact
 			statusHandler.AddConditions(status.HandleProgressingOrDegraded("OIDCProviderTrustedAuthorityConfigGet", "", nil))
 		}
 
-		sessionSecret, err = co.syncSessionSecret(ctx, updatedOperatorConfig, controllerContext.Recorder())
-		if err != nil {
-			return statusHandler.FlushAndReturn(err)
-		}
 	default:
 		// Clear any stale OIDC-related degraded/progressing conditions that
 		// may have been set during a previous reconciliation when the
@@ -142,6 +138,12 @@ func (co *consoleOperator) sync_v400(ctx context.Context, controllerContext fact
 		// permanently degraded because the OIDC code path is no longer
 		// executed and the condition is never updated.
 		statusHandler.AddConditions(status.HandleProgressingOrDegraded("OIDCProviderTrustedAuthorityConfigGet", "", nil))
+	}
+
+	// Generate session secret for all auth types
+	sessionSecret, err = co.syncSessionSecret(ctx, updatedOperatorConfig, controllerContext.Recorder())
+	if err != nil {
+		return statusHandler.FlushAndReturn(fmt.Errorf("sync session Secret: %w", err))
 	}
 
 	customLogosErr, customLogosErrReason := co.SyncCustomLogos(updatedOperatorConfig)

--- a/pkg/console/subresource/configmap/configmap_test.go
+++ b/pkg/console/subresource/configmap/configmap_test.go
@@ -123,7 +123,9 @@ clusterInfo:
   masterPublicURL: ` + mockAPIServer + `
   controlPlaneTopology: HighlyAvailable
   releaseVersion: ` + testReleaseVersion + `
-session: {}
+session:
+  cookieEncryptionKeyFile: /var/session-secret/sessionEncryptionKey
+  cookieAuthenticationKeyFile: /var/session-secret/sessionAuthenticationKey
 customization:
   branding: ` + DEFAULT_BRAND + `
   documentationBaseURL: ` + DEFAULT_DOC_URL + `
@@ -189,7 +191,9 @@ clusterInfo:
   consoleBaseAddress: https://` + host + `
   masterPublicURL: ` + mockAPIServer + `
   releaseVersion: ` + testReleaseVersion + `
-session: {}
+session:
+  cookieEncryptionKeyFile: /var/session-secret/sessionEncryptionKey
+  cookieAuthenticationKeyFile: /var/session-secret/sessionAuthenticationKey
 customization:
   branding: ` + DEFAULT_BRAND + `
   documentationBaseURL: ` + DEFAULT_DOC_URL + `
@@ -215,7 +219,9 @@ providers: {}
 				managedConfig: &corev1.ConfigMap{
 					Data: map[string]string{configKey: `kind: ConsoleConfig
 apiVersion: console.openshift.io/v1
-session: {}
+session:
+  cookieEncryptionKeyFile: /var/session-secret/sessionEncryptionKey
+  cookieAuthenticationKeyFile: /var/session-secret/sessionAuthenticationKey
 customization:
   branding: online
   documentationBaseURL: https://docs.okd.io/4.4/
@@ -271,7 +277,9 @@ clusterInfo:
   nodeArchitectures:
   - amd64
   - arm64
-session: {}
+session:
+  cookieEncryptionKeyFile: /var/session-secret/sessionEncryptionKey
+  cookieAuthenticationKeyFile: /var/session-secret/sessionAuthenticationKey
 customization:
   branding: online
   documentationBaseURL: https://docs.okd.io/4.4/
@@ -299,7 +307,9 @@ telemetry:
 				managedConfig: &corev1.ConfigMap{
 					Data: map[string]string{configKey: `kind: ConsoleConfig
 apiVersion: console.openshift.io/v1
-session: {}
+session:
+  cookieEncryptionKeyFile: /var/session-secret/sessionEncryptionKey
+  cookieAuthenticationKeyFile: /var/session-secret/sessionAuthenticationKey
 customization:
   branding: online
   documentationBaseURL: https://docs.okd.io/4.4/
@@ -352,7 +362,9 @@ clusterInfo:
   nodeOperatingSystems:
   - foo
   - bar
-session: {}
+session:
+  cookieEncryptionKeyFile: /var/session-secret/sessionEncryptionKey
+  cookieAuthenticationKeyFile: /var/session-secret/sessionAuthenticationKey
 customization:
   branding: online
   documentationBaseURL: https://docs.okd.io/4.4/
@@ -387,7 +399,9 @@ providers: {}
 				managedConfig: &corev1.ConfigMap{
 					Data: map[string]string{configKey: `kind: ConsoleConfig
 apiVersion: console.openshift.io/v1
-session: {}
+session:
+  cookieEncryptionKeyFile: /var/session-secret/sessionEncryptionKey
+  cookieAuthenticationKeyFile: /var/session-secret/sessionAuthenticationKey
 customization:
   branding: online
   documentationBaseURL: https://docs.okd.io/4.4/
@@ -436,7 +450,9 @@ clusterInfo:
   consoleBaseAddress: https://` + host + `
   masterPublicURL: ` + mockAPIServer + `
   releaseVersion: ` + testReleaseVersion + `
-session: {}
+session:
+  cookieEncryptionKeyFile: /var/session-secret/sessionEncryptionKey
+  cookieAuthenticationKeyFile: /var/session-secret/sessionAuthenticationKey
 customization:
   branding: ` + string(operatorv1.BrandDedicatedLegacy) + `
   documentationBaseURL: ` + mockOperatorDocURL + `
@@ -477,7 +493,9 @@ providers: {}
 				managedConfig: &corev1.ConfigMap{
 					Data: map[string]string{configKey: `kind: ConsoleConfig
 apiVersion: console.openshift.io/v1
-session: {}
+session:
+  cookieEncryptionKeyFile: /var/session-secret/sessionEncryptionKey
+  cookieAuthenticationKeyFile: /var/session-secret/sessionAuthenticationKey
 customization:
   branding: online
   documentationBaseURL: https://docs.okd.io/4.4/
@@ -526,7 +544,9 @@ clusterInfo:
   consoleBaseAddress: https://` + host + `
   masterPublicURL: ` + mockAPIServer + `
   releaseVersion: ` + testReleaseVersion + `
-session: {}
+session:
+  cookieEncryptionKeyFile: /var/session-secret/sessionEncryptionKey
+  cookieAuthenticationKeyFile: /var/session-secret/sessionAuthenticationKey
 customization:
   branding: ` + string(operatorv1.BrandDedicatedLegacy) + `
   documentationBaseURL: ` + mockOperatorDocURL + `
@@ -630,7 +650,9 @@ providers: {}
 				managedConfig: &corev1.ConfigMap{
 					Data: map[string]string{configKey: `kind: ConsoleConfig
 apiVersion: console.openshift.io/v1
-session: {}
+session:
+  cookieEncryptionKeyFile: /var/session-secret/sessionEncryptionKey
+  cookieAuthenticationKeyFile: /var/session-secret/sessionAuthenticationKey
 customization:
   branding: online
   documentationBaseURL: https://docs.okd.io/4.4/
@@ -679,7 +701,9 @@ clusterInfo:
   consoleBaseAddress: https://` + host + `
   masterPublicURL: ` + mockAPIServer + `
   releaseVersion: ` + testReleaseVersion + `
-session: {}
+session:
+  cookieEncryptionKeyFile: /var/session-secret/sessionEncryptionKey
+  cookieAuthenticationKeyFile: /var/session-secret/sessionAuthenticationKey
 customization:
   branding: ` + string(operatorv1.BrandDedicatedLegacy) + `
   documentationBaseURL: ` + mockOperatorDocURL + `
@@ -749,7 +773,9 @@ providers: {}
 				managedConfig: &corev1.ConfigMap{
 					Data: map[string]string{configKey: `kind: ConsoleConfig
 apiVersion: console.openshift.io/v1
-session: {}
+session:
+  cookieEncryptionKeyFile: /var/session-secret/sessionEncryptionKey
+  cookieAuthenticationKeyFile: /var/session-secret/sessionAuthenticationKey
 customization:
   branding: online
   documentationBaseURL: https://docs.okd.io/4.4/
@@ -798,7 +824,9 @@ clusterInfo:
   consoleBaseAddress: https://` + host + `
   masterPublicURL: ` + mockAPIServer + `
   releaseVersion: ` + testReleaseVersion + `
-session: {}
+session:
+  cookieEncryptionKeyFile: /var/session-secret/sessionEncryptionKey
+  cookieAuthenticationKeyFile: /var/session-secret/sessionAuthenticationKey
 customization:
   branding: ` + string(operatorv1.BrandDedicatedLegacy) + `
   documentationBaseURL: ` + mockOperatorDocURL + `
@@ -871,7 +899,9 @@ clusterInfo:
   consoleBaseAddress: https://` + customHostname + `
   masterPublicURL: ` + mockAPIServer + `
   releaseVersion: ` + testReleaseVersion + `
-session: {}
+session:
+  cookieEncryptionKeyFile: /var/session-secret/sessionEncryptionKey
+  cookieAuthenticationKeyFile: /var/session-secret/sessionAuthenticationKey
 customization:
   branding: ` + DEFAULT_BRAND + `
   documentationBaseURL: ` + DEFAULT_DOC_URL + `
@@ -939,7 +969,9 @@ clusterInfo:
   consoleBaseAddress: https://` + host + `
   masterPublicURL: ` + mockAPIServer + `
   releaseVersion: ` + testReleaseVersion + `
-session: {}
+session:
+  cookieEncryptionKeyFile: /var/session-secret/sessionEncryptionKey
+  cookieAuthenticationKeyFile: /var/session-secret/sessionAuthenticationKey
 customization:
   branding: ` + DEFAULT_BRAND + `
   documentationBaseURL: ` + DEFAULT_DOC_URL + `
@@ -1010,7 +1042,9 @@ clusterInfo:
   consoleBaseAddress: https://` + host + `
   masterPublicURL: ` + mockAPIServer + `
   releaseVersion: ` + testReleaseVersion + `
-session: {}
+session:
+  cookieEncryptionKeyFile: /var/session-secret/sessionEncryptionKey
+  cookieAuthenticationKeyFile: /var/session-secret/sessionAuthenticationKey
 customization:
   branding: ` + DEFAULT_BRAND + `
   documentationBaseURL: ` + DEFAULT_DOC_URL + `
@@ -1122,7 +1156,9 @@ clusterInfo:
   masterPublicURL: ` + mockAPIServer + `
   controlPlaneTopology: External
   releaseVersion: ` + testReleaseVersion + `
-session: {}
+session:
+  cookieEncryptionKeyFile: /var/session-secret/sessionEncryptionKey
+  cookieAuthenticationKeyFile: /var/session-secret/sessionAuthenticationKey
 customization:
   branding: ` + DEFAULT_BRAND + `
   documentationBaseURL: ` + DEFAULT_DOC_URL + `
@@ -1192,7 +1228,9 @@ clusterInfo:
   controlPlaneTopology: External
   releaseVersion: ` + testReleaseVersion + `
   copiedCSVsDisabled: true
-session: {}
+session:
+  cookieEncryptionKeyFile: /var/session-secret/sessionEncryptionKey
+  cookieAuthenticationKeyFile: /var/session-secret/sessionAuthenticationKey
 customization:
   branding: ` + DEFAULT_BRAND + `
   documentationBaseURL: ` + DEFAULT_DOC_URL + `
@@ -1266,7 +1304,9 @@ clusterInfo:
   masterPublicURL: ` + mockAPIServer + `
   controlPlaneTopology: HighlyAvailable
   releaseVersion: ` + testReleaseVersion + `
-session: {}
+session:
+  cookieEncryptionKeyFile: /var/session-secret/sessionEncryptionKey
+  cookieAuthenticationKeyFile: /var/session-secret/sessionAuthenticationKey
 customization:
   branding: ` + DEFAULT_BRAND + `
   documentationBaseURL: ` + DEFAULT_DOC_URL + `
@@ -1503,7 +1543,9 @@ func Test_extractYAML(t *testing.T) {
 					},
 					Data: map[string]string{configKey: `kind: ConsoleConfig
 apiVersion: console.openshift.io/v1
-session: {}
+session:
+  cookieEncryptionKeyFile: /var/session-secret/sessionEncryptionKey
+  cookieAuthenticationKeyFile: /var/session-secret/sessionAuthenticationKey
 customization:
   branding: online
   documentationBaseURL: https://docs.okd.io/4.4/
@@ -1514,7 +1556,9 @@ customization:
 			},
 			want: `kind: ConsoleConfig
 apiVersion: console.openshift.io/v1
-session: {}
+session:
+  cookieEncryptionKeyFile: /var/session-secret/sessionEncryptionKey
+  cookieAuthenticationKeyFile: /var/session-secret/sessionAuthenticationKey
 customization:
   branding: online
   documentationBaseURL: https://docs.okd.io/4.4/

--- a/pkg/console/subresource/configmap/configmap_test.go
+++ b/pkg/console/subresource/configmap/configmap_test.go
@@ -123,7 +123,11 @@ clusterInfo:
   masterPublicURL: ` + mockAPIServer + `
   controlPlaneTopology: HighlyAvailable
   releaseVersion: ` + testReleaseVersion + `
-session: {}
+session:
+  cookieEncryptionKeyFile: /var/session-secret/sessionEncryptionKey
+  cookieAuthenticationKeyFile: /var/session-secret/sessionAuthenticationKey
+  previousCookieEncryptionKeyFile: /var/session-secret/previousSessionEncryptionKey
+  previousCookieAuthenticationKeyFile: /var/session-secret/previousSessionAuthenticationKey
 customization:
   branding: ` + DEFAULT_BRAND + `
   documentationBaseURL: ` + DEFAULT_DOC_URL + `
@@ -189,7 +193,11 @@ clusterInfo:
   consoleBaseAddress: https://` + host + `
   masterPublicURL: ` + mockAPIServer + `
   releaseVersion: ` + testReleaseVersion + `
-session: {}
+session:
+  cookieEncryptionKeyFile: /var/session-secret/sessionEncryptionKey
+  cookieAuthenticationKeyFile: /var/session-secret/sessionAuthenticationKey
+  previousCookieEncryptionKeyFile: /var/session-secret/previousSessionEncryptionKey
+  previousCookieAuthenticationKeyFile: /var/session-secret/previousSessionAuthenticationKey
 customization:
   branding: ` + DEFAULT_BRAND + `
   documentationBaseURL: ` + DEFAULT_DOC_URL + `
@@ -215,7 +223,11 @@ providers: {}
 				managedConfig: &corev1.ConfigMap{
 					Data: map[string]string{configKey: `kind: ConsoleConfig
 apiVersion: console.openshift.io/v1
-session: {}
+session:
+  cookieEncryptionKeyFile: /var/session-secret/sessionEncryptionKey
+  cookieAuthenticationKeyFile: /var/session-secret/sessionAuthenticationKey
+  previousCookieEncryptionKeyFile: /var/session-secret/previousSessionEncryptionKey
+  previousCookieAuthenticationKeyFile: /var/session-secret/previousSessionAuthenticationKey
 customization:
   branding: online
   documentationBaseURL: https://docs.okd.io/4.4/
@@ -271,7 +283,11 @@ clusterInfo:
   nodeArchitectures:
   - amd64
   - arm64
-session: {}
+session:
+  cookieEncryptionKeyFile: /var/session-secret/sessionEncryptionKey
+  cookieAuthenticationKeyFile: /var/session-secret/sessionAuthenticationKey
+  previousCookieEncryptionKeyFile: /var/session-secret/previousSessionEncryptionKey
+  previousCookieAuthenticationKeyFile: /var/session-secret/previousSessionAuthenticationKey
 customization:
   branding: online
   documentationBaseURL: https://docs.okd.io/4.4/
@@ -299,7 +315,11 @@ telemetry:
 				managedConfig: &corev1.ConfigMap{
 					Data: map[string]string{configKey: `kind: ConsoleConfig
 apiVersion: console.openshift.io/v1
-session: {}
+session:
+  cookieEncryptionKeyFile: /var/session-secret/sessionEncryptionKey
+  cookieAuthenticationKeyFile: /var/session-secret/sessionAuthenticationKey
+  previousCookieEncryptionKeyFile: /var/session-secret/previousSessionEncryptionKey
+  previousCookieAuthenticationKeyFile: /var/session-secret/previousSessionAuthenticationKey
 customization:
   branding: online
   documentationBaseURL: https://docs.okd.io/4.4/
@@ -352,7 +372,11 @@ clusterInfo:
   nodeOperatingSystems:
   - foo
   - bar
-session: {}
+session:
+  cookieEncryptionKeyFile: /var/session-secret/sessionEncryptionKey
+  cookieAuthenticationKeyFile: /var/session-secret/sessionAuthenticationKey
+  previousCookieEncryptionKeyFile: /var/session-secret/previousSessionEncryptionKey
+  previousCookieAuthenticationKeyFile: /var/session-secret/previousSessionAuthenticationKey
 customization:
   branding: online
   documentationBaseURL: https://docs.okd.io/4.4/
@@ -387,7 +411,11 @@ providers: {}
 				managedConfig: &corev1.ConfigMap{
 					Data: map[string]string{configKey: `kind: ConsoleConfig
 apiVersion: console.openshift.io/v1
-session: {}
+session:
+  cookieEncryptionKeyFile: /var/session-secret/sessionEncryptionKey
+  cookieAuthenticationKeyFile: /var/session-secret/sessionAuthenticationKey
+  previousCookieEncryptionKeyFile: /var/session-secret/previousSessionEncryptionKey
+  previousCookieAuthenticationKeyFile: /var/session-secret/previousSessionAuthenticationKey
 customization:
   branding: online
   documentationBaseURL: https://docs.okd.io/4.4/
@@ -436,7 +464,11 @@ clusterInfo:
   consoleBaseAddress: https://` + host + `
   masterPublicURL: ` + mockAPIServer + `
   releaseVersion: ` + testReleaseVersion + `
-session: {}
+session:
+  cookieEncryptionKeyFile: /var/session-secret/sessionEncryptionKey
+  cookieAuthenticationKeyFile: /var/session-secret/sessionAuthenticationKey
+  previousCookieEncryptionKeyFile: /var/session-secret/previousSessionEncryptionKey
+  previousCookieAuthenticationKeyFile: /var/session-secret/previousSessionAuthenticationKey
 customization:
   branding: ` + string(operatorv1.BrandDedicatedLegacy) + `
   documentationBaseURL: ` + mockOperatorDocURL + `
@@ -477,7 +509,11 @@ providers: {}
 				managedConfig: &corev1.ConfigMap{
 					Data: map[string]string{configKey: `kind: ConsoleConfig
 apiVersion: console.openshift.io/v1
-session: {}
+session:
+  cookieEncryptionKeyFile: /var/session-secret/sessionEncryptionKey
+  cookieAuthenticationKeyFile: /var/session-secret/sessionAuthenticationKey
+  previousCookieEncryptionKeyFile: /var/session-secret/previousSessionEncryptionKey
+  previousCookieAuthenticationKeyFile: /var/session-secret/previousSessionAuthenticationKey
 customization:
   branding: online
   documentationBaseURL: https://docs.okd.io/4.4/
@@ -526,7 +562,11 @@ clusterInfo:
   consoleBaseAddress: https://` + host + `
   masterPublicURL: ` + mockAPIServer + `
   releaseVersion: ` + testReleaseVersion + `
-session: {}
+session:
+  cookieEncryptionKeyFile: /var/session-secret/sessionEncryptionKey
+  cookieAuthenticationKeyFile: /var/session-secret/sessionAuthenticationKey
+  previousCookieEncryptionKeyFile: /var/session-secret/previousSessionEncryptionKey
+  previousCookieAuthenticationKeyFile: /var/session-secret/previousSessionAuthenticationKey
 customization:
   branding: ` + string(operatorv1.BrandDedicatedLegacy) + `
   documentationBaseURL: ` + mockOperatorDocURL + `
@@ -630,7 +670,11 @@ providers: {}
 				managedConfig: &corev1.ConfigMap{
 					Data: map[string]string{configKey: `kind: ConsoleConfig
 apiVersion: console.openshift.io/v1
-session: {}
+session:
+  cookieEncryptionKeyFile: /var/session-secret/sessionEncryptionKey
+  cookieAuthenticationKeyFile: /var/session-secret/sessionAuthenticationKey
+  previousCookieEncryptionKeyFile: /var/session-secret/previousSessionEncryptionKey
+  previousCookieAuthenticationKeyFile: /var/session-secret/previousSessionAuthenticationKey
 customization:
   branding: online
   documentationBaseURL: https://docs.okd.io/4.4/
@@ -679,7 +723,11 @@ clusterInfo:
   consoleBaseAddress: https://` + host + `
   masterPublicURL: ` + mockAPIServer + `
   releaseVersion: ` + testReleaseVersion + `
-session: {}
+session:
+  cookieEncryptionKeyFile: /var/session-secret/sessionEncryptionKey
+  cookieAuthenticationKeyFile: /var/session-secret/sessionAuthenticationKey
+  previousCookieEncryptionKeyFile: /var/session-secret/previousSessionEncryptionKey
+  previousCookieAuthenticationKeyFile: /var/session-secret/previousSessionAuthenticationKey
 customization:
   branding: ` + string(operatorv1.BrandDedicatedLegacy) + `
   documentationBaseURL: ` + mockOperatorDocURL + `
@@ -749,7 +797,11 @@ providers: {}
 				managedConfig: &corev1.ConfigMap{
 					Data: map[string]string{configKey: `kind: ConsoleConfig
 apiVersion: console.openshift.io/v1
-session: {}
+session:
+  cookieEncryptionKeyFile: /var/session-secret/sessionEncryptionKey
+  cookieAuthenticationKeyFile: /var/session-secret/sessionAuthenticationKey
+  previousCookieEncryptionKeyFile: /var/session-secret/previousSessionEncryptionKey
+  previousCookieAuthenticationKeyFile: /var/session-secret/previousSessionAuthenticationKey
 customization:
   branding: online
   documentationBaseURL: https://docs.okd.io/4.4/
@@ -798,7 +850,11 @@ clusterInfo:
   consoleBaseAddress: https://` + host + `
   masterPublicURL: ` + mockAPIServer + `
   releaseVersion: ` + testReleaseVersion + `
-session: {}
+session:
+  cookieEncryptionKeyFile: /var/session-secret/sessionEncryptionKey
+  cookieAuthenticationKeyFile: /var/session-secret/sessionAuthenticationKey
+  previousCookieEncryptionKeyFile: /var/session-secret/previousSessionEncryptionKey
+  previousCookieAuthenticationKeyFile: /var/session-secret/previousSessionAuthenticationKey
 customization:
   branding: ` + string(operatorv1.BrandDedicatedLegacy) + `
   documentationBaseURL: ` + mockOperatorDocURL + `
@@ -871,7 +927,11 @@ clusterInfo:
   consoleBaseAddress: https://` + customHostname + `
   masterPublicURL: ` + mockAPIServer + `
   releaseVersion: ` + testReleaseVersion + `
-session: {}
+session:
+  cookieEncryptionKeyFile: /var/session-secret/sessionEncryptionKey
+  cookieAuthenticationKeyFile: /var/session-secret/sessionAuthenticationKey
+  previousCookieEncryptionKeyFile: /var/session-secret/previousSessionEncryptionKey
+  previousCookieAuthenticationKeyFile: /var/session-secret/previousSessionAuthenticationKey
 customization:
   branding: ` + DEFAULT_BRAND + `
   documentationBaseURL: ` + DEFAULT_DOC_URL + `
@@ -939,7 +999,11 @@ clusterInfo:
   consoleBaseAddress: https://` + host + `
   masterPublicURL: ` + mockAPIServer + `
   releaseVersion: ` + testReleaseVersion + `
-session: {}
+session:
+  cookieEncryptionKeyFile: /var/session-secret/sessionEncryptionKey
+  cookieAuthenticationKeyFile: /var/session-secret/sessionAuthenticationKey
+  previousCookieEncryptionKeyFile: /var/session-secret/previousSessionEncryptionKey
+  previousCookieAuthenticationKeyFile: /var/session-secret/previousSessionAuthenticationKey
 customization:
   branding: ` + DEFAULT_BRAND + `
   documentationBaseURL: ` + DEFAULT_DOC_URL + `
@@ -1010,7 +1074,11 @@ clusterInfo:
   consoleBaseAddress: https://` + host + `
   masterPublicURL: ` + mockAPIServer + `
   releaseVersion: ` + testReleaseVersion + `
-session: {}
+session:
+  cookieEncryptionKeyFile: /var/session-secret/sessionEncryptionKey
+  cookieAuthenticationKeyFile: /var/session-secret/sessionAuthenticationKey
+  previousCookieEncryptionKeyFile: /var/session-secret/previousSessionEncryptionKey
+  previousCookieAuthenticationKeyFile: /var/session-secret/previousSessionAuthenticationKey
 customization:
   branding: ` + DEFAULT_BRAND + `
   documentationBaseURL: ` + DEFAULT_DOC_URL + `
@@ -1122,7 +1190,11 @@ clusterInfo:
   masterPublicURL: ` + mockAPIServer + `
   controlPlaneTopology: External
   releaseVersion: ` + testReleaseVersion + `
-session: {}
+session:
+  cookieEncryptionKeyFile: /var/session-secret/sessionEncryptionKey
+  cookieAuthenticationKeyFile: /var/session-secret/sessionAuthenticationKey
+  previousCookieEncryptionKeyFile: /var/session-secret/previousSessionEncryptionKey
+  previousCookieAuthenticationKeyFile: /var/session-secret/previousSessionAuthenticationKey
 customization:
   branding: ` + DEFAULT_BRAND + `
   documentationBaseURL: ` + DEFAULT_DOC_URL + `
@@ -1192,7 +1264,11 @@ clusterInfo:
   controlPlaneTopology: External
   releaseVersion: ` + testReleaseVersion + `
   copiedCSVsDisabled: true
-session: {}
+session:
+  cookieEncryptionKeyFile: /var/session-secret/sessionEncryptionKey
+  cookieAuthenticationKeyFile: /var/session-secret/sessionAuthenticationKey
+  previousCookieEncryptionKeyFile: /var/session-secret/previousSessionEncryptionKey
+  previousCookieAuthenticationKeyFile: /var/session-secret/previousSessionAuthenticationKey
 customization:
   branding: ` + DEFAULT_BRAND + `
   documentationBaseURL: ` + DEFAULT_DOC_URL + `
@@ -1266,7 +1342,11 @@ clusterInfo:
   masterPublicURL: ` + mockAPIServer + `
   controlPlaneTopology: HighlyAvailable
   releaseVersion: ` + testReleaseVersion + `
-session: {}
+session:
+  cookieEncryptionKeyFile: /var/session-secret/sessionEncryptionKey
+  cookieAuthenticationKeyFile: /var/session-secret/sessionAuthenticationKey
+  previousCookieEncryptionKeyFile: /var/session-secret/previousSessionEncryptionKey
+  previousCookieAuthenticationKeyFile: /var/session-secret/previousSessionAuthenticationKey
 customization:
   branding: ` + DEFAULT_BRAND + `
   documentationBaseURL: ` + DEFAULT_DOC_URL + `
@@ -1505,7 +1585,11 @@ func Test_extractYAML(t *testing.T) {
 					},
 					Data: map[string]string{configKey: `kind: ConsoleConfig
 apiVersion: console.openshift.io/v1
-session: {}
+session:
+  cookieEncryptionKeyFile: /var/session-secret/sessionEncryptionKey
+  cookieAuthenticationKeyFile: /var/session-secret/sessionAuthenticationKey
+  previousCookieEncryptionKeyFile: /var/session-secret/previousSessionEncryptionKey
+  previousCookieAuthenticationKeyFile: /var/session-secret/previousSessionAuthenticationKey
 customization:
   branding: online
   documentationBaseURL: https://docs.okd.io/4.4/
@@ -1516,7 +1600,11 @@ customization:
 			},
 			want: `kind: ConsoleConfig
 apiVersion: console.openshift.io/v1
-session: {}
+session:
+  cookieEncryptionKeyFile: /var/session-secret/sessionEncryptionKey
+  cookieAuthenticationKeyFile: /var/session-secret/sessionAuthenticationKey
+  previousCookieEncryptionKeyFile: /var/session-secret/previousSessionEncryptionKey
+  previousCookieAuthenticationKeyFile: /var/session-secret/previousSessionAuthenticationKey
 customization:
   branding: online
   documentationBaseURL: https://docs.okd.io/4.4/

--- a/pkg/console/subresource/consoleserver/config_builder.go
+++ b/pkg/console/subresource/consoleserver/config_builder.go
@@ -483,27 +483,11 @@ func (b *ConsoleServerCLIConfigBuilder) session() Session {
 	if b.authType == "disabled" {
 		return Session{}
 	}
-	authFile := b.sessionAuthenticationFile
-	encFile := b.sessionEncryptionFile
-	if authFile == "" {
-		authFile = sessionAuthKeyFilePath
-	}
-	if encFile == "" {
-		encFile = sessionEncKeyFilePath
-	}
-	prevAuthFile := b.previousSessionAuthenticationFile
-	prevEncFile := b.previousSessionEncryptionFile
-	if prevAuthFile == "" {
-		prevAuthFile = previousSessionAuthKeyFilePath
-	}
-	if prevEncFile == "" {
-		prevEncFile = previousSessionEncKeyFilePath
-	}
 	return Session{
-		CookieAuthenticationKeyFile:         authFile,
-		CookieEncryptionKeyFile:             encFile,
-		PreviousCookieAuthenticationKeyFile: prevAuthFile,
-		PreviousCookieEncryptionKeyFile:     prevEncFile,
+		CookieAuthenticationKeyFile:         b.sessionAuthenticationFile,
+		CookieEncryptionKeyFile:             b.sessionEncryptionFile,
+		PreviousCookieAuthenticationKeyFile: b.previousSessionAuthenticationFile,
+		PreviousCookieEncryptionKeyFile:     b.previousSessionEncryptionFile,
 	}
 }
 

--- a/pkg/console/subresource/consoleserver/config_builder.go
+++ b/pkg/console/subresource/consoleserver/config_builder.go
@@ -21,8 +21,12 @@ const (
 	clientSecretFilePath     = "/var/oauth-config/clientSecret"
 	oauthServingCertFilePath = "/var/oauth-serving-cert/ca-bundle.crt"
 	// serving info
-	certFilePath = "/var/serving-cert/tls.crt"
-	keyFilePath  = "/var/serving-cert/tls.key"
+	certFilePath                   = "/var/serving-cert/tls.crt"
+	keyFilePath                    = "/var/serving-cert/tls.key"
+	sessionAuthKeyFilePath         = "/var/session-secret/sessionAuthenticationKey"
+	sessionEncKeyFilePath          = "/var/session-secret/sessionEncryptionKey"
+	previousSessionAuthKeyFilePath = "/var/session-secret/previousSessionAuthenticationKey"
+	previousSessionEncKeyFilePath  = "/var/session-secret/previousSessionEncryptionKey"
 )
 
 // SupportedLightspeedArchitectures defines the list of architectures that support Lightspeed.
@@ -46,47 +50,49 @@ var SupportedLightspeedArchitectures = []string{"amd64"}
 //
 //	b.Host().Brand("").Config()
 type ConsoleServerCLIConfigBuilder struct {
-	host                        string
-	logoutRedirectURL           string
-	brand                       operatorv1.Brand
-	docURL                      string
-	apiServerURL                string
-	controlPlaneToplogy         configv1.TopologyMode
-	statusPageID                string
-	customProductName           string
-	devCatalogCustomization     operatorv1.DeveloperConsoleCatalogCustomization
-	projectAccess               operatorv1.ProjectAccess
-	quickStarts                 operatorv1.QuickStarts
-	addPage                     operatorv1.AddPage
-	perspectives                []operatorv1.Perspective
-	CAFile                      string
-	monitoring                  map[string]string
-	customHostnameRedirectPort  int
-	inactivityTimeoutSeconds    int
-	pluginsList                 map[string]string
-	pluginsOrder                []string
-	i18nNamespaceList           []string
-	proxyServices               []ProxyService
-	telemetry                   map[string]string
-	releaseVersion              string
-	nodeArchitectures           []string
-	nodeOperatingSystems        []string
-	copiedCSVsDisabled          bool
-	oauthClientID               string
-	oidcExtraScopes             []string
-	oidcIssuerURL               string
-	oidcOCLoginCommand          string
-	authType                    string
-	sessionEncryptionFile       string
-	sessionAuthenticationFile   string
-	capabilities                []operatorv1.Capability
-	contentSecurityPolicyList   map[v1.DirectiveType][]string
-	logos                       []operatorv1.Logo
-	techPreviewEnabled          bool
-	olmLifecycleMetadataEnabled bool
-	additionalHosts             []string
-	minTLSVersion               string
-	cipherSuites                []string
+	host                              string
+	logoutRedirectURL                 string
+	brand                             operatorv1.Brand
+	docURL                            string
+	apiServerURL                      string
+	controlPlaneToplogy               configv1.TopologyMode
+	statusPageID                      string
+	customProductName                 string
+	devCatalogCustomization           operatorv1.DeveloperConsoleCatalogCustomization
+	projectAccess                     operatorv1.ProjectAccess
+	quickStarts                       operatorv1.QuickStarts
+	addPage                           operatorv1.AddPage
+	perspectives                      []operatorv1.Perspective
+	CAFile                            string
+	monitoring                        map[string]string
+	customHostnameRedirectPort        int
+	inactivityTimeoutSeconds          int
+	pluginsList                       map[string]string
+	pluginsOrder                      []string
+	i18nNamespaceList                 []string
+	proxyServices                     []ProxyService
+	telemetry                         map[string]string
+	releaseVersion                    string
+	nodeArchitectures                 []string
+	nodeOperatingSystems              []string
+	copiedCSVsDisabled                bool
+	oauthClientID                     string
+	oidcExtraScopes                   []string
+	oidcIssuerURL                     string
+	oidcOCLoginCommand                string
+	authType                          string
+	sessionEncryptionFile             string
+	sessionAuthenticationFile         string
+	previousSessionEncryptionFile     string
+	previousSessionAuthenticationFile string
+	capabilities                      []operatorv1.Capability
+	contentSecurityPolicyList         map[v1.DirectiveType][]string
+	logos                             []operatorv1.Logo
+	techPreviewEnabled                bool
+	olmLifecycleMetadataEnabled       bool
+	additionalHosts                   []string
+	minTLSVersion                     string
+	cipherSuites                      []string
 }
 
 func (b *ConsoleServerCLIConfigBuilder) Host(host string) *ConsoleServerCLIConfigBuilder {
@@ -200,6 +206,10 @@ func (b *ConsoleServerCLIConfigBuilder) AuthConfig(authnConfig *configv1.Authent
 		b.authType = "openshift"
 		b.oauthClientID = api.OAuthClientName
 		b.CAFile = oauthServingCertFilePath
+		b.sessionAuthenticationFile = sessionAuthKeyFilePath
+		b.sessionEncryptionFile = sessionEncKeyFilePath
+		b.previousSessionAuthenticationFile = previousSessionAuthKeyFilePath
+		b.previousSessionEncryptionFile = previousSessionEncKeyFilePath
 		return b
 
 	case configv1.AuthenticationTypeOIDC:
@@ -219,8 +229,10 @@ func (b *ConsoleServerCLIConfigBuilder) AuthConfig(authnConfig *configv1.Authent
 		b.oauthClientID = oidcConfig.ClientID
 		b.oidcExtraScopes = oidcConfig.ExtraScopes
 		b.oidcOCLoginCommand = authconfigsub.GetOIDCOCLoginCommand(authnConfig, apiServerURL)
-		b.sessionAuthenticationFile = "/var/session-secret/sessionAuthenticationKey"
-		b.sessionEncryptionFile = "/var/session-secret/sessionEncryptionKey"
+		b.sessionAuthenticationFile = sessionAuthKeyFilePath
+		b.sessionEncryptionFile = sessionEncKeyFilePath
+		b.previousSessionAuthenticationFile = previousSessionAuthKeyFilePath
+		b.previousSessionEncryptionFile = previousSessionEncKeyFilePath
 
 		if len(oidcProvider.Issuer.CertificateAuthority.Name) > 0 {
 			b.CAFile = path.Join(api.AuthServerCAMountDir, api.AuthServerCAFileName)
@@ -468,11 +480,31 @@ func (b *ConsoleServerCLIConfigBuilder) auth() Auth {
 }
 
 func (b *ConsoleServerCLIConfigBuilder) session() Session {
-	conf := Session{
-		CookieAuthenticationKeyFile: b.sessionAuthenticationFile,
-		CookieEncryptionKeyFile:     b.sessionEncryptionFile,
+	if b.authType == "disabled" {
+		return Session{}
 	}
-	return conf
+	authFile := b.sessionAuthenticationFile
+	encFile := b.sessionEncryptionFile
+	if authFile == "" {
+		authFile = sessionAuthKeyFilePath
+	}
+	if encFile == "" {
+		encFile = sessionEncKeyFilePath
+	}
+	prevAuthFile := b.previousSessionAuthenticationFile
+	prevEncFile := b.previousSessionEncryptionFile
+	if prevAuthFile == "" {
+		prevAuthFile = previousSessionAuthKeyFilePath
+	}
+	if prevEncFile == "" {
+		prevEncFile = previousSessionEncKeyFilePath
+	}
+	return Session{
+		CookieAuthenticationKeyFile:         authFile,
+		CookieEncryptionKeyFile:             encFile,
+		PreviousCookieAuthenticationKeyFile: prevAuthFile,
+		PreviousCookieEncryptionKeyFile:     prevEncFile,
+	}
 }
 
 func (b *ConsoleServerCLIConfigBuilder) customization() Customization {

--- a/pkg/console/subresource/consoleserver/config_builder.go
+++ b/pkg/console/subresource/consoleserver/config_builder.go
@@ -21,8 +21,10 @@ const (
 	clientSecretFilePath     = "/var/oauth-config/clientSecret"
 	oauthServingCertFilePath = "/var/oauth-serving-cert/ca-bundle.crt"
 	// serving info
-	certFilePath = "/var/serving-cert/tls.crt"
-	keyFilePath  = "/var/serving-cert/tls.key"
+	certFilePath             = "/var/serving-cert/tls.crt"
+	keyFilePath              = "/var/serving-cert/tls.key"
+	sessionAuthKeyFilePath   = "/var/session-secret/sessionAuthenticationKey"
+	sessionEncKeyFilePath    = "/var/session-secret/sessionEncryptionKey"
 )
 
 // SupportedLightspeedArchitectures defines the list of architectures that support Lightspeed.
@@ -198,6 +200,8 @@ func (b *ConsoleServerCLIConfigBuilder) AuthConfig(authnConfig *configv1.Authent
 		b.authType = "openshift"
 		b.oauthClientID = api.OAuthClientName
 		b.CAFile = oauthServingCertFilePath
+		b.sessionAuthenticationFile = sessionAuthKeyFilePath
+		b.sessionEncryptionFile = sessionEncKeyFilePath
 		return b
 
 	case configv1.AuthenticationTypeOIDC:
@@ -217,8 +221,8 @@ func (b *ConsoleServerCLIConfigBuilder) AuthConfig(authnConfig *configv1.Authent
 		b.oauthClientID = oidcConfig.ClientID
 		b.oidcExtraScopes = oidcConfig.ExtraScopes
 		b.oidcOCLoginCommand = authconfigsub.GetOIDCOCLoginCommand(authnConfig, apiServerURL)
-		b.sessionAuthenticationFile = "/var/session-secret/sessionAuthenticationKey"
-		b.sessionEncryptionFile = "/var/session-secret/sessionEncryptionKey"
+		b.sessionAuthenticationFile = sessionAuthKeyFilePath
+		b.sessionEncryptionFile = sessionEncKeyFilePath
 
 		if len(oidcProvider.Issuer.CertificateAuthority.Name) > 0 {
 			b.CAFile = path.Join(api.AuthServerCAMountDir, api.AuthServerCAFileName)
@@ -452,11 +456,21 @@ func (b *ConsoleServerCLIConfigBuilder) auth() Auth {
 }
 
 func (b *ConsoleServerCLIConfigBuilder) session() Session {
-	conf := Session{
-		CookieAuthenticationKeyFile: b.sessionAuthenticationFile,
-		CookieEncryptionKeyFile:     b.sessionEncryptionFile,
+	if b.authType == "disabled" {
+		return Session{}
 	}
-	return conf
+	authFile := b.sessionAuthenticationFile
+	encFile := b.sessionEncryptionFile
+	if authFile == "" {
+		authFile = sessionAuthKeyFilePath
+	}
+	if encFile == "" {
+		encFile = sessionEncKeyFilePath
+	}
+	return Session{
+		CookieAuthenticationKeyFile: authFile,
+		CookieEncryptionKeyFile:     encFile,
+	}
 }
 
 func (b *ConsoleServerCLIConfigBuilder) customization() Customization {

--- a/pkg/console/subresource/consoleserver/config_builder_test.go
+++ b/pkg/console/subresource/consoleserver/config_builder_test.go
@@ -71,6 +71,10 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 					ClientID:         api.OpenShiftConsoleName,
 					ClientSecretFile: clientSecretFilePath,
 				},
+				Session: Session{
+					CookieEncryptionKeyFile:     "/var/session-secret/sessionEncryptionKey",
+					CookieAuthenticationKeyFile: "/var/session-secret/sessionAuthenticationKey",
+				},
 				Customization: Customization{
 					Perspectives: []Perspective{
 						{
@@ -102,6 +106,10 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 				Auth: Auth{
 					ClientID:         api.OpenShiftConsoleName,
 					ClientSecretFile: clientSecretFilePath,
+				},
+				Session: Session{
+					CookieEncryptionKeyFile:     "/var/session-secret/sessionEncryptionKey",
+					CookieAuthenticationKeyFile: "/var/session-secret/sessionAuthenticationKey",
 				},
 				Customization: Customization{
 					Perspectives: []Perspective{
@@ -145,6 +153,10 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 				Auth: Auth{
 					ClientID:         api.OpenShiftConsoleName,
 					ClientSecretFile: clientSecretFilePath,
+				},
+				Session: Session{
+					CookieEncryptionKeyFile:     "/var/session-secret/sessionEncryptionKey",
+					CookieAuthenticationKeyFile: "/var/session-secret/sessionAuthenticationKey",
 				},
 				Customization: Customization{
 					Capabilities: []v1.Capability{
@@ -195,6 +207,10 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 					ClientSecretFile:    clientSecretFilePath,
 					OAuthEndpointCAFile: "/var/oauth-serving-cert/ca-bundle.crt",
 					LogoutRedirect:      "https://foobar.com/logout",
+				},
+				Session: Session{
+					CookieEncryptionKeyFile:     "/var/session-secret/sessionEncryptionKey",
+					CookieAuthenticationKeyFile: "/var/session-secret/sessionAuthenticationKey",
 				},
 				Customization: Customization{
 
@@ -346,6 +362,10 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 					ClientID:         api.OpenShiftConsoleName,
 					ClientSecretFile: clientSecretFilePath,
 				},
+				Session: Session{
+					CookieEncryptionKeyFile:     "/var/session-secret/sessionEncryptionKey",
+					CookieAuthenticationKeyFile: "/var/session-secret/sessionAuthenticationKey",
+				},
 				Customization: Customization{
 					Perspectives: []Perspective{
 						{
@@ -380,6 +400,10 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 				Auth: Auth{
 					ClientID:         api.OpenShiftConsoleName,
 					ClientSecretFile: clientSecretFilePath,
+				},
+				Session: Session{
+					CookieEncryptionKeyFile:     "/var/session-secret/sessionEncryptionKey",
+					CookieAuthenticationKeyFile: "/var/session-secret/sessionAuthenticationKey",
 				},
 				Customization: Customization{
 					Perspectives: []Perspective{
@@ -416,7 +440,10 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 					ClientID:         api.OpenShiftConsoleName,
 					ClientSecretFile: clientSecretFilePath,
 				},
-				Session: Session{},
+				Session: Session{
+					CookieEncryptionKeyFile:     "/var/session-secret/sessionEncryptionKey",
+					CookieAuthenticationKeyFile: "/var/session-secret/sessionAuthenticationKey",
+				},
 				Customization: Customization{
 					DeveloperCatalog: &DeveloperConsoleCatalogCustomization{
 						Categories: &[]DeveloperConsoleCatalogCategory{},
@@ -476,7 +503,10 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 					ClientID:         api.OpenShiftConsoleName,
 					ClientSecretFile: clientSecretFilePath,
 				},
-				Session: Session{},
+				Session: Session{
+					CookieEncryptionKeyFile:     "/var/session-secret/sessionEncryptionKey",
+					CookieAuthenticationKeyFile: "/var/session-secret/sessionAuthenticationKey",
+				},
 				Customization: Customization{
 					Perspectives: []Perspective{
 						{
@@ -536,7 +566,10 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 					ClientID:         api.OpenShiftConsoleName,
 					ClientSecretFile: clientSecretFilePath,
 				},
-				Session: Session{},
+				Session: Session{
+					CookieEncryptionKeyFile:     "/var/session-secret/sessionEncryptionKey",
+					CookieAuthenticationKeyFile: "/var/session-secret/sessionAuthenticationKey",
+				},
 				Customization: Customization{
 					DeveloperCatalog: &DeveloperConsoleCatalogCustomization{
 						Categories: nil,
@@ -576,7 +609,10 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 					ClientID:         api.OpenShiftConsoleName,
 					ClientSecretFile: clientSecretFilePath,
 				},
-				Session: Session{},
+				Session: Session{
+					CookieEncryptionKeyFile:     "/var/session-secret/sessionEncryptionKey",
+					CookieAuthenticationKeyFile: "/var/session-secret/sessionAuthenticationKey",
+				},
 				Customization: Customization{
 					DeveloperCatalog: &DeveloperConsoleCatalogCustomization{
 						Categories: nil,
@@ -616,7 +652,10 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 					ClientID:         api.OpenShiftConsoleName,
 					ClientSecretFile: clientSecretFilePath,
 				},
-				Session: Session{},
+				Session: Session{
+					CookieEncryptionKeyFile:     "/var/session-secret/sessionEncryptionKey",
+					CookieAuthenticationKeyFile: "/var/session-secret/sessionAuthenticationKey",
+				},
 				Customization: Customization{
 					ProjectAccess: ProjectAccess{
 						AvailableClusterRoles: []string{"View", "Edit", "Admin"},
@@ -655,7 +694,10 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 					ClientID:         api.OpenShiftConsoleName,
 					ClientSecretFile: clientSecretFilePath,
 				},
-				Session: Session{},
+				Session: Session{
+					CookieEncryptionKeyFile:     "/var/session-secret/sessionEncryptionKey",
+					CookieAuthenticationKeyFile: "/var/session-secret/sessionAuthenticationKey",
+				},
 				Customization: Customization{
 					QuickStarts: QuickStarts{
 						Disabled: []string{"quick-start0", "quick-start1", "quick-start2"},
@@ -708,7 +750,10 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 					ClientID:         api.OpenShiftConsoleName,
 					ClientSecretFile: clientSecretFilePath,
 				},
-				Session: Session{},
+				Session: Session{
+					CookieEncryptionKeyFile:     "/var/session-secret/sessionEncryptionKey",
+					CookieAuthenticationKeyFile: "/var/session-secret/sessionAuthenticationKey",
+				},
 				Customization: Customization{
 					Perspectives: []Perspective{
 						{
@@ -773,7 +818,10 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 					ClientID:         api.OpenShiftConsoleName,
 					ClientSecretFile: clientSecretFilePath,
 				},
-				Session: Session{},
+				Session: Session{
+					CookieEncryptionKeyFile:     "/var/session-secret/sessionEncryptionKey",
+					CookieAuthenticationKeyFile: "/var/session-secret/sessionAuthenticationKey",
+				},
 				Customization: Customization{
 					Perspectives: []Perspective{
 						{ID: "perspective1",
@@ -837,7 +885,10 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 					ClientID:         api.OpenShiftConsoleName,
 					ClientSecretFile: clientSecretFilePath,
 				},
-				Session: Session{},
+				Session: Session{
+					CookieEncryptionKeyFile:     "/var/session-secret/sessionEncryptionKey",
+					CookieAuthenticationKeyFile: "/var/session-secret/sessionAuthenticationKey",
+				},
 				Customization: Customization{
 					Perspectives: []Perspective{
 						{ID: "perspective1",
@@ -894,7 +945,10 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 					ClientSecretFile: clientSecretFilePath,
 					LogoutRedirect:   "https://foobar.com/logout",
 				},
-				Session: Session{},
+				Session: Session{
+					CookieEncryptionKeyFile:     "/var/session-secret/sessionEncryptionKey",
+					CookieAuthenticationKeyFile: "/var/session-secret/sessionAuthenticationKey",
+				},
 				Customization: Customization{
 					Branding:             "okd",
 					DocumentationBaseURL: "https://foobar.com/docs",
@@ -948,7 +1002,10 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 					ClientID:         api.OpenShiftConsoleName,
 					ClientSecretFile: clientSecretFilePath,
 				},
-				Session: Session{},
+				Session: Session{
+					CookieEncryptionKeyFile:     "/var/session-secret/sessionEncryptionKey",
+					CookieAuthenticationKeyFile: "/var/session-secret/sessionAuthenticationKey",
+				},
 				Customization: Customization{
 					Perspectives: []Perspective{
 						{
@@ -988,6 +1045,10 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 				Auth: Auth{
 					ClientID:         api.OpenShiftConsoleName,
 					ClientSecretFile: clientSecretFilePath,
+				},
+				Session: Session{
+					CookieEncryptionKeyFile:     "/var/session-secret/sessionEncryptionKey",
+					CookieAuthenticationKeyFile: "/var/session-secret/sessionAuthenticationKey",
 				},
 				Customization: Customization{
 					Perspectives: []Perspective{
@@ -1029,6 +1090,10 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 				Auth: Auth{
 					ClientID:         api.OpenShiftConsoleName,
 					ClientSecretFile: clientSecretFilePath,
+				},
+				Session: Session{
+					CookieEncryptionKeyFile:     "/var/session-secret/sessionEncryptionKey",
+					CookieAuthenticationKeyFile: "/var/session-secret/sessionAuthenticationKey",
 				},
 				Customization: Customization{
 					Perspectives: []Perspective{
@@ -1083,7 +1148,9 @@ clusterInfo: {}
 auth:
   clientID: console
   clientSecretFile: /var/oauth-config/clientSecret
-session: {}
+session:
+  cookieEncryptionKeyFile: /var/session-secret/sessionEncryptionKey
+  cookieAuthenticationKeyFile: /var/session-secret/sessionAuthenticationKey
 customization:
   perspectives:
   - id: dev
@@ -1166,7 +1233,9 @@ auth:
   clientSecretFile: /var/oauth-config/clientSecret
   oauthEndpointCAFile: /var/oauth-serving-cert/ca-bundle.crt
   logoutRedirect: https://foobar.com/logout
-session: {}
+session:
+  cookieEncryptionKeyFile: /var/session-secret/sessionEncryptionKey
+  cookieAuthenticationKeyFile: /var/session-secret/sessionAuthenticationKey
 customization:
   perspectives:
   - id: dev
@@ -1191,7 +1260,9 @@ clusterInfo: {}
 auth:
   clientID: console
   clientSecretFile: /var/oauth-config/clientSecret
-session: {}
+session:
+  cookieEncryptionKeyFile: /var/session-secret/sessionEncryptionKey
+  cookieAuthenticationKeyFile: /var/session-secret/sessionAuthenticationKey
 customization:
   perspectives:
   - id: dev
@@ -1218,7 +1289,9 @@ clusterInfo: {}
 auth:
   clientID: console
   clientSecretFile: /var/oauth-config/clientSecret
-session: {}
+session:
+  cookieEncryptionKeyFile: /var/session-secret/sessionEncryptionKey
+  cookieAuthenticationKeyFile: /var/session-secret/sessionAuthenticationKey
 customization:
   perspectives:
   - id: dev
@@ -1246,7 +1319,9 @@ clusterInfo: {}
 auth:
   clientID: console
   clientSecretFile: /var/oauth-config/clientSecret
-session: {}
+session:
+  cookieEncryptionKeyFile: /var/session-secret/sessionEncryptionKey
+  cookieAuthenticationKeyFile: /var/session-secret/sessionAuthenticationKey
 customization:
   developerCatalog:
     categories: []
@@ -1298,7 +1373,9 @@ clusterInfo: {}
 auth:
   clientID: console
   clientSecretFile: /var/oauth-config/clientSecret
-session: {}
+session:
+  cookieEncryptionKeyFile: /var/session-secret/sessionEncryptionKey
+  cookieAuthenticationKeyFile: /var/session-secret/sessionAuthenticationKey
 customization:
   developerCatalog:
     categories:
@@ -1342,7 +1419,9 @@ clusterInfo: {}
 auth:
   clientID: console
   clientSecretFile: /var/oauth-config/clientSecret
-session: {}
+session:
+  cookieEncryptionKeyFile: /var/session-secret/sessionEncryptionKey
+  cookieAuthenticationKeyFile: /var/session-secret/sessionAuthenticationKey
 customization:
   developerCatalog:
     categories: null
@@ -1377,7 +1456,9 @@ clusterInfo: {}
 auth:
   clientID: console
   clientSecretFile: /var/oauth-config/clientSecret
-session: {}
+session:
+  cookieEncryptionKeyFile: /var/session-secret/sessionEncryptionKey
+  cookieAuthenticationKeyFile: /var/session-secret/sessionAuthenticationKey
 customization:
   developerCatalog:
     categories: null
@@ -1413,7 +1494,9 @@ clusterInfo: {}
 auth:
   clientID: console
   clientSecretFile: /var/oauth-config/clientSecret
-session: {}
+session:
+  cookieEncryptionKeyFile: /var/session-secret/sessionEncryptionKey
+  cookieAuthenticationKeyFile: /var/session-secret/sessionAuthenticationKey
 customization:
   addPage:
     disabledActions:
@@ -1498,7 +1581,9 @@ clusterInfo: {}
 auth:
   clientID: console
   clientSecretFile: /var/oauth-config/clientSecret
-session: {}
+session:
+  cookieEncryptionKeyFile: /var/session-secret/sessionEncryptionKey
+  cookieAuthenticationKeyFile: /var/session-secret/sessionAuthenticationKey
 customization:
   quickStarts:
     disabled:
@@ -1544,7 +1629,9 @@ clusterInfo: {}
 auth:
   clientID: console
   clientSecretFile: /var/oauth-config/clientSecret
-session: {}
+session:
+  cookieEncryptionKeyFile: /var/session-secret/sessionEncryptionKey
+  cookieAuthenticationKeyFile: /var/session-secret/sessionAuthenticationKey
 customization:
   perspectives:
   - id: perspective1
@@ -1614,7 +1701,9 @@ clusterInfo: {}
 auth:
   clientID: console
   clientSecretFile: /var/oauth-config/clientSecret
-session: {}
+session:
+  cookieEncryptionKeyFile: /var/session-secret/sessionEncryptionKey
+  cookieAuthenticationKeyFile: /var/session-secret/sessionAuthenticationKey
 customization:
   perspectives:
   - id: perspective1
@@ -1688,7 +1777,9 @@ clusterInfo: {}
 auth:
   clientID: console
   clientSecretFile: /var/oauth-config/clientSecret
-session: {}
+session:
+  cookieEncryptionKeyFile: /var/session-secret/sessionEncryptionKey
+  cookieAuthenticationKeyFile: /var/session-secret/sessionAuthenticationKey
 customization:
   perspectives:
   - id: perspective1
@@ -1742,7 +1833,9 @@ clusterInfo: {}
 auth:
   clientID: console
   clientSecretFile: /var/oauth-config/clientSecret
-session: {}
+session:
+  cookieEncryptionKeyFile: /var/session-secret/sessionEncryptionKey
+  cookieAuthenticationKeyFile: /var/session-secret/sessionAuthenticationKey
 customization:
   perspectives:
   - id: dev
@@ -1778,7 +1871,9 @@ clusterInfo: {}
 auth:
   clientID: console
   clientSecretFile: /var/oauth-config/clientSecret
-session: {}
+session:
+  cookieEncryptionKeyFile: /var/session-secret/sessionEncryptionKey
+  cookieAuthenticationKeyFile: /var/session-secret/sessionAuthenticationKey
 customization:
   perspectives:
   - id: dev

--- a/pkg/console/subresource/consoleserver/config_builder_test.go
+++ b/pkg/console/subresource/consoleserver/config_builder_test.go
@@ -71,12 +71,7 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 					ClientID:         api.OpenShiftConsoleName,
 					ClientSecretFile: clientSecretFilePath,
 				},
-				Session: Session{
-					CookieEncryptionKeyFile:             "/var/session-secret/sessionEncryptionKey",
-					CookieAuthenticationKeyFile:         "/var/session-secret/sessionAuthenticationKey",
-					PreviousCookieEncryptionKeyFile:     "/var/session-secret/previousSessionEncryptionKey",
-					PreviousCookieAuthenticationKeyFile: "/var/session-secret/previousSessionAuthenticationKey",
-				},
+				Session: Session{},
 				Customization: Customization{
 					Perspectives: []Perspective{
 						{
@@ -109,12 +104,7 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 					ClientID:         api.OpenShiftConsoleName,
 					ClientSecretFile: clientSecretFilePath,
 				},
-				Session: Session{
-					CookieEncryptionKeyFile:             "/var/session-secret/sessionEncryptionKey",
-					CookieAuthenticationKeyFile:         "/var/session-secret/sessionAuthenticationKey",
-					PreviousCookieEncryptionKeyFile:     "/var/session-secret/previousSessionEncryptionKey",
-					PreviousCookieAuthenticationKeyFile: "/var/session-secret/previousSessionAuthenticationKey",
-				},
+				Session: Session{},
 				Customization: Customization{
 					Perspectives: []Perspective{
 						{
@@ -158,12 +148,7 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 					ClientID:         api.OpenShiftConsoleName,
 					ClientSecretFile: clientSecretFilePath,
 				},
-				Session: Session{
-					CookieEncryptionKeyFile:             "/var/session-secret/sessionEncryptionKey",
-					CookieAuthenticationKeyFile:         "/var/session-secret/sessionAuthenticationKey",
-					PreviousCookieEncryptionKeyFile:     "/var/session-secret/previousSessionEncryptionKey",
-					PreviousCookieAuthenticationKeyFile: "/var/session-secret/previousSessionAuthenticationKey",
-				},
+				Session: Session{},
 				Customization: Customization{
 					Capabilities: []v1.Capability{
 						{
@@ -372,12 +357,7 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 					ClientID:         api.OpenShiftConsoleName,
 					ClientSecretFile: clientSecretFilePath,
 				},
-				Session: Session{
-					CookieEncryptionKeyFile:             "/var/session-secret/sessionEncryptionKey",
-					CookieAuthenticationKeyFile:         "/var/session-secret/sessionAuthenticationKey",
-					PreviousCookieEncryptionKeyFile:     "/var/session-secret/previousSessionEncryptionKey",
-					PreviousCookieAuthenticationKeyFile: "/var/session-secret/previousSessionAuthenticationKey",
-				},
+				Session: Session{},
 				Customization: Customization{
 					Perspectives: []Perspective{
 						{
@@ -413,12 +393,7 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 					ClientID:         api.OpenShiftConsoleName,
 					ClientSecretFile: clientSecretFilePath,
 				},
-				Session: Session{
-					CookieEncryptionKeyFile:             "/var/session-secret/sessionEncryptionKey",
-					CookieAuthenticationKeyFile:         "/var/session-secret/sessionAuthenticationKey",
-					PreviousCookieEncryptionKeyFile:     "/var/session-secret/previousSessionEncryptionKey",
-					PreviousCookieAuthenticationKeyFile: "/var/session-secret/previousSessionAuthenticationKey",
-				},
+				Session: Session{},
 				Customization: Customization{
 					Perspectives: []Perspective{
 						{
@@ -454,12 +429,7 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 					ClientID:         api.OpenShiftConsoleName,
 					ClientSecretFile: clientSecretFilePath,
 				},
-				Session: Session{
-					CookieEncryptionKeyFile:             "/var/session-secret/sessionEncryptionKey",
-					CookieAuthenticationKeyFile:         "/var/session-secret/sessionAuthenticationKey",
-					PreviousCookieEncryptionKeyFile:     "/var/session-secret/previousSessionEncryptionKey",
-					PreviousCookieAuthenticationKeyFile: "/var/session-secret/previousSessionAuthenticationKey",
-				},
+				Session: Session{},
 				Customization: Customization{
 					DeveloperCatalog: &DeveloperConsoleCatalogCustomization{
 						Categories: &[]DeveloperConsoleCatalogCategory{},
@@ -519,12 +489,7 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 					ClientID:         api.OpenShiftConsoleName,
 					ClientSecretFile: clientSecretFilePath,
 				},
-				Session: Session{
-					CookieEncryptionKeyFile:             "/var/session-secret/sessionEncryptionKey",
-					CookieAuthenticationKeyFile:         "/var/session-secret/sessionAuthenticationKey",
-					PreviousCookieEncryptionKeyFile:     "/var/session-secret/previousSessionEncryptionKey",
-					PreviousCookieAuthenticationKeyFile: "/var/session-secret/previousSessionAuthenticationKey",
-				},
+				Session: Session{},
 				Customization: Customization{
 					Perspectives: []Perspective{
 						{
@@ -584,12 +549,7 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 					ClientID:         api.OpenShiftConsoleName,
 					ClientSecretFile: clientSecretFilePath,
 				},
-				Session: Session{
-					CookieEncryptionKeyFile:             "/var/session-secret/sessionEncryptionKey",
-					CookieAuthenticationKeyFile:         "/var/session-secret/sessionAuthenticationKey",
-					PreviousCookieEncryptionKeyFile:     "/var/session-secret/previousSessionEncryptionKey",
-					PreviousCookieAuthenticationKeyFile: "/var/session-secret/previousSessionAuthenticationKey",
-				},
+				Session: Session{},
 				Customization: Customization{
 					DeveloperCatalog: &DeveloperConsoleCatalogCustomization{
 						Categories: nil,
@@ -629,12 +589,7 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 					ClientID:         api.OpenShiftConsoleName,
 					ClientSecretFile: clientSecretFilePath,
 				},
-				Session: Session{
-					CookieEncryptionKeyFile:             "/var/session-secret/sessionEncryptionKey",
-					CookieAuthenticationKeyFile:         "/var/session-secret/sessionAuthenticationKey",
-					PreviousCookieEncryptionKeyFile:     "/var/session-secret/previousSessionEncryptionKey",
-					PreviousCookieAuthenticationKeyFile: "/var/session-secret/previousSessionAuthenticationKey",
-				},
+				Session: Session{},
 				Customization: Customization{
 					DeveloperCatalog: &DeveloperConsoleCatalogCustomization{
 						Categories: nil,
@@ -674,12 +629,7 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 					ClientID:         api.OpenShiftConsoleName,
 					ClientSecretFile: clientSecretFilePath,
 				},
-				Session: Session{
-					CookieEncryptionKeyFile:             "/var/session-secret/sessionEncryptionKey",
-					CookieAuthenticationKeyFile:         "/var/session-secret/sessionAuthenticationKey",
-					PreviousCookieEncryptionKeyFile:     "/var/session-secret/previousSessionEncryptionKey",
-					PreviousCookieAuthenticationKeyFile: "/var/session-secret/previousSessionAuthenticationKey",
-				},
+				Session: Session{},
 				Customization: Customization{
 					ProjectAccess: ProjectAccess{
 						AvailableClusterRoles: []string{"View", "Edit", "Admin"},
@@ -718,12 +668,7 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 					ClientID:         api.OpenShiftConsoleName,
 					ClientSecretFile: clientSecretFilePath,
 				},
-				Session: Session{
-					CookieEncryptionKeyFile:             "/var/session-secret/sessionEncryptionKey",
-					CookieAuthenticationKeyFile:         "/var/session-secret/sessionAuthenticationKey",
-					PreviousCookieEncryptionKeyFile:     "/var/session-secret/previousSessionEncryptionKey",
-					PreviousCookieAuthenticationKeyFile: "/var/session-secret/previousSessionAuthenticationKey",
-				},
+				Session: Session{},
 				Customization: Customization{
 					QuickStarts: QuickStarts{
 						Disabled: []string{"quick-start0", "quick-start1", "quick-start2"},
@@ -776,12 +721,7 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 					ClientID:         api.OpenShiftConsoleName,
 					ClientSecretFile: clientSecretFilePath,
 				},
-				Session: Session{
-					CookieEncryptionKeyFile:             "/var/session-secret/sessionEncryptionKey",
-					CookieAuthenticationKeyFile:         "/var/session-secret/sessionAuthenticationKey",
-					PreviousCookieEncryptionKeyFile:     "/var/session-secret/previousSessionEncryptionKey",
-					PreviousCookieAuthenticationKeyFile: "/var/session-secret/previousSessionAuthenticationKey",
-				},
+				Session: Session{},
 				Customization: Customization{
 					Perspectives: []Perspective{
 						{
@@ -846,12 +786,7 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 					ClientID:         api.OpenShiftConsoleName,
 					ClientSecretFile: clientSecretFilePath,
 				},
-				Session: Session{
-					CookieEncryptionKeyFile:             "/var/session-secret/sessionEncryptionKey",
-					CookieAuthenticationKeyFile:         "/var/session-secret/sessionAuthenticationKey",
-					PreviousCookieEncryptionKeyFile:     "/var/session-secret/previousSessionEncryptionKey",
-					PreviousCookieAuthenticationKeyFile: "/var/session-secret/previousSessionAuthenticationKey",
-				},
+				Session: Session{},
 				Customization: Customization{
 					Perspectives: []Perspective{
 						{ID: "perspective1",
@@ -915,12 +850,7 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 					ClientID:         api.OpenShiftConsoleName,
 					ClientSecretFile: clientSecretFilePath,
 				},
-				Session: Session{
-					CookieEncryptionKeyFile:             "/var/session-secret/sessionEncryptionKey",
-					CookieAuthenticationKeyFile:         "/var/session-secret/sessionAuthenticationKey",
-					PreviousCookieEncryptionKeyFile:     "/var/session-secret/previousSessionEncryptionKey",
-					PreviousCookieAuthenticationKeyFile: "/var/session-secret/previousSessionAuthenticationKey",
-				},
+				Session: Session{},
 				Customization: Customization{
 					Perspectives: []Perspective{
 						{ID: "perspective1",
@@ -977,12 +907,7 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 					ClientSecretFile: clientSecretFilePath,
 					LogoutRedirect:   "https://foobar.com/logout",
 				},
-				Session: Session{
-					CookieEncryptionKeyFile:             "/var/session-secret/sessionEncryptionKey",
-					CookieAuthenticationKeyFile:         "/var/session-secret/sessionAuthenticationKey",
-					PreviousCookieEncryptionKeyFile:     "/var/session-secret/previousSessionEncryptionKey",
-					PreviousCookieAuthenticationKeyFile: "/var/session-secret/previousSessionAuthenticationKey",
-				},
+				Session: Session{},
 				Customization: Customization{
 					Branding:             "okd",
 					DocumentationBaseURL: "https://foobar.com/docs",
@@ -1036,12 +961,7 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 					ClientID:         api.OpenShiftConsoleName,
 					ClientSecretFile: clientSecretFilePath,
 				},
-				Session: Session{
-					CookieEncryptionKeyFile:             "/var/session-secret/sessionEncryptionKey",
-					CookieAuthenticationKeyFile:         "/var/session-secret/sessionAuthenticationKey",
-					PreviousCookieEncryptionKeyFile:     "/var/session-secret/previousSessionEncryptionKey",
-					PreviousCookieAuthenticationKeyFile: "/var/session-secret/previousSessionAuthenticationKey",
-				},
+				Session: Session{},
 				Customization: Customization{
 					Perspectives: []Perspective{
 						{
@@ -1082,12 +1002,7 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 					ClientID:         api.OpenShiftConsoleName,
 					ClientSecretFile: clientSecretFilePath,
 				},
-				Session: Session{
-					CookieEncryptionKeyFile:             "/var/session-secret/sessionEncryptionKey",
-					CookieAuthenticationKeyFile:         "/var/session-secret/sessionAuthenticationKey",
-					PreviousCookieEncryptionKeyFile:     "/var/session-secret/previousSessionEncryptionKey",
-					PreviousCookieAuthenticationKeyFile: "/var/session-secret/previousSessionAuthenticationKey",
-				},
+				Session: Session{},
 				Customization: Customization{
 					Perspectives: []Perspective{
 						{
@@ -1129,12 +1044,7 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 					ClientID:         api.OpenShiftConsoleName,
 					ClientSecretFile: clientSecretFilePath,
 				},
-				Session: Session{
-					CookieEncryptionKeyFile:             "/var/session-secret/sessionEncryptionKey",
-					CookieAuthenticationKeyFile:         "/var/session-secret/sessionAuthenticationKey",
-					PreviousCookieEncryptionKeyFile:     "/var/session-secret/previousSessionEncryptionKey",
-					PreviousCookieAuthenticationKeyFile: "/var/session-secret/previousSessionAuthenticationKey",
-				},
+				Session: Session{},
 				Customization: Customization{
 					Perspectives: []Perspective{
 						{
@@ -1188,11 +1098,7 @@ clusterInfo: {}
 auth:
   clientID: console
   clientSecretFile: /var/oauth-config/clientSecret
-session:
-  cookieEncryptionKeyFile: /var/session-secret/sessionEncryptionKey
-  cookieAuthenticationKeyFile: /var/session-secret/sessionAuthenticationKey
-  previousCookieEncryptionKeyFile: /var/session-secret/previousSessionEncryptionKey
-  previousCookieAuthenticationKeyFile: /var/session-secret/previousSessionAuthenticationKey
+session: {}
 customization:
   perspectives:
   - id: dev
@@ -1306,11 +1212,7 @@ clusterInfo: {}
 auth:
   clientID: console
   clientSecretFile: /var/oauth-config/clientSecret
-session:
-  cookieEncryptionKeyFile: /var/session-secret/sessionEncryptionKey
-  cookieAuthenticationKeyFile: /var/session-secret/sessionAuthenticationKey
-  previousCookieEncryptionKeyFile: /var/session-secret/previousSessionEncryptionKey
-  previousCookieAuthenticationKeyFile: /var/session-secret/previousSessionAuthenticationKey
+session: {}
 customization:
   perspectives:
   - id: dev
@@ -1337,11 +1239,7 @@ clusterInfo: {}
 auth:
   clientID: console
   clientSecretFile: /var/oauth-config/clientSecret
-session:
-  cookieEncryptionKeyFile: /var/session-secret/sessionEncryptionKey
-  cookieAuthenticationKeyFile: /var/session-secret/sessionAuthenticationKey
-  previousCookieEncryptionKeyFile: /var/session-secret/previousSessionEncryptionKey
-  previousCookieAuthenticationKeyFile: /var/session-secret/previousSessionAuthenticationKey
+session: {}
 customization:
   perspectives:
   - id: dev
@@ -1369,11 +1267,7 @@ clusterInfo: {}
 auth:
   clientID: console
   clientSecretFile: /var/oauth-config/clientSecret
-session:
-  cookieEncryptionKeyFile: /var/session-secret/sessionEncryptionKey
-  cookieAuthenticationKeyFile: /var/session-secret/sessionAuthenticationKey
-  previousCookieEncryptionKeyFile: /var/session-secret/previousSessionEncryptionKey
-  previousCookieAuthenticationKeyFile: /var/session-secret/previousSessionAuthenticationKey
+session: {}
 customization:
   developerCatalog:
     categories: []
@@ -1425,11 +1319,7 @@ clusterInfo: {}
 auth:
   clientID: console
   clientSecretFile: /var/oauth-config/clientSecret
-session:
-  cookieEncryptionKeyFile: /var/session-secret/sessionEncryptionKey
-  cookieAuthenticationKeyFile: /var/session-secret/sessionAuthenticationKey
-  previousCookieEncryptionKeyFile: /var/session-secret/previousSessionEncryptionKey
-  previousCookieAuthenticationKeyFile: /var/session-secret/previousSessionAuthenticationKey
+session: {}
 customization:
   developerCatalog:
     categories:
@@ -1473,11 +1363,7 @@ clusterInfo: {}
 auth:
   clientID: console
   clientSecretFile: /var/oauth-config/clientSecret
-session:
-  cookieEncryptionKeyFile: /var/session-secret/sessionEncryptionKey
-  cookieAuthenticationKeyFile: /var/session-secret/sessionAuthenticationKey
-  previousCookieEncryptionKeyFile: /var/session-secret/previousSessionEncryptionKey
-  previousCookieAuthenticationKeyFile: /var/session-secret/previousSessionAuthenticationKey
+session: {}
 customization:
   developerCatalog:
     categories: null
@@ -1512,11 +1398,7 @@ clusterInfo: {}
 auth:
   clientID: console
   clientSecretFile: /var/oauth-config/clientSecret
-session:
-  cookieEncryptionKeyFile: /var/session-secret/sessionEncryptionKey
-  cookieAuthenticationKeyFile: /var/session-secret/sessionAuthenticationKey
-  previousCookieEncryptionKeyFile: /var/session-secret/previousSessionEncryptionKey
-  previousCookieAuthenticationKeyFile: /var/session-secret/previousSessionAuthenticationKey
+session: {}
 customization:
   developerCatalog:
     categories: null
@@ -1552,11 +1434,7 @@ clusterInfo: {}
 auth:
   clientID: console
   clientSecretFile: /var/oauth-config/clientSecret
-session:
-  cookieEncryptionKeyFile: /var/session-secret/sessionEncryptionKey
-  cookieAuthenticationKeyFile: /var/session-secret/sessionAuthenticationKey
-  previousCookieEncryptionKeyFile: /var/session-secret/previousSessionEncryptionKey
-  previousCookieAuthenticationKeyFile: /var/session-secret/previousSessionAuthenticationKey
+session: {}
 customization:
   addPage:
     disabledActions:
@@ -1641,11 +1519,7 @@ clusterInfo: {}
 auth:
   clientID: console
   clientSecretFile: /var/oauth-config/clientSecret
-session:
-  cookieEncryptionKeyFile: /var/session-secret/sessionEncryptionKey
-  cookieAuthenticationKeyFile: /var/session-secret/sessionAuthenticationKey
-  previousCookieEncryptionKeyFile: /var/session-secret/previousSessionEncryptionKey
-  previousCookieAuthenticationKeyFile: /var/session-secret/previousSessionAuthenticationKey
+session: {}
 customization:
   quickStarts:
     disabled:
@@ -1691,11 +1565,7 @@ clusterInfo: {}
 auth:
   clientID: console
   clientSecretFile: /var/oauth-config/clientSecret
-session:
-  cookieEncryptionKeyFile: /var/session-secret/sessionEncryptionKey
-  cookieAuthenticationKeyFile: /var/session-secret/sessionAuthenticationKey
-  previousCookieEncryptionKeyFile: /var/session-secret/previousSessionEncryptionKey
-  previousCookieAuthenticationKeyFile: /var/session-secret/previousSessionAuthenticationKey
+session: {}
 customization:
   perspectives:
   - id: perspective1
@@ -1765,11 +1635,7 @@ clusterInfo: {}
 auth:
   clientID: console
   clientSecretFile: /var/oauth-config/clientSecret
-session:
-  cookieEncryptionKeyFile: /var/session-secret/sessionEncryptionKey
-  cookieAuthenticationKeyFile: /var/session-secret/sessionAuthenticationKey
-  previousCookieEncryptionKeyFile: /var/session-secret/previousSessionEncryptionKey
-  previousCookieAuthenticationKeyFile: /var/session-secret/previousSessionAuthenticationKey
+session: {}
 customization:
   perspectives:
   - id: perspective1
@@ -1843,11 +1709,7 @@ clusterInfo: {}
 auth:
   clientID: console
   clientSecretFile: /var/oauth-config/clientSecret
-session:
-  cookieEncryptionKeyFile: /var/session-secret/sessionEncryptionKey
-  cookieAuthenticationKeyFile: /var/session-secret/sessionAuthenticationKey
-  previousCookieEncryptionKeyFile: /var/session-secret/previousSessionEncryptionKey
-  previousCookieAuthenticationKeyFile: /var/session-secret/previousSessionAuthenticationKey
+session: {}
 customization:
   perspectives:
   - id: perspective1
@@ -1901,11 +1763,7 @@ clusterInfo: {}
 auth:
   clientID: console
   clientSecretFile: /var/oauth-config/clientSecret
-session:
-  cookieEncryptionKeyFile: /var/session-secret/sessionEncryptionKey
-  cookieAuthenticationKeyFile: /var/session-secret/sessionAuthenticationKey
-  previousCookieEncryptionKeyFile: /var/session-secret/previousSessionEncryptionKey
-  previousCookieAuthenticationKeyFile: /var/session-secret/previousSessionAuthenticationKey
+session: {}
 customization:
   perspectives:
   - id: dev
@@ -1941,11 +1799,7 @@ clusterInfo: {}
 auth:
   clientID: console
   clientSecretFile: /var/oauth-config/clientSecret
-session:
-  cookieEncryptionKeyFile: /var/session-secret/sessionEncryptionKey
-  cookieAuthenticationKeyFile: /var/session-secret/sessionAuthenticationKey
-  previousCookieEncryptionKeyFile: /var/session-secret/previousSessionEncryptionKey
-  previousCookieAuthenticationKeyFile: /var/session-secret/previousSessionAuthenticationKey
+session: {}
 customization:
   perspectives:
   - id: dev

--- a/pkg/console/subresource/consoleserver/config_builder_test.go
+++ b/pkg/console/subresource/consoleserver/config_builder_test.go
@@ -71,6 +71,12 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 					ClientID:         api.OpenShiftConsoleName,
 					ClientSecretFile: clientSecretFilePath,
 				},
+				Session: Session{
+					CookieEncryptionKeyFile:             "/var/session-secret/sessionEncryptionKey",
+					CookieAuthenticationKeyFile:         "/var/session-secret/sessionAuthenticationKey",
+					PreviousCookieEncryptionKeyFile:     "/var/session-secret/previousSessionEncryptionKey",
+					PreviousCookieAuthenticationKeyFile: "/var/session-secret/previousSessionAuthenticationKey",
+				},
 				Customization: Customization{
 					Perspectives: []Perspective{
 						{
@@ -102,6 +108,12 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 				Auth: Auth{
 					ClientID:         api.OpenShiftConsoleName,
 					ClientSecretFile: clientSecretFilePath,
+				},
+				Session: Session{
+					CookieEncryptionKeyFile:             "/var/session-secret/sessionEncryptionKey",
+					CookieAuthenticationKeyFile:         "/var/session-secret/sessionAuthenticationKey",
+					PreviousCookieEncryptionKeyFile:     "/var/session-secret/previousSessionEncryptionKey",
+					PreviousCookieAuthenticationKeyFile: "/var/session-secret/previousSessionAuthenticationKey",
 				},
 				Customization: Customization{
 					Perspectives: []Perspective{
@@ -145,6 +157,12 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 				Auth: Auth{
 					ClientID:         api.OpenShiftConsoleName,
 					ClientSecretFile: clientSecretFilePath,
+				},
+				Session: Session{
+					CookieEncryptionKeyFile:             "/var/session-secret/sessionEncryptionKey",
+					CookieAuthenticationKeyFile:         "/var/session-secret/sessionAuthenticationKey",
+					PreviousCookieEncryptionKeyFile:     "/var/session-secret/previousSessionEncryptionKey",
+					PreviousCookieAuthenticationKeyFile: "/var/session-secret/previousSessionAuthenticationKey",
 				},
 				Customization: Customization{
 					Capabilities: []v1.Capability{
@@ -195,6 +213,12 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 					ClientSecretFile:    clientSecretFilePath,
 					OAuthEndpointCAFile: "/var/oauth-serving-cert/ca-bundle.crt",
 					LogoutRedirect:      "https://foobar.com/logout",
+				},
+				Session: Session{
+					CookieEncryptionKeyFile:             "/var/session-secret/sessionEncryptionKey",
+					CookieAuthenticationKeyFile:         "/var/session-secret/sessionAuthenticationKey",
+					PreviousCookieEncryptionKeyFile:     "/var/session-secret/previousSessionEncryptionKey",
+					PreviousCookieAuthenticationKeyFile: "/var/session-secret/previousSessionAuthenticationKey",
 				},
 				Customization: Customization{
 
@@ -257,8 +281,10 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 					LogoutRedirect:      "https://foobar.com/logout",
 				},
 				Session: Session{
-					CookieEncryptionKeyFile:     "/var/session-secret/sessionEncryptionKey",
-					CookieAuthenticationKeyFile: "/var/session-secret/sessionAuthenticationKey",
+					CookieEncryptionKeyFile:             "/var/session-secret/sessionEncryptionKey",
+					CookieAuthenticationKeyFile:         "/var/session-secret/sessionAuthenticationKey",
+					PreviousCookieEncryptionKeyFile:     "/var/session-secret/previousSessionEncryptionKey",
+					PreviousCookieAuthenticationKeyFile: "/var/session-secret/previousSessionAuthenticationKey",
 				},
 				Customization: Customization{
 					Perspectives: []Perspective{
@@ -346,6 +372,12 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 					ClientID:         api.OpenShiftConsoleName,
 					ClientSecretFile: clientSecretFilePath,
 				},
+				Session: Session{
+					CookieEncryptionKeyFile:             "/var/session-secret/sessionEncryptionKey",
+					CookieAuthenticationKeyFile:         "/var/session-secret/sessionAuthenticationKey",
+					PreviousCookieEncryptionKeyFile:     "/var/session-secret/previousSessionEncryptionKey",
+					PreviousCookieAuthenticationKeyFile: "/var/session-secret/previousSessionAuthenticationKey",
+				},
 				Customization: Customization{
 					Perspectives: []Perspective{
 						{
@@ -380,6 +412,12 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 				Auth: Auth{
 					ClientID:         api.OpenShiftConsoleName,
 					ClientSecretFile: clientSecretFilePath,
+				},
+				Session: Session{
+					CookieEncryptionKeyFile:             "/var/session-secret/sessionEncryptionKey",
+					CookieAuthenticationKeyFile:         "/var/session-secret/sessionAuthenticationKey",
+					PreviousCookieEncryptionKeyFile:     "/var/session-secret/previousSessionEncryptionKey",
+					PreviousCookieAuthenticationKeyFile: "/var/session-secret/previousSessionAuthenticationKey",
 				},
 				Customization: Customization{
 					Perspectives: []Perspective{
@@ -416,7 +454,12 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 					ClientID:         api.OpenShiftConsoleName,
 					ClientSecretFile: clientSecretFilePath,
 				},
-				Session: Session{},
+				Session: Session{
+					CookieEncryptionKeyFile:             "/var/session-secret/sessionEncryptionKey",
+					CookieAuthenticationKeyFile:         "/var/session-secret/sessionAuthenticationKey",
+					PreviousCookieEncryptionKeyFile:     "/var/session-secret/previousSessionEncryptionKey",
+					PreviousCookieAuthenticationKeyFile: "/var/session-secret/previousSessionAuthenticationKey",
+				},
 				Customization: Customization{
 					DeveloperCatalog: &DeveloperConsoleCatalogCustomization{
 						Categories: &[]DeveloperConsoleCatalogCategory{},
@@ -476,7 +519,12 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 					ClientID:         api.OpenShiftConsoleName,
 					ClientSecretFile: clientSecretFilePath,
 				},
-				Session: Session{},
+				Session: Session{
+					CookieEncryptionKeyFile:             "/var/session-secret/sessionEncryptionKey",
+					CookieAuthenticationKeyFile:         "/var/session-secret/sessionAuthenticationKey",
+					PreviousCookieEncryptionKeyFile:     "/var/session-secret/previousSessionEncryptionKey",
+					PreviousCookieAuthenticationKeyFile: "/var/session-secret/previousSessionAuthenticationKey",
+				},
 				Customization: Customization{
 					Perspectives: []Perspective{
 						{
@@ -536,7 +584,12 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 					ClientID:         api.OpenShiftConsoleName,
 					ClientSecretFile: clientSecretFilePath,
 				},
-				Session: Session{},
+				Session: Session{
+					CookieEncryptionKeyFile:             "/var/session-secret/sessionEncryptionKey",
+					CookieAuthenticationKeyFile:         "/var/session-secret/sessionAuthenticationKey",
+					PreviousCookieEncryptionKeyFile:     "/var/session-secret/previousSessionEncryptionKey",
+					PreviousCookieAuthenticationKeyFile: "/var/session-secret/previousSessionAuthenticationKey",
+				},
 				Customization: Customization{
 					DeveloperCatalog: &DeveloperConsoleCatalogCustomization{
 						Categories: nil,
@@ -576,7 +629,12 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 					ClientID:         api.OpenShiftConsoleName,
 					ClientSecretFile: clientSecretFilePath,
 				},
-				Session: Session{},
+				Session: Session{
+					CookieEncryptionKeyFile:             "/var/session-secret/sessionEncryptionKey",
+					CookieAuthenticationKeyFile:         "/var/session-secret/sessionAuthenticationKey",
+					PreviousCookieEncryptionKeyFile:     "/var/session-secret/previousSessionEncryptionKey",
+					PreviousCookieAuthenticationKeyFile: "/var/session-secret/previousSessionAuthenticationKey",
+				},
 				Customization: Customization{
 					DeveloperCatalog: &DeveloperConsoleCatalogCustomization{
 						Categories: nil,
@@ -616,7 +674,12 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 					ClientID:         api.OpenShiftConsoleName,
 					ClientSecretFile: clientSecretFilePath,
 				},
-				Session: Session{},
+				Session: Session{
+					CookieEncryptionKeyFile:             "/var/session-secret/sessionEncryptionKey",
+					CookieAuthenticationKeyFile:         "/var/session-secret/sessionAuthenticationKey",
+					PreviousCookieEncryptionKeyFile:     "/var/session-secret/previousSessionEncryptionKey",
+					PreviousCookieAuthenticationKeyFile: "/var/session-secret/previousSessionAuthenticationKey",
+				},
 				Customization: Customization{
 					ProjectAccess: ProjectAccess{
 						AvailableClusterRoles: []string{"View", "Edit", "Admin"},
@@ -655,7 +718,12 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 					ClientID:         api.OpenShiftConsoleName,
 					ClientSecretFile: clientSecretFilePath,
 				},
-				Session: Session{},
+				Session: Session{
+					CookieEncryptionKeyFile:             "/var/session-secret/sessionEncryptionKey",
+					CookieAuthenticationKeyFile:         "/var/session-secret/sessionAuthenticationKey",
+					PreviousCookieEncryptionKeyFile:     "/var/session-secret/previousSessionEncryptionKey",
+					PreviousCookieAuthenticationKeyFile: "/var/session-secret/previousSessionAuthenticationKey",
+				},
 				Customization: Customization{
 					QuickStarts: QuickStarts{
 						Disabled: []string{"quick-start0", "quick-start1", "quick-start2"},
@@ -708,7 +776,12 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 					ClientID:         api.OpenShiftConsoleName,
 					ClientSecretFile: clientSecretFilePath,
 				},
-				Session: Session{},
+				Session: Session{
+					CookieEncryptionKeyFile:             "/var/session-secret/sessionEncryptionKey",
+					CookieAuthenticationKeyFile:         "/var/session-secret/sessionAuthenticationKey",
+					PreviousCookieEncryptionKeyFile:     "/var/session-secret/previousSessionEncryptionKey",
+					PreviousCookieAuthenticationKeyFile: "/var/session-secret/previousSessionAuthenticationKey",
+				},
 				Customization: Customization{
 					Perspectives: []Perspective{
 						{
@@ -773,7 +846,12 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 					ClientID:         api.OpenShiftConsoleName,
 					ClientSecretFile: clientSecretFilePath,
 				},
-				Session: Session{},
+				Session: Session{
+					CookieEncryptionKeyFile:             "/var/session-secret/sessionEncryptionKey",
+					CookieAuthenticationKeyFile:         "/var/session-secret/sessionAuthenticationKey",
+					PreviousCookieEncryptionKeyFile:     "/var/session-secret/previousSessionEncryptionKey",
+					PreviousCookieAuthenticationKeyFile: "/var/session-secret/previousSessionAuthenticationKey",
+				},
 				Customization: Customization{
 					Perspectives: []Perspective{
 						{ID: "perspective1",
@@ -837,7 +915,12 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 					ClientID:         api.OpenShiftConsoleName,
 					ClientSecretFile: clientSecretFilePath,
 				},
-				Session: Session{},
+				Session: Session{
+					CookieEncryptionKeyFile:             "/var/session-secret/sessionEncryptionKey",
+					CookieAuthenticationKeyFile:         "/var/session-secret/sessionAuthenticationKey",
+					PreviousCookieEncryptionKeyFile:     "/var/session-secret/previousSessionEncryptionKey",
+					PreviousCookieAuthenticationKeyFile: "/var/session-secret/previousSessionAuthenticationKey",
+				},
 				Customization: Customization{
 					Perspectives: []Perspective{
 						{ID: "perspective1",
@@ -894,7 +977,12 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 					ClientSecretFile: clientSecretFilePath,
 					LogoutRedirect:   "https://foobar.com/logout",
 				},
-				Session: Session{},
+				Session: Session{
+					CookieEncryptionKeyFile:             "/var/session-secret/sessionEncryptionKey",
+					CookieAuthenticationKeyFile:         "/var/session-secret/sessionAuthenticationKey",
+					PreviousCookieEncryptionKeyFile:     "/var/session-secret/previousSessionEncryptionKey",
+					PreviousCookieAuthenticationKeyFile: "/var/session-secret/previousSessionAuthenticationKey",
+				},
 				Customization: Customization{
 					Branding:             "okd",
 					DocumentationBaseURL: "https://foobar.com/docs",
@@ -948,7 +1036,12 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 					ClientID:         api.OpenShiftConsoleName,
 					ClientSecretFile: clientSecretFilePath,
 				},
-				Session: Session{},
+				Session: Session{
+					CookieEncryptionKeyFile:             "/var/session-secret/sessionEncryptionKey",
+					CookieAuthenticationKeyFile:         "/var/session-secret/sessionAuthenticationKey",
+					PreviousCookieEncryptionKeyFile:     "/var/session-secret/previousSessionEncryptionKey",
+					PreviousCookieAuthenticationKeyFile: "/var/session-secret/previousSessionAuthenticationKey",
+				},
 				Customization: Customization{
 					Perspectives: []Perspective{
 						{
@@ -988,6 +1081,12 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 				Auth: Auth{
 					ClientID:         api.OpenShiftConsoleName,
 					ClientSecretFile: clientSecretFilePath,
+				},
+				Session: Session{
+					CookieEncryptionKeyFile:             "/var/session-secret/sessionEncryptionKey",
+					CookieAuthenticationKeyFile:         "/var/session-secret/sessionAuthenticationKey",
+					PreviousCookieEncryptionKeyFile:     "/var/session-secret/previousSessionEncryptionKey",
+					PreviousCookieAuthenticationKeyFile: "/var/session-secret/previousSessionAuthenticationKey",
 				},
 				Customization: Customization{
 					Perspectives: []Perspective{
@@ -1029,6 +1128,12 @@ func TestConsoleServerCLIConfigBuilder(t *testing.T) {
 				Auth: Auth{
 					ClientID:         api.OpenShiftConsoleName,
 					ClientSecretFile: clientSecretFilePath,
+				},
+				Session: Session{
+					CookieEncryptionKeyFile:             "/var/session-secret/sessionEncryptionKey",
+					CookieAuthenticationKeyFile:         "/var/session-secret/sessionAuthenticationKey",
+					PreviousCookieEncryptionKeyFile:     "/var/session-secret/previousSessionEncryptionKey",
+					PreviousCookieAuthenticationKeyFile: "/var/session-secret/previousSessionAuthenticationKey",
 				},
 				Customization: Customization{
 					Perspectives: []Perspective{
@@ -1083,7 +1188,11 @@ clusterInfo: {}
 auth:
   clientID: console
   clientSecretFile: /var/oauth-config/clientSecret
-session: {}
+session:
+  cookieEncryptionKeyFile: /var/session-secret/sessionEncryptionKey
+  cookieAuthenticationKeyFile: /var/session-secret/sessionAuthenticationKey
+  previousCookieEncryptionKeyFile: /var/session-secret/previousSessionEncryptionKey
+  previousCookieAuthenticationKeyFile: /var/session-secret/previousSessionAuthenticationKey
 customization:
   perspectives:
   - id: dev
@@ -1132,6 +1241,8 @@ auth:
 session:
   cookieEncryptionKeyFile: /var/session-secret/sessionEncryptionKey
   cookieAuthenticationKeyFile: /var/session-secret/sessionAuthenticationKey
+  previousCookieEncryptionKeyFile: /var/session-secret/previousSessionEncryptionKey
+  previousCookieAuthenticationKeyFile: /var/session-secret/previousSessionAuthenticationKey
 customization:
   perspectives:
   - id: dev
@@ -1166,7 +1277,11 @@ auth:
   clientSecretFile: /var/oauth-config/clientSecret
   oauthEndpointCAFile: /var/oauth-serving-cert/ca-bundle.crt
   logoutRedirect: https://foobar.com/logout
-session: {}
+session:
+  cookieEncryptionKeyFile: /var/session-secret/sessionEncryptionKey
+  cookieAuthenticationKeyFile: /var/session-secret/sessionAuthenticationKey
+  previousCookieEncryptionKeyFile: /var/session-secret/previousSessionEncryptionKey
+  previousCookieAuthenticationKeyFile: /var/session-secret/previousSessionAuthenticationKey
 customization:
   perspectives:
   - id: dev
@@ -1191,7 +1306,11 @@ clusterInfo: {}
 auth:
   clientID: console
   clientSecretFile: /var/oauth-config/clientSecret
-session: {}
+session:
+  cookieEncryptionKeyFile: /var/session-secret/sessionEncryptionKey
+  cookieAuthenticationKeyFile: /var/session-secret/sessionAuthenticationKey
+  previousCookieEncryptionKeyFile: /var/session-secret/previousSessionEncryptionKey
+  previousCookieAuthenticationKeyFile: /var/session-secret/previousSessionAuthenticationKey
 customization:
   perspectives:
   - id: dev
@@ -1218,7 +1337,11 @@ clusterInfo: {}
 auth:
   clientID: console
   clientSecretFile: /var/oauth-config/clientSecret
-session: {}
+session:
+  cookieEncryptionKeyFile: /var/session-secret/sessionEncryptionKey
+  cookieAuthenticationKeyFile: /var/session-secret/sessionAuthenticationKey
+  previousCookieEncryptionKeyFile: /var/session-secret/previousSessionEncryptionKey
+  previousCookieAuthenticationKeyFile: /var/session-secret/previousSessionAuthenticationKey
 customization:
   perspectives:
   - id: dev
@@ -1246,7 +1369,11 @@ clusterInfo: {}
 auth:
   clientID: console
   clientSecretFile: /var/oauth-config/clientSecret
-session: {}
+session:
+  cookieEncryptionKeyFile: /var/session-secret/sessionEncryptionKey
+  cookieAuthenticationKeyFile: /var/session-secret/sessionAuthenticationKey
+  previousCookieEncryptionKeyFile: /var/session-secret/previousSessionEncryptionKey
+  previousCookieAuthenticationKeyFile: /var/session-secret/previousSessionAuthenticationKey
 customization:
   developerCatalog:
     categories: []
@@ -1298,7 +1425,11 @@ clusterInfo: {}
 auth:
   clientID: console
   clientSecretFile: /var/oauth-config/clientSecret
-session: {}
+session:
+  cookieEncryptionKeyFile: /var/session-secret/sessionEncryptionKey
+  cookieAuthenticationKeyFile: /var/session-secret/sessionAuthenticationKey
+  previousCookieEncryptionKeyFile: /var/session-secret/previousSessionEncryptionKey
+  previousCookieAuthenticationKeyFile: /var/session-secret/previousSessionAuthenticationKey
 customization:
   developerCatalog:
     categories:
@@ -1342,7 +1473,11 @@ clusterInfo: {}
 auth:
   clientID: console
   clientSecretFile: /var/oauth-config/clientSecret
-session: {}
+session:
+  cookieEncryptionKeyFile: /var/session-secret/sessionEncryptionKey
+  cookieAuthenticationKeyFile: /var/session-secret/sessionAuthenticationKey
+  previousCookieEncryptionKeyFile: /var/session-secret/previousSessionEncryptionKey
+  previousCookieAuthenticationKeyFile: /var/session-secret/previousSessionAuthenticationKey
 customization:
   developerCatalog:
     categories: null
@@ -1377,7 +1512,11 @@ clusterInfo: {}
 auth:
   clientID: console
   clientSecretFile: /var/oauth-config/clientSecret
-session: {}
+session:
+  cookieEncryptionKeyFile: /var/session-secret/sessionEncryptionKey
+  cookieAuthenticationKeyFile: /var/session-secret/sessionAuthenticationKey
+  previousCookieEncryptionKeyFile: /var/session-secret/previousSessionEncryptionKey
+  previousCookieAuthenticationKeyFile: /var/session-secret/previousSessionAuthenticationKey
 customization:
   developerCatalog:
     categories: null
@@ -1413,7 +1552,11 @@ clusterInfo: {}
 auth:
   clientID: console
   clientSecretFile: /var/oauth-config/clientSecret
-session: {}
+session:
+  cookieEncryptionKeyFile: /var/session-secret/sessionEncryptionKey
+  cookieAuthenticationKeyFile: /var/session-secret/sessionAuthenticationKey
+  previousCookieEncryptionKeyFile: /var/session-secret/previousSessionEncryptionKey
+  previousCookieAuthenticationKeyFile: /var/session-secret/previousSessionAuthenticationKey
 customization:
   addPage:
     disabledActions:
@@ -1498,7 +1641,11 @@ clusterInfo: {}
 auth:
   clientID: console
   clientSecretFile: /var/oauth-config/clientSecret
-session: {}
+session:
+  cookieEncryptionKeyFile: /var/session-secret/sessionEncryptionKey
+  cookieAuthenticationKeyFile: /var/session-secret/sessionAuthenticationKey
+  previousCookieEncryptionKeyFile: /var/session-secret/previousSessionEncryptionKey
+  previousCookieAuthenticationKeyFile: /var/session-secret/previousSessionAuthenticationKey
 customization:
   quickStarts:
     disabled:
@@ -1544,7 +1691,11 @@ clusterInfo: {}
 auth:
   clientID: console
   clientSecretFile: /var/oauth-config/clientSecret
-session: {}
+session:
+  cookieEncryptionKeyFile: /var/session-secret/sessionEncryptionKey
+  cookieAuthenticationKeyFile: /var/session-secret/sessionAuthenticationKey
+  previousCookieEncryptionKeyFile: /var/session-secret/previousSessionEncryptionKey
+  previousCookieAuthenticationKeyFile: /var/session-secret/previousSessionAuthenticationKey
 customization:
   perspectives:
   - id: perspective1
@@ -1614,7 +1765,11 @@ clusterInfo: {}
 auth:
   clientID: console
   clientSecretFile: /var/oauth-config/clientSecret
-session: {}
+session:
+  cookieEncryptionKeyFile: /var/session-secret/sessionEncryptionKey
+  cookieAuthenticationKeyFile: /var/session-secret/sessionAuthenticationKey
+  previousCookieEncryptionKeyFile: /var/session-secret/previousSessionEncryptionKey
+  previousCookieAuthenticationKeyFile: /var/session-secret/previousSessionAuthenticationKey
 customization:
   perspectives:
   - id: perspective1
@@ -1688,7 +1843,11 @@ clusterInfo: {}
 auth:
   clientID: console
   clientSecretFile: /var/oauth-config/clientSecret
-session: {}
+session:
+  cookieEncryptionKeyFile: /var/session-secret/sessionEncryptionKey
+  cookieAuthenticationKeyFile: /var/session-secret/sessionAuthenticationKey
+  previousCookieEncryptionKeyFile: /var/session-secret/previousSessionEncryptionKey
+  previousCookieAuthenticationKeyFile: /var/session-secret/previousSessionAuthenticationKey
 customization:
   perspectives:
   - id: perspective1
@@ -1742,7 +1901,11 @@ clusterInfo: {}
 auth:
   clientID: console
   clientSecretFile: /var/oauth-config/clientSecret
-session: {}
+session:
+  cookieEncryptionKeyFile: /var/session-secret/sessionEncryptionKey
+  cookieAuthenticationKeyFile: /var/session-secret/sessionAuthenticationKey
+  previousCookieEncryptionKeyFile: /var/session-secret/previousSessionEncryptionKey
+  previousCookieAuthenticationKeyFile: /var/session-secret/previousSessionAuthenticationKey
 customization:
   perspectives:
   - id: dev
@@ -1778,7 +1941,11 @@ clusterInfo: {}
 auth:
   clientID: console
   clientSecretFile: /var/oauth-config/clientSecret
-session: {}
+session:
+  cookieEncryptionKeyFile: /var/session-secret/sessionEncryptionKey
+  cookieAuthenticationKeyFile: /var/session-secret/sessionAuthenticationKey
+  previousCookieEncryptionKeyFile: /var/session-secret/previousSessionEncryptionKey
+  previousCookieAuthenticationKeyFile: /var/session-secret/previousSessionAuthenticationKey
 customization:
   perspectives:
   - id: dev

--- a/pkg/console/subresource/consoleserver/config_merger_test.go
+++ b/pkg/console/subresource/consoleserver/config_merger_test.go
@@ -61,7 +61,11 @@ servingInfo:
   bindAddress: https://[::]:8443
   certFile: /var/serving-cert/tls.crt
   keyFile: /var/serving-cert/tls.key
-session: {}
+session:
+  cookieAuthenticationKeyFile: /var/session-secret/sessionAuthenticationKey
+  cookieEncryptionKeyFile: /var/session-secret/sessionEncryptionKey
+  previousCookieAuthenticationKeyFile: /var/session-secret/previousSessionAuthenticationKey
+  previousCookieEncryptionKeyFile: /var/session-secret/previousSessionEncryptionKey
 `,
 		},
 	}

--- a/pkg/console/subresource/consoleserver/config_merger_test.go
+++ b/pkg/console/subresource/consoleserver/config_merger_test.go
@@ -61,11 +61,7 @@ servingInfo:
   bindAddress: https://[::]:8443
   certFile: /var/serving-cert/tls.crt
   keyFile: /var/serving-cert/tls.key
-session:
-  cookieAuthenticationKeyFile: /var/session-secret/sessionAuthenticationKey
-  cookieEncryptionKeyFile: /var/session-secret/sessionEncryptionKey
-  previousCookieAuthenticationKeyFile: /var/session-secret/previousSessionAuthenticationKey
-  previousCookieEncryptionKeyFile: /var/session-secret/previousSessionEncryptionKey
+session: {}
 `,
 		},
 	}

--- a/pkg/console/subresource/consoleserver/config_merger_test.go
+++ b/pkg/console/subresource/consoleserver/config_merger_test.go
@@ -61,7 +61,9 @@ servingInfo:
   bindAddress: https://[::]:8443
   certFile: /var/serving-cert/tls.crt
   keyFile: /var/serving-cert/tls.key
-session: {}
+session:
+  cookieAuthenticationKeyFile: /var/session-secret/sessionAuthenticationKey
+  cookieEncryptionKeyFile: /var/session-secret/sessionEncryptionKey
 `,
 		},
 	}

--- a/pkg/console/subresource/consoleserver/types.go
+++ b/pkg/console/subresource/consoleserver/types.go
@@ -100,8 +100,10 @@ type Auth struct {
 
 // Session holds configuration for web-session related configuration
 type Session struct {
-	CookieEncryptionKeyFile     string `yaml:"cookieEncryptionKeyFile,omitempty"`
-	CookieAuthenticationKeyFile string `yaml:"cookieAuthenticationKeyFile,omitempty"`
+	CookieEncryptionKeyFile             string `yaml:"cookieEncryptionKeyFile,omitempty"`
+	CookieAuthenticationKeyFile         string `yaml:"cookieAuthenticationKeyFile,omitempty"`
+	PreviousCookieEncryptionKeyFile     string `yaml:"previousCookieEncryptionKeyFile,omitempty"`
+	PreviousCookieAuthenticationKeyFile string `yaml:"previousCookieAuthenticationKeyFile,omitempty"`
 	// TODO: move InactivityTimeoutSeconds here
 }
 

--- a/pkg/console/subresource/secret/session_secret.go
+++ b/pkg/console/subresource/secret/session_secret.go
@@ -38,11 +38,20 @@ func ResetSessionSecretKeysIfNeeded(secret *corev1.Secret) bool {
 	}
 
 	if len(secret.Data["sessionEncryptionKey"]) != aes256KeyLenBytes {
+		// Preserve the current key as the previous key for graceful rotation,
+		// so that existing sessions can still be decrypted during the transition.
+		if len(secret.Data["previousSessionEncryptionKey"]) == 0 && len(secret.Data["sessionEncryptionKey"]) > 0 {
+			secret.Data["previousSessionEncryptionKey"] = secret.Data["sessionEncryptionKey"]
+		}
 		secret.Data["sessionEncryptionKey"] = []byte(randomString(aes256KeyLenBytes))
 		changed = true
 	}
 
 	if len(secret.Data["sessionAuthenticationKey"]) != sha256KeyLenBytes {
+		// Preserve the current key as the previous key for graceful rotation.
+		if len(secret.Data["previousSessionAuthenticationKey"]) == 0 && len(secret.Data["sessionAuthenticationKey"]) > 0 {
+			secret.Data["previousSessionAuthenticationKey"] = secret.Data["sessionAuthenticationKey"]
+		}
 		secret.Data["sessionAuthenticationKey"] = []byte(randomString(sha256KeyLenBytes))
 		changed = true
 	}

--- a/pkg/console/subresource/secret/session_secret_test.go
+++ b/pkg/console/subresource/secret/session_secret_test.go
@@ -1,0 +1,159 @@
+package secret
+
+import (
+	"crypto/sha256"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+const (
+	testAES256KeyLen    = 32
+	testSHA256BlockSize = sha256.BlockSize // 64
+)
+
+func validEncryptionKey() []byte {
+	return []byte(randomString(testAES256KeyLen))
+}
+
+func validAuthenticationKey() []byte {
+	return []byte(randomString(testSHA256BlockSize))
+}
+
+func TestResetSessionSecretKeysIfNeeded_FreshInstall(t *testing.T) {
+	secret := &corev1.Secret{}
+
+	changed := ResetSessionSecretKeysIfNeeded(secret)
+
+	if !changed {
+		t.Error("expected changed=true for fresh install")
+	}
+	if len(secret.Data["sessionEncryptionKey"]) != testAES256KeyLen {
+		t.Errorf("sessionEncryptionKey length = %d, want %d", len(secret.Data["sessionEncryptionKey"]), testAES256KeyLen)
+	}
+	if len(secret.Data["sessionAuthenticationKey"]) != testSHA256BlockSize {
+		t.Errorf("sessionAuthenticationKey length = %d, want %d", len(secret.Data["sessionAuthenticationKey"]), testSHA256BlockSize)
+	}
+	if len(secret.Data["previousSessionEncryptionKey"]) != 0 {
+		t.Error("previousSessionEncryptionKey should be empty on fresh install")
+	}
+	if len(secret.Data["previousSessionAuthenticationKey"]) != 0 {
+		t.Error("previousSessionAuthenticationKey should be empty on fresh install")
+	}
+}
+
+func TestResetSessionSecretKeysIfNeeded_ValidKeysNoOp(t *testing.T) {
+	encKey := validEncryptionKey()
+	authKey := validAuthenticationKey()
+
+	secret := &corev1.Secret{
+		Data: map[string][]byte{
+			"sessionEncryptionKey":     encKey,
+			"sessionAuthenticationKey": authKey,
+		},
+	}
+
+	changed := ResetSessionSecretKeysIfNeeded(secret)
+
+	if changed {
+		t.Error("expected changed=false when keys are valid")
+	}
+	if string(secret.Data["sessionEncryptionKey"]) != string(encKey) {
+		t.Error("sessionEncryptionKey should not change when valid")
+	}
+	if string(secret.Data["sessionAuthenticationKey"]) != string(authKey) {
+		t.Error("sessionAuthenticationKey should not change when valid")
+	}
+}
+
+func TestResetSessionSecretKeysIfNeeded_CorruptedCurrentKey_NoPrevious(t *testing.T) {
+	badKey := []byte("too-short")
+
+	secret := &corev1.Secret{
+		Data: map[string][]byte{
+			"sessionEncryptionKey":     badKey,
+			"sessionAuthenticationKey": badKey,
+		},
+	}
+
+	changed := ResetSessionSecretKeysIfNeeded(secret)
+
+	if !changed {
+		t.Error("expected changed=true when current keys are invalid")
+	}
+	if len(secret.Data["sessionEncryptionKey"]) != testAES256KeyLen {
+		t.Errorf("sessionEncryptionKey length = %d, want %d", len(secret.Data["sessionEncryptionKey"]), testAES256KeyLen)
+	}
+	if len(secret.Data["sessionAuthenticationKey"]) != testSHA256BlockSize {
+		t.Errorf("sessionAuthenticationKey length = %d, want %d", len(secret.Data["sessionAuthenticationKey"]), testSHA256BlockSize)
+	}
+	if string(secret.Data["previousSessionEncryptionKey"]) != string(badKey) {
+		t.Error("previousSessionEncryptionKey should contain the old (bad) current key when no previous existed")
+	}
+	if string(secret.Data["previousSessionAuthenticationKey"]) != string(badKey) {
+		t.Error("previousSessionAuthenticationKey should contain the old (bad) current key when no previous existed")
+	}
+}
+
+func TestResetSessionSecretKeysIfNeeded_CorruptedCurrentKey_ValidPreviousPreserved(t *testing.T) {
+	validPrevEnc := []byte("valid-previous-encryption-key!!!")
+	validPrevAuth := []byte("valid-previous-authentication-key-that-is-sixty-four-bytes-long!")
+
+	secret := &corev1.Secret{
+		Data: map[string][]byte{
+			"sessionEncryptionKey":             []byte("bad"),
+			"sessionAuthenticationKey":         []byte("bad"),
+			"previousSessionEncryptionKey":     validPrevEnc,
+			"previousSessionAuthenticationKey": validPrevAuth,
+		},
+	}
+
+	changed := ResetSessionSecretKeysIfNeeded(secret)
+
+	if !changed {
+		t.Error("expected changed=true when current keys are invalid")
+	}
+	if len(secret.Data["sessionEncryptionKey"]) != testAES256KeyLen {
+		t.Errorf("sessionEncryptionKey should be regenerated, got length %d", len(secret.Data["sessionEncryptionKey"]))
+	}
+	if string(secret.Data["previousSessionEncryptionKey"]) != string(validPrevEnc) {
+		t.Error("previousSessionEncryptionKey should be preserved, not overwritten with bad current key")
+	}
+	if string(secret.Data["previousSessionAuthenticationKey"]) != string(validPrevAuth) {
+		t.Error("previousSessionAuthenticationKey should be preserved, not overwritten with bad current key")
+	}
+}
+
+func TestResetSessionSecretKeysIfNeeded_NilData(t *testing.T) {
+	secret := &corev1.Secret{Data: nil}
+
+	changed := ResetSessionSecretKeysIfNeeded(secret)
+
+	if !changed {
+		t.Error("expected changed=true for nil data")
+	}
+	if secret.Data == nil {
+		t.Fatal("Data map should be initialized")
+	}
+	if len(secret.Data["sessionEncryptionKey"]) != testAES256KeyLen {
+		t.Errorf("sessionEncryptionKey length = %d, want %d", len(secret.Data["sessionEncryptionKey"]), testAES256KeyLen)
+	}
+	if len(secret.Data["sessionAuthenticationKey"]) != testSHA256BlockSize {
+		t.Errorf("sessionAuthenticationKey length = %d, want %d", len(secret.Data["sessionAuthenticationKey"]), testSHA256BlockSize)
+	}
+}
+
+func TestResetSessionSecretKeysIfNeeded_KeysAreUnique(t *testing.T) {
+	secret1 := &corev1.Secret{}
+	secret2 := &corev1.Secret{}
+
+	ResetSessionSecretKeysIfNeeded(secret1)
+	ResetSessionSecretKeysIfNeeded(secret2)
+
+	if string(secret1.Data["sessionEncryptionKey"]) == string(secret2.Data["sessionEncryptionKey"]) {
+		t.Error("two generated encryption keys should not be identical")
+	}
+	if string(secret1.Data["sessionAuthenticationKey"]) == string(secret2.Data["sessionAuthenticationKey"]) {
+		t.Error("two generated authentication keys should not be identical")
+	}
+}


### PR DESCRIPTION
**Analysis / Root cause**:

Console sessions are lost on pod restart because encryption keys are generated randomly per process, making cookies non-portable across pods. The `session-secret` Secret infrastructure already exists for OIDC auth but was not enabled for OpenShift/IntegratedOAuth auth.

Jira: https://redhat.atlassian.net/browse/OCPBUGS-71237
Companion PR: https://github.com/openshift/console/pull/16911

**Solution description**:

Extend the existing `session-secret` Secret management to all authentication types:

- **sync_v400.go**: `syncSessionSecret()` now runs for all auth types, not just OIDC
- **config_builder.go**: Sets session key file paths in the console config for OpenShift auth. Extracted `sessionAuthKeyFilePath` and `sessionEncKeyFilePath` constants
- **deployment.go**: No changes needed — volume mount is already conditional on `sessionSecret != nil`

**Upgrade safety**: On upgrade, `syncSessionSecret()` creates the Secret before the ConfigMap and Deployment are synced.

**Rollback safety**: If downgraded, the orphaned Secret is harmless. The downgraded operator reverts to per-pod random keys.

**Test cases:**
- All existing unit tests updated and passing
- Config builder correctly sets session key paths for OpenShift auth
- Config builder correctly omits session key paths for disabled auth

**Additional info:**
- Companion to console PR: https://github.com/openshift/console/pull/16911
- Both PRs must be merged together for the feature to work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session security configuration across all authentication modes.
  * Preserved previous session keys during key replacement for smoother session transitions.
  * Preserved empty session configuration when authentication is disabled.
  * Improved deployment upgrade checks and synchronization error reporting.
  * Cleared outdated OIDC status conditions when OIDC is no longer configured.
* **New Features**
  * Applied configured TLS minimum versions and cipher suites to console serving configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->