### PR TITLE
OCPBUGS-104854: Cache deployment generation to prevent echo events

### DIFF
--- a/pkg/console/operator/operator.go
+++ b/pkg/console/operator/operator.go
@@ -95,7 +95,8 @@ type consoleOperator struct {
 
 	monitoringDeploymentLister appsv1listers.DeploymentLister
 
-	lastDeploymentAvailableTime time.Time
+	lastDeploymentAvailableTime     time.Time
+	lastAppliedDeploymentGeneration int64
 }
 
 type trackables struct {

--- a/pkg/console/operator/sync_v400.go
+++ b/pkg/console/operator/sync_v400.go
@@ -333,6 +333,16 @@ func (co *consoleOperator) SyncDeployment(
 	}
 	deploymentsub.LogDeploymentAnnotationChanges(co.deploymentClient, requiredDeployment, ctx)
 
+	expectedGen := resourcemerge.ExpectedDeploymentGeneration(requiredDeployment, updatedOperatorConfig.Status.Generations)
+	// After the operator updates the deployment, the deployment informer
+	// triggers a re-sync before the operator config informer has processed
+	// the corresponding status write. The stale expected generation causes
+	// a no-op update and a spurious DeploymentUpdated event. Use the
+	// in-memory cached generation to bridge the informer cache gap.
+	if co.lastAppliedDeploymentGeneration > expectedGen {
+		expectedGen = co.lastAppliedDeploymentGeneration
+	}
+
 	var deployment *appsv1.Deployment
 	applyDepErr := controllersutil.RetryOnTransientError(func() error {
 		var e error
@@ -341,7 +351,7 @@ func (co *consoleOperator) SyncDeployment(
 			co.deploymentClient,
 			recorder,
 			requiredDeployment,
-			resourcemerge.ExpectedDeploymentGeneration(requiredDeployment, updatedOperatorConfig.Status.Generations),
+			expectedGen,
 		)
 		return e
 	})
@@ -349,6 +359,7 @@ func (co *consoleOperator) SyncDeployment(
 	if applyDepErr != nil {
 		return nil, "FailedApply", applyDepErr
 	}
+	co.lastAppliedDeploymentGeneration = deployment.Generation
 	return deployment, "", nil
 }
 

--- a/pkg/console/operator/sync_v400_test.go
+++ b/pkg/console/operator/sync_v400_test.go
@@ -3,6 +3,7 @@ package operator
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"sort"
 	"strings"
 	"testing"
@@ -13,13 +14,19 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	configlistersv1 "github.com/openshift/client-go/config/listers/config/v1"
+	"github.com/openshift/library-go/pkg/operator/events"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	kubefake "k8s.io/client-go/kubernetes/fake"
 	appsv1listers "k8s.io/client-go/listers/apps/v1"
 	corev1listers "k8s.io/client-go/listers/core/v1"
+	clienttesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
+	clocktesting "k8s.io/utils/clock/testing"
 
 	"github.com/openshift/console-operator/pkg/api"
 	"github.com/openshift/console-operator/pkg/console/telemetry"
@@ -843,4 +850,166 @@ func TestGetTLSConfigFromObservedConfig(t *testing.T) {
 			}
 		})
 	}
