### PR TITLE
CONSOLE-5475: Replace old Segment CDN variable

### DIFF
--- a/manifests/05-telemetry-config.yaml
+++ b/manifests/05-telemetry-config.yaml
@@ -11,5 +11,5 @@ metadata:
     capability.openshift.io/name: Console
 data:
   SEGMENT_API_HOST: console.redhat.com/connections/api/v1
-  SEGMENT_JS_HOST: console.redhat.com/connections/cdn
+  SEGMENT_CDN_URL: https://console.redhat.com/connections/cdn
   SEGMENT_PUBLIC_API_KEY: BnuS1RP39EmLQjP21ko67oDjhbl9zpNU

--- a/pkg/console/operator/sync_v400_test.go
+++ b/pkg/console/operator/sync_v400_test.go
@@ -371,7 +371,7 @@ func newTestConsoleOperator(t *testing.T, telemeterAvailable bool, pullSecretHas
 		},
 		Data: map[string]string{
 			"SEGMENT_API_HOST":       "https://segment.example.com",
-			"SEGMENT_JS_HOST":        "https://segment-js.example.com",
+			"SEGMENT_CDN_URL":        "https://segment.example.com/cdn",
 			"SEGMENT_PUBLIC_API_KEY": "test-key",
 		},
 	}
@@ -547,7 +547,7 @@ func TestGetTelemetryConfiguration_KeySetStableAcrossAvailabilityChange(t *testi
 	keysAvailable := sortedKeys(configAvailable)
 
 	// All keys must be present in both states — no key-set difference allowed.
-	sharedKeys := []string{"CLUSTER_ID", "ORGANIZATION_ID", "ACCOUNT_MAIL", "TELEMETER_CLIENT_DISABLED", "SEGMENT_API_HOST", "SEGMENT_JS_HOST", "SEGMENT_PUBLIC_API_KEY"}
+	sharedKeys := []string{"CLUSTER_ID", "ORGANIZATION_ID", "ACCOUNT_MAIL", "TELEMETER_CLIENT_DISABLED", "SEGMENT_API_HOST", "SEGMENT_CDN_URL", "SEGMENT_PUBLIC_API_KEY"}
 	for _, key := range sharedKeys {
 		if _, ok := configUnavailable[key]; !ok {
 			t.Errorf("key %q missing from unavailable config, keys present: %v", key, keysUnavailable)

--- a/test/e2e/telemetry_config_test.go
+++ b/test/e2e/telemetry_config_test.go
@@ -7,18 +7,24 @@ import (
 	"time"
 
 	operatorsv1 "github.com/openshift/api/operator/v1"
+	"github.com/openshift/console-operator/pkg/api"
+	"github.com/openshift/console-operator/pkg/console/subresource/consoleserver"
+	"github.com/openshift/console-operator/pkg/console/telemetry"
+	"github.com/openshift/console-operator/test/e2e/framework"
+	yaml "gopkg.in/yaml.v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
-
-	"github.com/openshift/console-operator/pkg/api"
-	"github.com/openshift/console-operator/pkg/console/telemetry"
-	"github.com/openshift/console-operator/test/e2e/framework"
 )
 
 const (
 	SEGMENT_API_HOST = "SEGMENT_API_HOST"
+	SEGMENT_CDN_URL  = "SEGMENT_CDN_URL"
+
+	defaultSegmentAPIHost = "console.redhat.com/connections/api/v1"
+	defaultSegmentCDNURL  = "https://console.redhat.com/connections/cdn"
+	patchedSegmentCDNURL  = "https://test.example.com/cdn"
 )
 
 func setupTelemetryConfigTestCase(t *testing.T) (*framework.ClientSet, *operatorsv1.Console) {
@@ -30,8 +36,8 @@ func cleanupTelemetryConfigTestCase(t *testing.T, client *framework.ClientSet) {
 }
 
 func TestTelemetryConfig(t *testing.T) {
-	client, _ := setupDownloadsTestCase(t)
-	defer cleanupDownloadsTestCase(t, client)
+	client, _ := setupTelemetryConfigTestCase(t)
+	defer cleanupTelemetryConfigTestCase(t, client)
 	telemetryConfigMap, err := client.Core.ConfigMaps(api.OpenShiftConsoleOperatorNamespace).Get(context.TODO(), telemetry.TelemetryConfigMapName, v1.GetOptions{})
 	if err != nil {
 		t.Fatal(err)
@@ -42,15 +48,28 @@ func TestTelemetryConfig(t *testing.T) {
 	}
 
 	// check default value for SEGMENT_API_HOST key
-	value, ok := telemetryConfigMap.Data[SEGMENT_API_HOST]
+	apiHostValue, ok := telemetryConfigMap.Data[SEGMENT_API_HOST]
 	if !ok {
-		t.Fatalf("telemetry-config configmap does not contain SEGMENT_JS_HOST data key. Instead contains: %v", telemetryConfigMap.Data)
+		t.Fatalf("telemetry-config configmap does not contain SEGMENT_API_HOST data key. Instead contains: %v", telemetryConfigMap.Data)
 	}
-	if value != "console.redhat.com/connections/api/v1" {
-		t.Fatalf("telemetry-config configmap does not contain SEGMENT_API_HOST key with value 'console.redhat.com/connections/api/v1'. Instead contains: %q", value)
+	if apiHostValue != defaultSegmentAPIHost {
+		t.Fatalf("telemetry-config configmap does not contain SEGMENT_API_HOST key with value '%s'. Instead contains: %q", defaultSegmentAPIHost, apiHostValue)
 	}
 
-	// update the defaul value for SEGMENT_API_HOST key
+	// check default value for SEGMENT_CDN_URL key
+	cdnURLValue, ok := telemetryConfigMap.Data[SEGMENT_CDN_URL]
+	if !ok {
+		t.Fatalf("telemetry-config configmap does not contain SEGMENT_CDN_URL data key. Instead contains: %v", telemetryConfigMap.Data)
+	}
+	if cdnURLValue != defaultSegmentCDNURL {
+		t.Fatalf("telemetry-config configmap does not contain SEGMENT_CDN_URL key with value '%s'. Instead contains: %q", defaultSegmentCDNURL, cdnURLValue)
+	}
+
+	if _, ok := telemetryConfigMap.Data["SEGMENT_JS_HOST"]; ok {
+		t.Fatal("telemetry-config configmap should not contain deprecated SEGMENT_JS_HOST key")
+	}
+
+	// update the default value for SEGMENT_API_HOST key
 	_, err = client.Core.ConfigMaps(api.OpenShiftConsoleOperatorNamespace).Patch(context.TODO(), telemetry.TelemetryConfigMapName, types.MergePatchType, []byte(`{"data": {"SEGMENT_API_HOST": "test"}}`), metav1.PatchOptions{})
 	if err != nil {
 		t.Fatal(err)
@@ -59,17 +78,55 @@ func TestTelemetryConfig(t *testing.T) {
 	err = wait.Poll(1*time.Second, framework.AsyncOperationTimeout, func() (stop bool, err error) {
 		telemetryConfigMap, err := client.Core.ConfigMaps(api.OpenShiftConsoleOperatorNamespace).Get(context.TODO(), telemetry.TelemetryConfigMapName, v1.GetOptions{})
 		if err != nil {
-			t.Fatal(err)
+			return false, err
 		}
 		value, ok := telemetryConfigMap.Data[SEGMENT_API_HOST]
 		if !ok {
-			return false, fmt.Errorf("updated telemetry-config configmap does not contain SEGMENT_JS_HOST data key. Instead contains: %v", telemetryConfigMap.Data)
+			return false, fmt.Errorf("updated telemetry-config configmap does not contain SEGMENT_API_HOST data key. Instead contains: %v", telemetryConfigMap.Data)
 		}
 		if value != "test" {
-			return false, fmt.Errorf("update telemetry-config configmap does not contain SEGMENT_API_HOST key with value 'console.redhat.com/connections/api/v1'. Instead contains: %q", value)
+			return false, fmt.Errorf("updated telemetry-config configmap does not contain SEGMENT_API_HOST key with value 'test'. Instead contains: %q", value)
 		}
 
 		return true, nil
 	})
+	if err != nil {
+		t.Fatal(err)
+	}
 
+	// update the default value for SEGMENT_CDN_URL key
+	_, err = client.Core.ConfigMaps(api.OpenShiftConsoleOperatorNamespace).Patch(context.TODO(), telemetry.TelemetryConfigMapName, types.MergePatchType, []byte(fmt.Sprintf(`{"data": {"SEGMENT_CDN_URL": "%s"}}`, patchedSegmentCDNURL)), metav1.PatchOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = wait.Poll(1*time.Second, framework.AsyncOperationTimeout, func() (stop bool, err error) {
+		consoleConfigMap, err := framework.GetConsoleConfigMap(client)
+		if err != nil {
+			return false, err
+		}
+		configYAML, ok := consoleConfigMap.Data["console-config.yaml"]
+		if !ok {
+			return false, fmt.Errorf("console-config configmap does not contain console-config.yaml data key")
+		}
+		var consoleConfig consoleserver.Config
+		if err := yaml.Unmarshal([]byte(configYAML), &consoleConfig); err != nil {
+			return false, fmt.Errorf("failed to unmarshal console-config.yaml: %w", err)
+		}
+		if consoleConfig.Telemetry == nil {
+			return false, fmt.Errorf("console-config.yaml telemetry section is missing")
+		}
+		value, ok := consoleConfig.Telemetry[SEGMENT_CDN_URL]
+		if !ok {
+			return false, fmt.Errorf("console-config.yaml telemetry does not contain SEGMENT_CDN_URL key. Instead contains: %v", consoleConfig.Telemetry)
+		}
+		if value != patchedSegmentCDNURL {
+			return false, fmt.Errorf("console-config.yaml telemetry SEGMENT_CDN_URL expected '%s', got %q", patchedSegmentCDNURL, value)
+		}
+
+		return true, nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
 }


### PR DESCRIPTION
**Analysis / Root cause**:
<!-- Briefly describe analysis of US/Task or root cause of Defect -->
We are going to bundle the Segment analytics library directly in the UI, and the way the settings are specified for it changes. The old env vars are being deprecated, so the config map for the Console needs updating.

**Related PR:** https://github.com/openshift/console/pull/17159

**Solution description**:
<!-- Describe your code changes in detail and explain the solution or functionality -->
The Segment analytics library is now going to be bundled in the UI, and the way of specifying its settings changes a bit. Although the Console UI will still support the old way of specifying Segment's settings, the goal of these changes is to use the new settings' format.

**Test setup:**
<!-- If any setup required to test this PR, mention the details -->
N/A

**Test cases:**
<!-- List possible test cases to validate the changes. -->
1. Verify that the configmap has the new settings.

**Browser conformance**:
<!-- To mark tested browsers, use [x] -->
- [x] Chrome
- [x] Firefox
- [x] Safari (or Epiphany on Linux)

**Additional info:**
<!-- Add any additional info here -->

**Reviewers and assignees:**
<!--
- Tag an OCP console engineer to review the changes and verify the functionality.
- If there are visual, content, or interaction changes in the PR, tag "@openshift/team-ux-review"
- If the PR is implementing a story, assign Docs, and PX approvers:
  Console Approver:
  /assign <gh-user>

  Docs approver:
  /assign <gh-user>

  PX approver:
  /assign <gh-user>
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration**
  - Updated telemetry configuration to use `SEGMENT_CDN_URL` for the Segment CDN endpoint.
  - Preserved the existing CDN endpoint value.
  - The deprecated `SEGMENT_JS_HOST` configuration key is no longer included.
  - Telemetry configuration updates now support changing both the Segment API host and CDN URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->