### PR TITLE
OCPBUGS-104500: Use content hash for ConfigMap deployment annotations

### DIFF
--- a/pkg/console/subresource/deployment/deployment.go
+++ b/pkg/console/subresource/deployment/deployment.go
@@ -250,8 +250,8 @@ func withConsoleAnnotations(
 ) {
 	deployment.ObjectMeta.Annotations = map[string]string{
 		configMapResourceVersionAnnotation:            configMapContentHash(consoleConfigMap),
-		serviceCAConfigMapResourceVersionAnnotation:   serviceCAConfigMap.GetResourceVersion(),
-		trustedCAConfigMapResourceVersionAnnotation:   trustedCAConfigMap.GetResourceVersion(),
+		serviceCAConfigMapResourceVersionAnnotation:   configMapContentHash(serviceCAConfigMap),
+		trustedCAConfigMapResourceVersionAnnotation:   configMapContentHash(trustedCAConfigMap),
 		proxyConfigResourceVersionAnnotation:          proxyConfig.GetResourceVersion(),
 		infrastructureConfigResourceVersionAnnotation: infrastructureConfig.GetResourceVersion(),
 		secretResourceVersionAnnotation:               oAuthClientSecret.GetResourceVersion(),
@@ -260,7 +260,7 @@ func withConsoleAnnotations(
 	}
 
 	if authServerCAConfigMap != nil {
-		deployment.ObjectMeta.Annotations[authnCATrustConfigMapResourceVersionAnnotation] = authServerCAConfigMap.GetResourceVersion()
+		deployment.ObjectMeta.Annotations[authnCATrustConfigMapResourceVersionAnnotation] = configMapContentHash(authServerCAConfigMap)
 	}
 
 	if sessionSecret != nil {

--- a/pkg/console/subresource/deployment/deployment_test.go
+++ b/pkg/console/subresource/deployment/deployment_test.go
@@ -85,6 +85,18 @@ func TestDefaultDeployment(t *testing.T) {
 	}
 
 	expectedConfigHash := configMapContentHash(consoleConfig)
+
+	trustedCAConfigMapEmpty := configmap.TrustedCAStub()
+	trustedCAConfigMapSet := configmap.TrustedCAStub()
+	trustedCAConfigMapSet.Data[api.TrustedCABundleKey] = "testCAValue"
+
+	commonServiceCA := &corev1.ConfigMap{}
+	commonOAuthServingCert := &corev1.ConfigMap{Data: map[string]string{"ca-bundle.crt": "test"}}
+	expectedServiceCAHash := configMapContentHash(commonServiceCA)
+	expectedOAuthCertHash := configMapContentHash(commonOAuthServingCert)
+	expectedTrustedCAEmptyHash := configMapContentHash(trustedCAConfigMapEmpty)
+	expectedTrustedCASetHash := configMapContentHash(trustedCAConfigMapSet)
+
 	consoleDeploymentObjectMeta := metav1.ObjectMeta{
 		Name:                       api.OpenShiftConsoleName,
 		Namespace:                  api.OpenShiftConsoleNamespace,
@@ -100,9 +112,9 @@ func TestDefaultDeployment(t *testing.T) {
 		Annotations: map[string]string{
 			configMapResourceVersionAnnotation:             expectedConfigHash,
 			secretResourceVersionAnnotation:                "",
-			authnCATrustConfigMapResourceVersionAnnotation: "",
-			serviceCAConfigMapResourceVersionAnnotation:    "",
-			trustedCAConfigMapResourceVersionAnnotation:    "",
+			authnCATrustConfigMapResourceVersionAnnotation: expectedOAuthCertHash,
+			serviceCAConfigMapResourceVersionAnnotation:    expectedServiceCAHash,
+			trustedCAConfigMapResourceVersionAnnotation:    expectedTrustedCAEmptyHash,
 			proxyConfigResourceVersionAnnotation:           "",
 			infrastructureConfigResourceVersionAnnotation:  "",
 			consoleImageAnnotation:                         "",
@@ -133,9 +145,9 @@ func TestDefaultDeployment(t *testing.T) {
 	consoleDeploymentTemplateAnnotations := map[string]string{
 		configMapResourceVersionAnnotation:             expectedConfigHash,
 		secretResourceVersionAnnotation:                "",
-		authnCATrustConfigMapResourceVersionAnnotation: "",
-		serviceCAConfigMapResourceVersionAnnotation:    "",
-		trustedCAConfigMapResourceVersionAnnotation:    "",
+		authnCATrustConfigMapResourceVersionAnnotation: expectedOAuthCertHash,
+		serviceCAConfigMapResourceVersionAnnotation:    expectedServiceCAHash,
+		trustedCAConfigMapResourceVersionAnnotation:    expectedTrustedCAEmptyHash,
 		proxyConfigResourceVersionAnnotation:           "",
 		infrastructureConfigResourceVersionAnnotation:  "",
 		consoleImageAnnotation:                         "",
@@ -160,10 +172,6 @@ func TestDefaultDeployment(t *testing.T) {
 			}},
 		},
 	}
-
-	trustedCAConfigMapEmpty := configmap.TrustedCAStub()
-	trustedCAConfigMapSet := configmap.TrustedCAStub()
-	trustedCAConfigMapSet.Data[api.TrustedCABundleKey] = "testCAValue"
 
 	proxyConfig := &configv1.Proxy{
 		TypeMeta:   metav1.TypeMeta{},
@@ -308,16 +316,27 @@ func TestDefaultDeployment(t *testing.T) {
 					Kind:       "Deployment",
 					APIVersion: "apps/v1",
 				},
-				ObjectMeta: consoleDeploymentObjectMeta,
+				ObjectMeta: func() metav1.ObjectMeta {
+					om := consoleDeploymentObjectMeta.DeepCopy()
+					om.Annotations[trustedCAConfigMapResourceVersionAnnotation] = expectedTrustedCASetHash
+					return *om
+				}(),
 				Spec: appsv1.DeploymentSpec{
 					Replicas: &defaultReplicaCount,
 					Selector: &metav1.LabelSelector{
 						MatchLabels: labels,
 					},
 					Template: corev1.PodTemplateSpec{ObjectMeta: metav1.ObjectMeta{
-						Name:        api.OpenShiftConsoleName,
-						Labels:      labels,
-						Annotations: consoleDeploymentTemplateAnnotations,
+						Name:   api.OpenShiftConsoleName,
+						Labels: labels,
+						Annotations: func() map[string]string {
+							a := make(map[string]string, len(consoleDeploymentTemplateAnnotations))
+							for k, v := range consoleDeploymentTemplateAnnotations {
+								a[k] = v
+							}
+							a[trustedCAConfigMapResourceVersionAnnotation] = expectedTrustedCASetHash
+							return a
+						}(),
 					},
 						Spec: corev1.PodSpec{
 							DNSPolicy:                corev1.DNSClusterFirst,
@@ -646,9 +665,9 @@ func TestWithConsoleAnnotations(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
 						configMapResourceVersionAnnotation:             configMapContentHash(consoleConfigMap),
-						serviceCAConfigMapResourceVersionAnnotation:    serviceCAConfigMap.GetResourceVersion(),
-						authnCATrustConfigMapResourceVersionAnnotation: oauthServingCertConfigMap.GetResourceVersion(),
-						trustedCAConfigMapResourceVersionAnnotation:    trustedCAConfigMap.GetResourceVersion(),
+						serviceCAConfigMapResourceVersionAnnotation:    configMapContentHash(serviceCAConfigMap),
+						authnCATrustConfigMapResourceVersionAnnotation: configMapContentHash(oauthServingCertConfigMap),
+						trustedCAConfigMapResourceVersionAnnotation:    configMapContentHash(trustedCAConfigMap),
 						proxyConfigResourceVersionAnnotation:           proxyConfig.GetResourceVersion(),
 						infrastructureConfigResourceVersionAnnotation:  infrastructureConfig.GetResourceVersion(),
 						secretResourceVersionAnnotation:                oAuthClientSecret.GetResourceVersion(),
@@ -662,9 +681,9 @@ func TestWithConsoleAnnotations(t *testing.T) {
 							Annotations: map[string]string{
 								workloadManagementAnnotation:                   workloadManagementAnnotationValue,
 								configMapResourceVersionAnnotation:             configMapContentHash(consoleConfigMap),
-								serviceCAConfigMapResourceVersionAnnotation:    serviceCAConfigMap.GetResourceVersion(),
-								authnCATrustConfigMapResourceVersionAnnotation: oauthServingCertConfigMap.GetResourceVersion(),
-								trustedCAConfigMapResourceVersionAnnotation:    trustedCAConfigMap.GetResourceVersion(),
+								serviceCAConfigMapResourceVersionAnnotation:    configMapContentHash(serviceCAConfigMap),
+								authnCATrustConfigMapResourceVersionAnnotation: configMapContentHash(oauthServingCertConfigMap),
+								trustedCAConfigMapResourceVersionAnnotation:    configMapContentHash(trustedCAConfigMap),
 								proxyConfigResourceVersionAnnotation:           proxyConfig.GetResourceVersion(),
 								infrastructureConfigResourceVersionAnnotation:  infrastructureConfig.GetResourceVersion(),
 								secretResourceVersionAnnotation:                oAuthClientSecret.GetResourceVersion(),
@@ -749,6 +768,66 @@ func TestServingCertAnnotationChangesOnRotation(t *testing.T) {
 	if oldPodVal == newPodVal {
 		t.Error("pod template annotation value did not change after cert rotation — rollout would not be triggered")
 	}
+}
+
+func TestConfigMapAnnotationsUseContentHash(t *testing.T) {
+	consoleConfigMap := &corev1.ConfigMap{
+		Data: map[string]string{"console-config.yaml": "kind: ConsoleConfig"},
+	}
+	proxyConfig := &configv1.Proxy{ObjectMeta: metav1.ObjectMeta{ResourceVersion: "1"}}
+	infrastructureConfig := &configv1.Infrastructure{ObjectMeta: metav1.ObjectMeta{ResourceVersion: "1"}}
+	oAuthClientSecret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{ResourceVersion: "1"}}
+	servingCert := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{ResourceVersion: "1"}}
+
+	caData := map[string]string{"ca-bundle.crt": "SOME-CA-BUNDLE"}
+
+	makeDeployment := func() *appsv1.Deployment {
+		return &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{}},
+			Spec: appsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{}},
+				},
+			},
+		}
+	}
+
+	annotationsFor := func(serviceCA, authCA, trustedCA *corev1.ConfigMap) map[string]string {
+		dep := makeDeployment()
+		withConsoleAnnotations(dep, consoleConfigMap, serviceCA, authCA, trustedCA, oAuthClientSecret, nil, servingCert, proxyConfig, infrastructureConfig)
+		return dep.ObjectMeta.Annotations
+	}
+
+	t.Run("same data different ResourceVersion produces identical annotation", func(t *testing.T) {
+		cm1 := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{ResourceVersion: "100"}, Data: caData}
+		cm2 := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{ResourceVersion: "999"}, Data: caData}
+		trustedCA := &corev1.ConfigMap{}
+
+		a1 := annotationsFor(&corev1.ConfigMap{}, cm1, trustedCA)
+		a2 := annotationsFor(&corev1.ConfigMap{}, cm2, trustedCA)
+
+		if a1[authnCATrustConfigMapResourceVersionAnnotation] != a2[authnCATrustConfigMapResourceVersionAnnotation] {
+			t.Errorf("authn CA annotation changed despite identical data: %q vs %q",
+				a1[authnCATrustConfigMapResourceVersionAnnotation], a2[authnCATrustConfigMapResourceVersionAnnotation])
+		}
+		if a1[serviceCAConfigMapResourceVersionAnnotation] != a2[serviceCAConfigMapResourceVersionAnnotation] {
+			t.Errorf("service CA annotation changed despite identical data: %q vs %q",
+				a1[serviceCAConfigMapResourceVersionAnnotation], a2[serviceCAConfigMapResourceVersionAnnotation])
+		}
+	})
+
+	t.Run("different data produces different annotation", func(t *testing.T) {
+		cm1 := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{ResourceVersion: "1"}, Data: map[string]string{"ca-bundle.crt": "OLD-CA"}}
+		cm2 := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{ResourceVersion: "1"}, Data: map[string]string{"ca-bundle.crt": "NEW-CA"}}
+		trustedCA := &corev1.ConfigMap{}
+
+		a1 := annotationsFor(&corev1.ConfigMap{}, cm1, trustedCA)
+		a2 := annotationsFor(&corev1.ConfigMap{}, cm2, trustedCA)
+
+		if a1[authnCATrustConfigMapResourceVersionAnnotation] == a2[authnCATrustConfigMapResourceVersionAnnotation] {
+			t.Error("authn CA annotation did not change when data changed")
+		}
+	})
 }
 
 func TestServingCertAnnotationInResourceAnnotations(t *testing.T) {


### PR DESCRIPTION
## Summary
- Replace `GetResourceVersion()` with `configMapContentHash()` (SHA-256) for the `service-ca`, `trusted-ca`, and `authn-ca-trust` ConfigMap annotations on the console Deployment, preventing spurious pod rollouts when ConfigMap metadata changes but data is unchanged.
- Extend the existing content-hash pattern (already used for `console-config`) to all ConfigMap-backed deployment annotations.
- Add `TestConfigMapAnnotationsUseContentHash` to verify that identical data with different ResourceVersions produces the same annotation value, and that actual data changes are still detected.
## Background
Reported in [OCPBUGS-104500](https://redhat.atlassian.net/browse/OCPBUGS-104500): customers using cert-manager with short-lived certificates (e.g. Vault PKI with 1-hour TTL) for their default ingress certificate experience periodic console pod rollouts on every certificate renewal. The propagation chain is:
1. cert-manager renews the ingress certificate
2. ingress-operator updates `router-certs` in `openshift-config-managed`
3. cluster-authentication-operator syncs to `oauth-serving-cert` in `openshift-config-managed`
4. console-operator syncs `oauth-serving-cert` to `openshift-console`, then annotates the Deployment with its **raw `resourceVersion`**
5. The annotation change triggers a rolling update of console pods
The `resourceVersion` changes on any write to the ConfigMap — including metadata-only updates — even when the actual CA bundle data is unchanged. By switching to a content hash, the annotation only changes when the data changes, eliminating this class of spurious rollouts.
## Scope and limitations
This fix addresses **Option B** from the bug: track content instead of `resourceVersion`. It eliminates rollouts caused by metadata-only ConfigMap changes.
When `oauth-serving-cert` contains the full certificate chain (leaf + CA) rather than just the CA, leaf certificate rotations will still change the data and trigger rollouts. A companion fix in `cluster-authentication-operator` (**Option A**: strip leaf certificates from `oauth-serving-cert`) is needed to fully resolve that case.
## Changes
| File | Change |
|------|--------|
| `pkg/console/subresource/deployment/deployment.go` | Replace `GetResourceVersion()` with `configMapContentHash()` for `serviceCA`, `trustedCA`, and `authnCATrust` annotations |
| `pkg/console/subresource/deployment/deployment_test.go` | Update expected annotation values; add `TestConfigMapAnnotationsUseContentHash` |
## Test plan
- [x] `go test ./pkg/console/subresource/deployment/...` — all 37 tests pass
- [x] `go test ./pkg/...` — full unit test suite passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment annotation consistency by basing CA configuration updates on configuration content rather than resource version changes.
  * Prevented unnecessary deployment updates when CA configuration content remains unchanged.
  * Ensured deployments respond correctly when CA configuration data changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->