+}
+
+// syncDeploymentInputs holds the minimal inputs needed to call SyncDeployment.
+type syncDeploymentInputs struct {
+	operatorConfig       *operatorv1.Console
+	cm                   *v1.ConfigMap
+	serviceCAConfigMap   *v1.ConfigMap
+	oauthServingCertCM   *v1.ConfigMap
+	authServerCACM       *v1.ConfigMap
+	trustedCACM          *v1.ConfigMap
+	oauthSecret          *v1.Secret
+	sessionSecret        *v1.Secret
+	servingCertSecret    *v1.Secret
+	proxyConfig          *configv1.Proxy
+	infrastructureConfig *configv1.Infrastructure
+}
+
+func newSyncDeploymentInputs() syncDeploymentInputs {
+	return syncDeploymentInputs{
+		operatorConfig: &operatorv1.Console{
+			ObjectMeta: metav1.ObjectMeta{Name: "cluster", UID: "test-uid"},
+			Spec:       operatorv1.ConsoleSpec{},
+		},
+		cm:                 &v1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "console-config", Namespace: "openshift-console", ResourceVersion: "100"}},
+		serviceCAConfigMap: &v1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "service-ca", Namespace: "openshift-console", ResourceVersion: "200"}},
+		oauthServingCertCM: &v1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "oauth-serving-cert", Namespace: "openshift-console", ResourceVersion: "300"}},
+		authServerCACM:     nil,
+		trustedCACM:        &v1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "trusted-ca", Namespace: "openshift-console", ResourceVersion: "400"}},
+		oauthSecret:        &v1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "console-oauth-config", Namespace: "openshift-console", ResourceVersion: "500"}},
+		sessionSecret:      nil,
+		servingCertSecret:  &v1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "console-serving-cert", Namespace: "openshift-console", ResourceVersion: "600"}},
+		proxyConfig:        &configv1.Proxy{ObjectMeta: metav1.ObjectMeta{Name: "cluster", ResourceVersion: "700"}},
+		infrastructureConfig: &configv1.Infrastructure{
+			ObjectMeta: metav1.ObjectMeta{Name: "cluster", ResourceVersion: "800"},
+			Status: configv1.InfrastructureStatus{
+				ControlPlaneTopology: configv1.HighlyAvailableTopologyMode,
+			},
+		},
+	}
+}
+
+func (in syncDeploymentInputs) callSyncDeployment(co *consoleOperator, recorder events.Recorder) (*appsv1.Deployment, string, error) {
+	return co.SyncDeployment(
+		context.Background(),
+		in.operatorConfig,
+		in.cm,
+		in.serviceCAConfigMap,
+		in.oauthServingCertCM,
+		in.authServerCACM,
+		in.trustedCACM,
+		in.oauthSecret,
+		in.sessionSecret,
+		in.servingCertSecret,
+		in.proxyConfig,
+		in.infrastructureConfig,
+		recorder,
+	)
+}
+
+func TestSyncDeploymentGenerationCache(t *testing.T) {
+	newRecorder := func() events.Recorder {
+		return events.NewInMemoryRecorder("test", clocktesting.NewFakePassiveClock(time.Now()))
+	}
+
+	t.Run("first apply caches generation", func(t *testing.T) {
+		fakeClient := kubefake.NewSimpleClientset()
+		co := &consoleOperator{
+			deploymentClient: fakeClient.AppsV1(),
+		}
+		inputs := newSyncDeploymentInputs()
+
+		dep, _, err := inputs.callSyncDeployment(co, newRecorder())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if co.lastAppliedDeploymentGeneration != dep.Generation {
+			t.Errorf("expected cache=%d, got=%d", dep.Generation, co.lastAppliedDeploymentGeneration)
+		}
+	})
+
+	t.Run("cached generation prevents echo update", func(t *testing.T) {
+		fakeClient := kubefake.NewSimpleClientset()
+		co := &consoleOperator{
+			deploymentClient: fakeClient.AppsV1(),
+		}
+		inputs := newSyncDeploymentInputs()
+		recorder := newRecorder()
+
+		// First apply creates the deployment and populates all annotations
+		// including the specHash.
+		_, _, err := inputs.callSyncDeployment(co, recorder)
+		if err != nil {
+			t.Fatalf("first apply: %v", err)
+		}
+
+		// Simulate the API server incrementing generation after the update.
+		existing, _ := fakeClient.AppsV1().Deployments("openshift-console").Get(context.Background(), "console", metav1.GetOptions{})
+		existing.Generation = 10
+		_, err = fakeClient.AppsV1().Deployments("openshift-console").Update(context.Background(), existing, metav1.UpdateOptions{})
+		if err != nil {
+			t.Fatalf("simulating generation bump: %v", err)
+		}
+
+		// Set cache to match (as if previous SyncDeployment returned this).
+		co.lastAppliedDeploymentGeneration = 10
+
+		// Simulate stale informer: operator status still has gen 9.
+		inputs.operatorConfig = inputs.operatorConfig.DeepCopy()
+		inputs.operatorConfig.Status.Generations = []operatorv1.GenerationStatus{{
+			Group:          "apps",
+			Resource:       "deployments",
+			Namespace:      "openshift-console",
+			Name:           "console",
+			LastGeneration: 9,
+		}}
+
+		// Track whether ApplyDeployment calls Update.
+		updateCalls := 0
+		fakeClient.PrependReactor("update", "deployments", func(action clienttesting.Action) (bool, runtime.Object, error) {
+			updateCalls++
+			return false, nil, nil
+		})
+
+		// Second apply with identical inputs — cache should bridge the gap.
+		_, _, err = inputs.callSyncDeployment(co, recorder)
+		if err != nil {
+			t.Fatalf("second apply: %v", err)
+		}
+		if updateCalls != 0 {
+			t.Errorf("expected no deployment update (echo prevented), got %d update(s)", updateCalls)
+		}
+		if co.lastAppliedDeploymentGeneration != 10 {
+			t.Errorf("expected cache to remain 10, got %d", co.lastAppliedDeploymentGeneration)
+		}
+	})
+
+	t.Run("failed apply preserves cached generation", func(t *testing.T) {
+		fakeClient := kubefake.NewSimpleClientset()
+		co := &consoleOperator{
+			deploymentClient:                fakeClient.AppsV1(),
+			lastAppliedDeploymentGeneration: 5,
+		}
+		inputs := newSyncDeploymentInputs()
+
+		// Make Get return a non-retryable error so RetryOnTransientError
+		// gives up immediately.
+		fakeClient.PrependReactor("get", "deployments", func(action clienttesting.Action) (bool, runtime.Object, error) {
+			return true, nil, apierrors.NewForbidden(
+				schema.GroupResource{Group: "apps", Resource: "deployments"},
+				"console",
+				fmt.Errorf("synthetic test error"),
+			)
+		})
+
+		_, _, err := inputs.callSyncDeployment(co, newRecorder())
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if co.lastAppliedDeploymentGeneration != 5 {
+			t.Errorf("expected cache to remain 5 after failure, got %d", co.lastAppliedDeploymentGeneration)
+		}
+	})
 }


### PR DESCRIPTION
**Analysis / Root cause**:

The console-operator triggers excessive `DeploymentUpdated` events (21-31 per test run, avg 24) on vsphere techpreview serial clusters, failing the `[Monitor:legacy-test-framework-invariants-pathological]` event invariant test. Pass rate dropped from 100% to 32.81% since July 24, 2026.

Must-gather analysis of a failed run (31 events) reveals two compounding issues:

1. **[CONSOLE-5122](https://redhat.atlassian.net/browse/CONSOLE-5122) e2e tests** (direct regression trigger, merged July 15): Serial tests create/delete `console-label-test-N` componentRoutes, each producing configmap content changes (`additionalConsoleBaseAddresses`). 5 test iterations × 2 changes = 10 real configmap changes → 10 deployment updates.

2. **Generation echo amplifier** (pre-existing): After `ApplyDeployment` updates the console deployment, the deployment informer triggers a re-sync before the operator config informer has processed the corresponding status write from `FlushAndReturn`. The stale expected generation causes a no-op deployment update and a spurious `DeploymentUpdated` event — effectively doubling every legitimate update.

Event breakdown from must-gather:
| Source | Real changes | Gen echoes | Total |
|--------|-------------|------------|-------|
| [CONSOLE-5122](https://redhat.atlassian.net/browse/CONSOLE-5122) e2e tests | 10 | 6 | 16 |
| Cluster init (plugins, monitoring) | 5 | 6 | 11 |
| Infrastructure config RV churn | 3 | 1 | 4 |
| **Total** | **18** | **13** | **31** |

**Solution description**:

Cache the last-applied deployment generation in-memory on the `consoleOperator` struct. In `SyncDeployment`, use `max(cachedGen, statusGen)` as the expected generation passed to `ApplyDeployment`. This bridges the informer cache gap: even if the operator config informer hasn't yet processed the status write, the in-memory cache holds the correct generation, preventing the no-op update.

The cache starts at zero on operator restart, which is safe — the first sync reads the correct generation from the operator config status (which the informer has had time to populate). Subsequent syncs benefit from the cache when the informer lags.

**Test setup:**

Deploy the operator to any cluster and trigger a configmap change (e.g., add a componentRoute to the ingress config).

**Test cases:**

- **Before fix**: Each ingress config change produces 2 `DeploymentUpdated` events (real + echo ~2s later)
- **After fix**: Each change produces exactly 1 event

Verified manually on a dev cluster:
```
# Baseline (stock operator): 2 events per change
EVENT      LAST SEEN   TYPE     REASON              OBJECT
ADDED      0s          Normal   DeploymentUpdated   deployment/console-operator
MODIFIED   0s          Normal   DeploymentUpdated   deployment/console-operator

# Fixed operator: 1 event per change
EVENT      LAST SEEN   TYPE     REASON              OBJECT
ADDED      0s          Normal   DeploymentUpdated   deployment/console-operator
```

Expected CI impact: 31 events → ~18 events (13 echo events eliminated), under the pathological threshold of 20.

**Browser conformance**:
N/A — backend-only change, no UI impact.

**Additional info:**

This is a targeted fix for the echo amplifier only. The underlying configmap churn during cluster initialization (plugins registering, monitoring coming online) and from [CONSOLE-5122](https://redhat.atlassian.net/browse/CONSOLE-5122) e2e tests is legitimate operator behavior. A secondary optimization to remove redundant infrastructure/proxy config RV annotations from the deployment could further reduce event count but is not included in this PR to keep scope minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment synchronization to consistently apply the expected deployment generation.
  * Prevented stale deployment information from triggering redundant updates.
  * Preserved the latest successfully applied deployment state during subsequent synchronization attempts.
  * Ensured failed deployment applications do not overwrite the last known successful state, improving reliability when deployment information is temporarily out of date.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->